### PR TITLE
Fill missing home hero logos from TMDB artwork

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeRepository.kt
@@ -11,6 +11,8 @@ import com.nuvio.app.features.collection.CollectionSource
 import com.nuvio.app.features.collection.TmdbCollectionSourceResolver
 import com.nuvio.app.features.collection.catalogRouteKey
 import com.nuvio.app.features.collection.findCollectionCatalog
+import com.nuvio.app.features.tmdb.TmdbMetadataService
+import com.nuvio.app.features.tmdb.TmdbSettingsRepository
 import com.nuvio.app.features.trakt.TraktPublicListSourceResolver
 import com.nuvio.app.features.watchprogress.CurrentDateProvider
 import kotlinx.coroutines.CoroutineScope
@@ -38,6 +40,9 @@ object HomeRepository {
     private var currentDefinitions: List<HomeCatalogDefinition> = emptyList()
     private var cachedSections: Map<String, HomeCatalogSection> = emptyMap()
     private var cachedCollectionHeroItems: List<MetaPreview> = emptyList()
+    private var cachedCatalogHeroLogos: Map<String, String> = emptyMap()
+    private var catalogHeroLogoJob: Job? = null
+    private var catalogHeroLogoRequestKey: String? = null
     private var collectionHeroJob: Job? = null
     private var collectionHeroRequestKey: String? = null
     private var lastPublishedCatalogHeroEmpty: Boolean = true
@@ -166,6 +171,10 @@ object HomeRepository {
         currentDefinitions = emptyList()
         cachedSections = emptyMap()
         cachedCollectionHeroItems = emptyList()
+        cachedCatalogHeroLogos = emptyMap()
+        catalogHeroLogoJob?.cancel()
+        catalogHeroLogoJob = null
+        catalogHeroLogoRequestKey = null
         collectionHeroJob?.cancel()
         collectionHeroJob = null
         collectionHeroRequestKey = null
@@ -211,9 +220,10 @@ object HomeRepository {
         } else {
             emptyList()
         }
+        val resolvedCatalogHeroItems = catalogHeroItems.withCachedCatalogHeroLogos()
         lastPublishedCatalogHeroEmpty = snapshot.heroEnabled && catalogHeroItems.isEmpty()
         val heroItems = if (snapshot.heroEnabled) {
-            catalogHeroItems.ifEmpty { cachedCollectionHeroItems }
+            resolvedCatalogHeroItems.ifEmpty { cachedCollectionHeroItems }
         } else {
             emptyList()
         }
@@ -223,6 +233,12 @@ object HomeRepository {
             heroItems = heroItems,
             sections = sections,
             errorMessage = if (sections.isEmpty()) lastErrorMessage else null,
+        )
+
+        ensureCatalogHeroLogos(
+            items = catalogHeroItems,
+            requestKey = requestKey,
+            heroEnabled = snapshot.heroEnabled,
         )
     }
 
@@ -338,6 +354,67 @@ object HomeRepository {
             .flatMap { collection -> collection.folders }
             .flatMap { folder -> folder.resolvedSources }
             .take(HOME_COLLECTION_HERO_SOURCE_LIMIT)
+
+    private fun List<MetaPreview>.withCachedCatalogHeroLogos(): List<MetaPreview> =
+        map { item ->
+            val logo = cachedCatalogHeroLogos[item.stableKey()]
+                ?.takeIf(String::isNotBlank)
+                ?: return@map item
+            if (item.logo.isNullOrBlank()) item.copy(logo = logo) else item
+        }
+
+    private fun ensureCatalogHeroLogos(
+        items: List<MetaPreview>,
+        requestKey: String?,
+        heroEnabled: Boolean,
+    ) {
+        if (!heroEnabled || items.isEmpty()) return
+        val settings = TmdbSettingsRepository.snapshot()
+        if (!settings.enabled || !settings.hasApiKey || !settings.useArtwork) return
+
+        val candidates = items.filter { item ->
+            item.logo.isNullOrBlank() && cachedCatalogHeroLogos[item.stableKey()].isNullOrBlank()
+        }
+        if (candidates.isEmpty()) return
+
+        val nextRequestKey = buildString {
+            append(requestKey.orEmpty())
+            append("|tmdb-logo:")
+            append(settings.language)
+            append(":")
+            candidates.forEach { item ->
+                append(item.stableKey())
+                append(";")
+            }
+        }
+        if (catalogHeroLogoRequestKey == nextRequestKey) return
+
+        catalogHeroLogoJob?.cancel()
+        catalogHeroLogoRequestKey = nextRequestKey
+        catalogHeroLogoJob = scope.launch {
+            val resolvedLogos = candidates
+                .map { item ->
+                    async {
+                        val enriched = TmdbMetadataService.enrichPreviewLogo(
+                            item = item,
+                            settings = settings,
+                        )
+                        enriched.logo
+                            ?.takeIf(String::isNotBlank)
+                            ?.let { logo -> item.stableKey() to logo }
+                    }
+                }
+                .awaitAll()
+                .filterNotNull()
+
+            if (resolvedLogos.isEmpty()) return@launch
+            cachedCatalogHeroLogos = cachedCatalogHeroLogos + resolvedLogos
+            publishCurrentState(
+                isLoading = _uiState.value.isLoading,
+                requestKey = requestKey,
+            )
+        }
+    }
 
     private suspend fun CollectionSource.resolveCollectionHeroItems(addons: List<ManagedAddon>): List<MetaPreview> {
         val page = when {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeRepository.kt
@@ -12,6 +12,7 @@ import com.nuvio.app.features.collection.TmdbCollectionSourceResolver
 import com.nuvio.app.features.collection.catalogRouteKey
 import com.nuvio.app.features.collection.findCollectionCatalog
 import com.nuvio.app.features.tmdb.TmdbMetadataService
+import com.nuvio.app.features.tmdb.TmdbSettings
 import com.nuvio.app.features.tmdb.TmdbSettingsRepository
 import com.nuvio.app.features.trakt.TraktPublicListSourceResolver
 import com.nuvio.app.features.watchprogress.CurrentDateProvider
@@ -220,7 +221,8 @@ object HomeRepository {
         } else {
             emptyList()
         }
-        val resolvedCatalogHeroItems = catalogHeroItems.withCachedCatalogHeroLogos()
+        val tmdbSettings = TmdbSettingsRepository.snapshot()
+        val resolvedCatalogHeroItems = catalogHeroItems.withCachedCatalogHeroLogos(tmdbSettings)
         lastPublishedCatalogHeroEmpty = snapshot.heroEnabled && catalogHeroItems.isEmpty()
         val heroItems = if (snapshot.heroEnabled) {
             resolvedCatalogHeroItems.ifEmpty { cachedCollectionHeroItems }
@@ -239,6 +241,7 @@ object HomeRepository {
             items = catalogHeroItems,
             requestKey = requestKey,
             heroEnabled = snapshot.heroEnabled,
+            settings = tmdbSettings,
         )
     }
 
@@ -355,25 +358,31 @@ object HomeRepository {
             .flatMap { folder -> folder.resolvedSources }
             .take(HOME_COLLECTION_HERO_SOURCE_LIMIT)
 
-    private fun List<MetaPreview>.withCachedCatalogHeroLogos(): List<MetaPreview> =
-        map { item ->
-            val logo = cachedCatalogHeroLogos[item.stableKey()]
+    private fun List<MetaPreview>.withCachedCatalogHeroLogos(settings: TmdbSettings): List<MetaPreview> {
+        if (!settings.enabled || !settings.hasApiKey || !settings.useArtwork) return this
+        return map { item ->
+            val logo = cachedCatalogHeroLogos[catalogHeroLogoCacheKey(settings, item)]
                 ?.takeIf(String::isNotBlank)
                 ?: return@map item
             if (item.logo.isNullOrBlank()) item.copy(logo = logo) else item
         }
+    }
+
+    private fun catalogHeroLogoCacheKey(settings: TmdbSettings, item: MetaPreview): String =
+        "${settings.language.trim().lowercase()}|${item.stableKey()}"
 
     private fun ensureCatalogHeroLogos(
         items: List<MetaPreview>,
         requestKey: String?,
         heroEnabled: Boolean,
+        settings: TmdbSettings,
     ) {
         if (!heroEnabled || items.isEmpty()) return
-        val settings = TmdbSettingsRepository.snapshot()
         if (!settings.enabled || !settings.hasApiKey || !settings.useArtwork) return
 
         val candidates = items.filter { item ->
-            item.logo.isNullOrBlank() && cachedCatalogHeroLogos[item.stableKey()].isNullOrBlank()
+            item.logo.isNullOrBlank() &&
+                cachedCatalogHeroLogos[catalogHeroLogoCacheKey(settings, item)].isNullOrBlank()
         }
         if (candidates.isEmpty()) return
 
@@ -401,7 +410,7 @@ object HomeRepository {
                         )
                         enriched.logo
                             ?.takeIf(String::isNotBlank)
-                            ?.let { logo -> item.stableKey() to logo }
+                            ?.let { logo -> catalogHeroLogoCacheKey(settings, item) to logo }
                     }
                 }
                 .awaitAll()

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt
@@ -28,6 +28,7 @@ object TmdbMetadataService {
     private val json = Json { ignoreUnknownKeys = true }
 
     private val enrichmentCache = mutableMapOf<String, TmdbEnrichment>()
+    private val previewLogoCache = mutableMapOf<String, String?>()
     private val episodeCache = mutableMapOf<String, Map<Pair<Int, Int>, TmdbEpisodeEnrichment>>()
     private val moreLikeThisCache = mutableMapOf<String, List<MetaPreview>>()
     private val collectionCache = mutableMapOf<String, Pair<String?, List<MetaPreview>>>()
@@ -590,6 +591,37 @@ object TmdbMetadataService {
         )
     }
 
+    suspend fun enrichPreviewLogo(
+        item: MetaPreview,
+        settings: TmdbSettings,
+    ): MetaPreview = withContext(Dispatchers.Default) {
+        if (!settings.enabled || !settings.hasApiKey || !settings.useArtwork) return@withContext item
+        if (!item.logo.isNullOrBlank()) return@withContext item
+
+        val tmdbType = normalizeMetaType(item.type)
+        val tmdbId = TmdbService.ensureTmdbId(item.id, tmdbType) ?: return@withContext item
+        val logo = fetchPreviewLogo(
+            tmdbId = tmdbId,
+            mediaType = tmdbType,
+            language = settings.language,
+        )
+
+        applyPreviewLogo(
+            item = item,
+            logo = logo,
+            settings = settings,
+        )
+    }
+
+    internal fun applyPreviewLogo(
+        item: MetaPreview,
+        logo: String?,
+        settings: TmdbSettings,
+    ): MetaPreview {
+        if (!settings.useArtwork || logo.isNullOrBlank() || !item.logo.isNullOrBlank()) return item
+        return item.copy(logo = logo)
+    }
+
     internal fun buildStandaloneMeta(
         type: String,
         id: String,
@@ -746,6 +778,32 @@ object TmdbMetadataService {
         }
 
         return updated
+    }
+
+    private suspend fun fetchPreviewLogo(
+        tmdbId: String,
+        mediaType: String,
+        language: String,
+    ): String? {
+        val normalizedLanguage = normalizeTmdbLanguage(language)
+        val cacheKey = "$tmdbId:$mediaType:$normalizedLanguage:preview-logo"
+        if (previewLogoCache.containsKey(cacheKey)) return previewLogoCache[cacheKey]
+
+        val numericId = tmdbId.toIntOrNull() ?: return null
+        val includeImageLanguage = buildString {
+            append(normalizedLanguage.substringBefore("-"))
+            append(",")
+            append(normalizedLanguage)
+            append(",en,null")
+        }
+
+        val images = fetch<TmdbImagesResponse>(
+            endpoint = "$mediaType/$numericId/images",
+            query = mapOf("include_image_language" to includeImageLanguage),
+        )
+        val logo = buildImageUrl(images?.logos.orEmpty().selectBestLocalizedImagePath(normalizedLanguage), "w500")
+        previewLogoCache[cacheKey] = logo
+        return logo
     }
 
     private suspend fun fetchEnrichment(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt
@@ -16,6 +16,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -29,6 +31,7 @@ object TmdbMetadataService {
 
     private val enrichmentCache = mutableMapOf<String, TmdbEnrichment>()
     private val previewLogoCache = mutableMapOf<String, String?>()
+    private val previewLogoCacheMutex = Mutex()
     private val episodeCache = mutableMapOf<String, Map<Pair<Int, Int>, TmdbEpisodeEnrichment>>()
     private val moreLikeThisCache = mutableMapOf<String, List<MetaPreview>>()
     private val collectionCache = mutableMapOf<String, Pair<String?, List<MetaPreview>>>()
@@ -787,9 +790,20 @@ object TmdbMetadataService {
     ): String? {
         val normalizedLanguage = normalizeTmdbLanguage(language)
         val cacheKey = "$tmdbId:$mediaType:$normalizedLanguage:preview-logo"
-        if (previewLogoCache.containsKey(cacheKey)) return previewLogoCache[cacheKey]
+        var hasCachedLogo = false
+        val cachedLogo = previewLogoCacheMutex.withLock {
+            hasCachedLogo = previewLogoCache.containsKey(cacheKey)
+            previewLogoCache[cacheKey]
+        }
+        if (hasCachedLogo) return cachedLogo
 
-        val numericId = tmdbId.toIntOrNull() ?: return null
+        val numericId = tmdbId.toIntOrNull()
+        if (numericId == null) {
+            previewLogoCacheMutex.withLock {
+                previewLogoCache[cacheKey] = null
+            }
+            return null
+        }
         val includeImageLanguage = buildString {
             append(normalizedLanguage.substringBefore("-"))
             append(",")
@@ -802,7 +816,9 @@ object TmdbMetadataService {
             query = mapOf("include_image_language" to includeImageLanguage),
         )
         val logo = buildImageUrl(images?.logos.orEmpty().selectBestLocalizedImagePath(normalizedLanguage), "w500")
-        previewLogoCache[cacheKey] = logo
+        previewLogoCacheMutex.withLock {
+            previewLogoCache[cacheKey] = logo
+        }
         return logo
     }
 

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataServiceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataServiceTest.kt
@@ -4,10 +4,41 @@ import com.nuvio.app.features.details.MetaCompany
 import com.nuvio.app.features.details.MetaDetails
 import com.nuvio.app.features.details.MetaPerson
 import com.nuvio.app.features.details.MetaVideo
+import com.nuvio.app.features.home.MetaPreview
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class TmdbMetadataServiceTest {
+    @Test
+    fun `applyPreviewLogo fills missing preview logo without replacing existing artwork`() {
+        val missingLogo = MetaPreview(
+            id = "tt1234567",
+            type = "movie",
+            name = "Movie",
+        )
+        val existingLogo = missingLogo.copy(logo = "https://example.com/addon-logo.png")
+
+        val filled = TmdbMetadataService.applyPreviewLogo(
+            item = missingLogo,
+            logo = "https://image.tmdb.org/t/p/w500/logo.png",
+            settings = TmdbSettings(enabled = true, useArtwork = true),
+        )
+        val preserved = TmdbMetadataService.applyPreviewLogo(
+            item = existingLogo,
+            logo = "https://image.tmdb.org/t/p/w500/logo.png",
+            settings = TmdbSettings(enabled = true, useArtwork = true),
+        )
+        val disabled = TmdbMetadataService.applyPreviewLogo(
+            item = missingLogo,
+            logo = "https://image.tmdb.org/t/p/w500/logo.png",
+            settings = TmdbSettings(enabled = true, useArtwork = false),
+        )
+
+        assertEquals("https://image.tmdb.org/t/p/w500/logo.png", filled.logo)
+        assertEquals("https://example.com/addon-logo.png", preserved.logo)
+        assertEquals(null, disabled.logo)
+    }
+
     @Test
     fun `buildStandaloneMeta maps tmdb enrichment without addon meta`() {
         val enrichment = TmdbEnrichment(


### PR DESCRIPTION
## What changed

This lets home catalog hero items fill a missing logo from TMDB artwork when TMDB artwork enrichment is enabled.

## Why

Some catalog preview items have a backdrop and title, but no logo. On desktop that leaves the home hero falling back to plain title text even though TMDB has a localized logo available. This keeps add-on supplied logos untouched and only fills the missing case.

## Scope

- Home catalog hero items only.
- Uses the existing TMDB artwork setting and API key checks.
- Fetches only TMDB image metadata for the logo.
- Does not change details pages, player behavior, or hero metadata text.

## Testing

- Ran `./gradlew.bat :composeApp:desktopTest --tests "com.nuvio.app.features.tmdb.TmdbMetadataServiceTest" --tests "com.nuvio.app.features.home.HomeCatalogParserTest" --project-prop=nuvio.webview2.dir=S:/Nuvio/NuvioDesktop/.tmp/nuget/microsoft.web.webview2/1.0.3351.48 --no-daemon --stacktrace`
- Manually checked the desktop home hero locally with an item that previously showed plain title text; it now shows logo artwork when TMDB provides one.