### PR TITLE
feat: port keyboard/mouse shortcuts from NuvioDesktop

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/core/ui/DesktopHorizontalLazyRowGestures.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/core/ui/DesktopHorizontalLazyRowGestures.android.kt
@@ -1,0 +1,6 @@
+package com.nuvio.app.core.ui
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.ui.Modifier
+
+actual fun Modifier.desktopHorizontalLazyRowGestures(listState: LazyListState): Modifier = this

--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerPlatformEffects.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerPlatformEffects.android.kt
@@ -78,6 +78,9 @@ actual fun ManagePlayerPictureInPicture(
 }
 
 @Composable
+actual fun ManagePlayerCursorVisibility(visible: Boolean) = Unit
+
+@Composable
 actual fun rememberPlayerGestureController(): PlayerGestureController? {
     val context = LocalContext.current
     val activity = context.findActivity() ?: return null
@@ -98,6 +101,32 @@ actual fun rememberPlayerGestureController(): PlayerGestureController? {
 
     return controller
 }
+
+@Composable
+actual fun rememberPlayerFullscreenController(): PlayerFullscreenController =
+    remember {
+        object : PlayerFullscreenController {
+            override val isFullscreenSupported: Boolean = false
+            override val isFullscreen: Boolean = false
+            override fun toggleFullscreen() = Unit
+        }
+    }
+
+@Composable
+actual fun ManageFullscreenKeyboardShortcuts(
+    isHomeRouteActive: Boolean,
+    onBack: () -> Unit,
+) = Unit
+
+@Composable
+actual fun BindPlayerKeyboardShortcuts(
+    enabled: Boolean,
+    handlers: PlayerKeyboardShortcutHandlers,
+) = Unit
+
+actual val usesNativePlayerChrome: Boolean = false
+
+actual val usesAnimatedPlayerChrome: Boolean = true
 
 private tailrec fun Context.findActivity(): Activity? =
     when (this) {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
@@ -10,6 +10,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
+import com.nuvio.app.features.player.ManageFullscreenKeyboardShortcuts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.hoverable
@@ -698,6 +699,12 @@ private fun MainAppContent(
             warmProfileBoundRepositories()
         }
         val currentBackStackEntry by navController.currentBackStackEntryAsState()
+        val isHomeRouteActive = selectedTab == AppScreenTab.Home &&
+            currentBackStackEntry?.destination?.hasRoute<TabsRoute>() == true
+        ManageFullscreenKeyboardShortcuts(
+            isHomeRouteActive = isHomeRouteActive,
+            onBack = { navController.popBackStack() },
+        )
         val liquidGlassNativeTabBarEnabled by remember {
             ThemeSettingsRepository.liquidGlassNativeTabBarEnabled
         }.collectAsStateWithLifecycle()

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/DesktopHorizontalLazyRowGestures.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/DesktopHorizontalLazyRowGestures.kt
@@ -1,0 +1,6 @@
+package com.nuvio.app.core.ui
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.ui.Modifier
+
+expect fun Modifier.desktopHorizontalLazyRowGestures(listState: LazyListState): Modifier

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerPlatformEffects.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerPlatformEffects.kt
@@ -10,6 +10,25 @@ interface PlayerGestureController {
     fun setVolume(level: Float): PlayerAudioLevel?
 }
 
+interface PlayerFullscreenController {
+    val isFullscreenSupported: Boolean
+    val isFullscreen: Boolean
+    fun toggleFullscreen()
+}
+
+data class PlayerKeyboardShortcutHandlers(
+    val toggleFullscreen: () -> Unit,
+    val togglePlayback: () -> Unit,
+    val seekForward: () -> Unit,
+    val seekBackward: () -> Unit,
+    val volumeUp: () -> Unit,
+    val volumeDown: () -> Unit,
+    val toggleMute: () -> Unit,
+    val cyclePlaybackSpeed: () -> Unit,
+    val playNextEpisode: () -> Unit,
+    val skipActiveSegment: () -> Unit,
+)
+
 data class PlayerAudioLevel(
     val fraction: Float,
     val isMuted: Boolean,
@@ -28,4 +47,26 @@ expect fun ManagePlayerPictureInPicture(
 )
 
 @Composable
+expect fun ManagePlayerCursorVisibility(visible: Boolean)
+
+@Composable
 expect fun rememberPlayerGestureController(): PlayerGestureController?
+
+@Composable
+expect fun rememberPlayerFullscreenController(): PlayerFullscreenController
+
+@Composable
+expect fun ManageFullscreenKeyboardShortcuts(
+    isHomeRouteActive: Boolean,
+    onBack: () -> Unit = {},
+)
+
+@Composable
+expect fun BindPlayerKeyboardShortcuts(
+    enabled: Boolean,
+    handlers: PlayerKeyboardShortcutHandlers,
+)
+
+expect val usesNativePlayerChrome: Boolean
+
+expect val usesAnimatedPlayerChrome: Boolean

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/LocalDesktopWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/LocalDesktopWindow.kt
@@ -1,0 +1,6 @@
+package com.nuvio.app
+
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.awt.ComposeWindow
+
+val LocalDesktopWindow = compositionLocalOf<ComposeWindow?> { null }

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
@@ -1,6 +1,7 @@
 package com.nuvio.app
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
@@ -73,7 +74,9 @@ fun main() {
             }
 
             if (smokePlayerUrl == null) {
-                App()
+                CompositionLocalProvider(LocalDesktopWindow provides window) {
+                    App()
+                }
             } else {
                 PlatformPlayerSurface(
                     sourceUrl = smokePlayerUrl,

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/core/ui/DesktopHorizontalLazyRowGestures.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/core/ui/DesktopHorizontalLazyRowGestures.desktop.kt
@@ -1,0 +1,53 @@
+package com.nuvio.app.core.ui
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.input.pointer.onPointerEvent
+import androidx.compose.ui.input.pointer.pointerInput
+import kotlin.math.abs
+
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalFoundationApi::class)
+actual fun Modifier.desktopHorizontalLazyRowGestures(listState: LazyListState): Modifier =
+    this
+        .pointerInput(listState) {
+            awaitEachGesture {
+                val down = awaitFirstDown(pass = PointerEventPass.Initial)
+                if (down.type != PointerType.Mouse) return@awaitEachGesture
+
+                var totalDx = 0f
+                var totalDy = 0f
+                var dragging = false
+
+                while (true) {
+                    val event = awaitPointerEvent(pass = PointerEventPass.Initial)
+                    val change = event.changes.firstOrNull { it.id == down.id } ?: break
+                    if (!change.pressed) break
+
+                    val delta = change.position - change.previousPosition
+                    totalDx += delta.x
+                    totalDy += delta.y
+
+                    if (!dragging) {
+                        val verticalDrag =
+                            abs(totalDy) > viewConfiguration.touchSlop && abs(totalDy) > abs(totalDx)
+                        val horizontalDrag =
+                            abs(totalDx) > viewConfiguration.touchSlop && abs(totalDx) > abs(totalDy)
+                        when {
+                            verticalDrag -> break
+                            horizontalDrag -> dragging = true
+                            else -> continue
+                        }
+                    }
+
+                    listState.dispatchRawDelta(-delta.x)
+                    change.consume()
+                }
+            }
+        }

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/KeybindsStorage.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/KeybindsStorage.kt
@@ -1,0 +1,85 @@
+package com.nuvio.app.features.player
+
+import com.nuvio.app.core.storage.DesktopStorage
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+@Serializable
+data class KeybindEntry(
+    val action: String,
+    val keyCode: Int,
+    val modifiers: Int = 0,
+)
+
+@Serializable
+data class KeybindsConfig(
+    val binds: List<KeybindEntry> = defaultKeybinds(),
+) {
+    companion object {
+        fun defaultKeybinds(): List<KeybindEntry> = listOf(
+            KeybindEntry("toggle_fullscreen", java.awt.event.KeyEvent.VK_F),
+            KeybindEntry("toggle_app_fullscreen", java.awt.event.KeyEvent.VK_F11),
+            KeybindEntry("exit_fullscreen", java.awt.event.KeyEvent.VK_ESCAPE),
+            KeybindEntry("play_pause", java.awt.event.KeyEvent.VK_SPACE),
+            KeybindEntry("seek_forward_10s", java.awt.event.KeyEvent.VK_RIGHT),
+            KeybindEntry("seek_backward_10s", java.awt.event.KeyEvent.VK_LEFT),
+            KeybindEntry("volume_up", java.awt.event.KeyEvent.VK_UP),
+            KeybindEntry("volume_down", java.awt.event.KeyEvent.VK_DOWN),
+            KeybindEntry("mute", java.awt.event.KeyEvent.VK_M),
+            KeybindEntry("cycle_speed", java.awt.event.KeyEvent.VK_R),
+            KeybindEntry("next_episode", java.awt.event.KeyEvent.VK_N),
+            KeybindEntry("skip_intro", java.awt.event.KeyEvent.VK_S),
+        )
+    }
+}
+
+object KeybindsStorage {
+    private const val storeName = "nuvio_keybinds"
+    private const val configKey = "keybinds_v1"
+    private val json = Json { ignoreUnknownKeys = true; prettyPrint = false }
+    private val store by lazy { DesktopStorage.store(storeName) }
+
+    fun load(): KeybindsConfig {
+        val raw = store.getString(configKey) ?: return KeybindsConfig()
+        return runCatching { json.decodeFromString<KeybindsConfig>(raw) }
+            .getOrDefault(KeybindsConfig())
+            .withDefaultActions()
+    }
+
+    fun save(config: KeybindsConfig) {
+        val raw = json.encodeToString(config)
+        store.putString(configKey, raw)
+    }
+
+    fun getKeyCode(action: String): Int? = load().binds
+        .firstOrNull { it.action == action }?.keyCode
+
+    fun actionForKeyCode(keyCode: Int, modifiers: Int = 0): String? {
+        val disallowedModifiers = java.awt.event.KeyEvent.CTRL_DOWN_MASK or
+            java.awt.event.KeyEvent.ALT_DOWN_MASK or
+            java.awt.event.KeyEvent.META_DOWN_MASK or
+            java.awt.event.KeyEvent.ALT_GRAPH_DOWN_MASK
+        return load().binds.firstOrNull { bind ->
+            bind.keyCode == keyCode &&
+                if (bind.modifiers == 0) {
+                    modifiers and disallowedModifiers == 0
+                } else {
+                    bind.modifiers == modifiers
+                }
+        }?.action
+    }
+
+    private fun KeybindsConfig.withDefaultActions(): KeybindsConfig {
+        val savedByAction = binds.associateBy { it.action }
+        val normalized = KeybindsConfig.defaultKeybinds().map { defaultEntry ->
+            val saved = savedByAction[defaultEntry.action] ?: return@map defaultEntry
+            if (saved.action == "cycle_speed" && saved.keyCode == java.awt.event.KeyEvent.VK_CLOSE_BRACKET) {
+                defaultEntry
+            } else {
+                saved
+            }
+        }
+        return copy(binds = normalized)
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/PlayerDesktop.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/PlayerDesktop.desktop.kt
@@ -1,0 +1,220 @@
+package com.nuvio.app.features.player
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.awt.ComposeWindow
+import androidx.compose.ui.window.WindowPlacement
+import com.nuvio.app.LocalDesktopWindow
+import java.awt.Cursor
+import java.awt.AWTEvent
+import java.awt.KeyEventDispatcher
+import java.awt.KeyboardFocusManager
+import java.awt.Point
+import java.awt.Toolkit
+import java.awt.event.AWTEventListener
+import java.awt.event.KeyEvent
+import java.awt.event.MouseEvent
+import java.awt.event.WindowEvent
+import java.awt.event.WindowFocusListener
+import java.awt.image.BufferedImage
+import kotlinx.coroutines.delay
+
+@Composable
+actual fun ManagePlayerCursorVisibility(visible: Boolean) {
+    val window = LocalDesktopWindow.current
+    val hiddenCursor = remember { createHiddenPlayerCursor() }
+
+    DisposableEffect(window) {
+        val previousCursor = window?.cursor
+        onDispose {
+            if (window != null && previousCursor != null) {
+                window.cursor = previousCursor
+            }
+        }
+    }
+
+    SideEffect {
+        window?.cursor = if (visible) Cursor.getDefaultCursor() else hiddenCursor
+    }
+}
+
+@Composable
+actual fun rememberPlayerFullscreenController(): PlayerFullscreenController {
+    val window = LocalDesktopWindow.current as? ComposeWindow
+    var isFullscreen by remember(window) {
+        mutableStateOf(window?.placement == WindowPlacement.Fullscreen)
+    }
+
+    LaunchedEffect(window) {
+        while (true) {
+            isFullscreen = window?.placement == WindowPlacement.Fullscreen
+            delay(250)
+        }
+    }
+
+    return object : PlayerFullscreenController {
+        override val isFullscreenSupported: Boolean
+            get() = window != null
+
+        override val isFullscreen: Boolean
+            get() = isFullscreen
+
+        override fun toggleFullscreen() {
+            val w = window ?: return
+            w.placement = if (w.placement == WindowPlacement.Fullscreen) {
+                WindowPlacement.Floating
+            } else {
+                WindowPlacement.Fullscreen
+            }
+            isFullscreen = w.placement == WindowPlacement.Fullscreen
+        }
+    }
+}
+
+@Composable
+actual fun ManageFullscreenKeyboardShortcuts(
+    isHomeRouteActive: Boolean,
+    onBack: () -> Unit,
+) {
+    val window = LocalDesktopWindow.current as? ComposeWindow
+    val currentOnBack by rememberUpdatedState(onBack)
+
+    DisposableEffect(window) {
+        val composeWindow = window ?: return@DisposableEffect onDispose {}
+        val keyboardFocusManager = KeyboardFocusManager.getCurrentKeyboardFocusManager()
+        val dispatcher = KeyEventDispatcher { event ->
+            if (event.id != KeyEvent.KEY_RELEASED) {
+                return@KeyEventDispatcher false
+            }
+            if (event.keyCode == KeyEvent.VK_TAB &&
+                event.modifiersEx and KeyEvent.ALT_DOWN_MASK != 0
+            ) {
+                return@KeyEventDispatcher false
+            }
+            when (KeybindsStorage.actionForKeyCode(event.keyCode, event.modifiersEx)) {
+                "toggle_app_fullscreen" -> {
+                    composeWindow.toggleDesktopFullscreen()
+                    true
+                }
+                "exit_fullscreen" -> {
+                    if (composeWindow.isPlayerFullscreen()) {
+                        composeWindow.exitDesktopFullscreen()
+                        true
+                    } else {
+                        currentOnBack()
+                        true
+                    }
+                }
+                else -> false
+            }
+        }
+
+        keyboardFocusManager.addKeyEventDispatcher(dispatcher)
+
+        val mouseListener = AWTEventListener { awtEvent ->
+            if (awtEvent.id != MouseEvent.MOUSE_PRESSED) return@AWTEventListener
+            val mouseEvent = awtEvent as? MouseEvent ?: return@AWTEventListener
+            val isSideButton = mouseEvent.button in 4..9
+            if (!isSideButton) return@AWTEventListener
+            if (!composeWindow.isFocused) return@AWTEventListener
+            if (composeWindow.isPlayerFullscreen()) {
+                composeWindow.exitDesktopFullscreen()
+            } else {
+                currentOnBack()
+            }
+        }
+        Toolkit.getDefaultToolkit().addAWTEventListener(
+            mouseListener,
+            AWTEvent.MOUSE_EVENT_MASK,
+        )
+
+        val focusListener = object : WindowFocusListener {
+            override fun windowGainedFocus(e: WindowEvent?) {
+                composeWindow.repaint()
+                Toolkit.getDefaultToolkit().sync()
+            }
+            override fun windowLostFocus(e: WindowEvent?) = Unit
+        }
+        composeWindow.addWindowFocusListener(focusListener)
+
+        onDispose {
+            keyboardFocusManager.removeKeyEventDispatcher(dispatcher)
+            composeWindow.removeWindowFocusListener(focusListener)
+            Toolkit.getDefaultToolkit().removeAWTEventListener(mouseListener)
+        }
+    }
+}
+
+@Composable
+actual fun BindPlayerKeyboardShortcuts(
+    enabled: Boolean,
+    handlers: PlayerKeyboardShortcutHandlers,
+) {
+    val latestHandlers by rememberUpdatedState(handlers)
+
+    DisposableEffect(enabled) {
+        if (!enabled) return@DisposableEffect onDispose {}
+        val keyboardFocusManager = KeyboardFocusManager.getCurrentKeyboardFocusManager()
+        val dispatcher = KeyEventDispatcher { event ->
+            if (event.id != KeyEvent.KEY_RELEASED) {
+                return@KeyEventDispatcher false
+            }
+            if (event.keyCode == KeyEvent.VK_TAB &&
+                event.modifiersEx and KeyEvent.ALT_DOWN_MASK != 0
+            ) {
+                return@KeyEventDispatcher false
+            }
+            when (KeybindsStorage.actionForKeyCode(event.keyCode, event.modifiersEx)) {
+                "toggle_fullscreen" -> latestHandlers.toggleFullscreen()
+                "play_pause" -> latestHandlers.togglePlayback()
+                "seek_forward_10s" -> latestHandlers.seekForward()
+                "seek_backward_10s" -> latestHandlers.seekBackward()
+                "volume_up" -> latestHandlers.volumeUp()
+                "volume_down" -> latestHandlers.volumeDown()
+                "mute" -> latestHandlers.toggleMute()
+                "cycle_speed" -> latestHandlers.cyclePlaybackSpeed()
+                "next_episode" -> latestHandlers.playNextEpisode()
+                "skip_intro" -> latestHandlers.skipActiveSegment()
+                else -> return@KeyEventDispatcher false
+            }
+            true
+        }
+
+        keyboardFocusManager.addKeyEventDispatcher(dispatcher)
+        onDispose {
+            keyboardFocusManager.removeKeyEventDispatcher(dispatcher)
+        }
+    }
+}
+
+private fun ComposeWindow.toggleDesktopFullscreen() {
+    placement = if (placement == WindowPlacement.Fullscreen) {
+        WindowPlacement.Floating
+    } else {
+        WindowPlacement.Fullscreen
+    }
+}
+
+private fun ComposeWindow.exitDesktopFullscreen() {
+    placement = WindowPlacement.Floating
+}
+
+private fun ComposeWindow.isPlayerFullscreen(): Boolean {
+    return placement == WindowPlacement.Fullscreen
+}
+
+private fun createHiddenPlayerCursor(): Cursor {
+    val image = BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB)
+    return Toolkit.getDefaultToolkit().createCustomCursor(image, Point(0, 0), "nuvio-player-hidden-cursor")
+}
+
+actual val usesNativePlayerChrome: Boolean = false
+
+actual val usesAnimatedPlayerChrome: Boolean = false

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/core/ui/DesktopHorizontalLazyRowGestures.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/core/ui/DesktopHorizontalLazyRowGestures.ios.kt
@@ -1,0 +1,6 @@
+package com.nuvio.app.core.ui
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.ui.Modifier
+
+actual fun Modifier.desktopHorizontalLazyRowGestures(listState: LazyListState): Modifier = this

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/PlayerPlatformEffects.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/PlayerPlatformEffects.ios.kt
@@ -52,6 +52,9 @@ actual fun ManagePlayerPictureInPicture(
 ) = Unit
 
 @Composable
+actual fun ManagePlayerCursorVisibility(visible: Boolean) = Unit
+
+@Composable
 actual fun rememberPlayerGestureController(): PlayerGestureController? {
     val controller = remember { IOSPlayerGestureController() }
 
@@ -63,6 +66,32 @@ actual fun rememberPlayerGestureController(): PlayerGestureController? {
 
     return controller
 }
+
+@Composable
+actual fun rememberPlayerFullscreenController(): PlayerFullscreenController =
+    remember {
+        object : PlayerFullscreenController {
+            override val isFullscreenSupported: Boolean = false
+            override val isFullscreen: Boolean = false
+            override fun toggleFullscreen() = Unit
+        }
+    }
+
+@Composable
+actual fun ManageFullscreenKeyboardShortcuts(
+    isHomeRouteActive: Boolean,
+    onBack: () -> Unit,
+) = Unit
+
+@Composable
+actual fun BindPlayerKeyboardShortcuts(
+    enabled: Boolean,
+    handlers: PlayerKeyboardShortcutHandlers,
+) = Unit
+
+actual val usesNativePlayerChrome: Boolean = false
+
+actual val usesAnimatedPlayerChrome: Boolean = true
 
 private class IOSPlayerGestureController : PlayerGestureController {
     private val volumeView = MPVolumeView().apply {


### PR DESCRIPTION
Port keyboard and mouse shortcut controls from the main NuvioDesktop project to this fork.

**Changes:**
- New expect/actual declarations for player platform effects (cursor visibility, fullscreen, keyboard shortcuts)
- Desktop implementation with AWT KeyEventDispatcher for keyboard shortcuts (F/F11/Esc/Space/arrows/M/R/N/S)
- Mouse side button support for back navigation
- KeybindsStorage with configurable key bindings backed by DesktopStorage
- LocalDesktopWindow CompositionLocal for window access

**Keybindings:**
- F = toggle fullscreen, F11 = toggle app fullscreen, Esc = exit fullscreen/back
- Space = play/pause, ←/→ = seek, ↑/↓ = volume, M = mute
- R = cycle speed, N = next episode, S = skip intro
- Mouse buttons 4-9 = back