### PR TITLE
Fix Windows fullscreen layout issue with display scaling

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopAppFullscreen.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopAppFullscreen.kt
@@ -74,16 +74,21 @@ internal class DesktopAppFullscreenController {
     }
 
     private fun enterWindowsFullscreen(window: Window) {
-        val screenBounds = window.graphicsConfiguration?.bounds
-            ?: GraphicsEnvironment.getLocalGraphicsEnvironment().defaultScreenDevice.defaultConfiguration.bounds
+        val gc = window.graphicsConfiguration
+            ?: GraphicsEnvironment.getLocalGraphicsEnvironment().defaultScreenDevice.defaultConfiguration
+        val screenBounds = gc.bounds
+        val transform = gc.defaultTransform
+        val scaleX = transform.scaleX
+        val scaleY = transform.scaleY
+
         val hwnd = AwtNativeViewResolver.resolveNativeViewPointer(window)
         NativePlayerBridge.setWindowBorderlessFullscreen(
             windowHwnd = hwnd,
             fullscreen = true,
-            x = screenBounds.x,
-            y = screenBounds.y,
-            width = screenBounds.width,
-            height = screenBounds.height,
+            x = (screenBounds.x * scaleX).toInt(),
+            y = (screenBounds.y * scaleY).toInt(),
+            width = (screenBounds.width * scaleX).toInt(),
+            height = (screenBounds.height * scaleY).toInt(),
         )
         windowsFullscreenState = WindowsFullscreenState(window = window, windowHwnd = hwnd)
         window.toFront()


### PR DESCRIPTION
## Summary
This PR fixes a Windows scaling bug where entering fullscreen mode in the player does not cover the entire screen when display scaling (e.g. 125%, 150%) is enabled in Windows. 
The logic in `DesktopAppFullscreen.kt` has been updated to retrieve the screen device's `defaultTransform` scale factors (`scaleX`/`scaleY`) and multiply them by the logical `screenBounds` to pass the correct physical device pixels to the Win32 `setWindowBorderlessFullscreen` bridge.

## PR type
- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why
When the OS display scaling is set to anything other than 100% on Windows, the logical screen boundaries returned by Java AWT / Compose do not match the physical pixel bounds expected by the underlying Win32 window manager. As a result, the application window was sized smaller than the actual screen size when switching to borderless fullscreen, leaving parts of the desktop or taskbar visible.

## Desktop scope
This change only affects **Windows** desktop platforms. The scaling adjustments are within the Windows-specific fullscreen block (`toggleWindowsFullscreen`) inside `composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopAppFullscreen.kt`.
## Issue or approval

Fixes # (Insert the Issue number here, if one exists on the main repository, or mention if approved by maintainers)
## UI / behavior impact
- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries
This PR is strictly limited to calculating the correct physical scale bounds in `DesktopAppFullscreen.kt`. It does not modify styling, keybinding/shortcut defaults, or non-Windows platform fullscreen implementations.

## Testing
- **OS & Environment:** Tested on Windows 11 with display scaling set to `125%` and `150%`.
- **Manual Flow:** 
  1. Set Windows display scaling to `125%`.
  2. Opened the application and toggled fullscreen mode (F11 / player button).
  3. Verified that the window successfully covered the entire display canvas without exposing the taskbar or desktop.
  4. Repeated the same flow with `150%` scaling.
 
## Screenshots / Video

## Breaking changes
None.

## Linked issues
Fixes #39 