### PR TITLE
enabled download feature with fix in urldecoder for playback fix

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/core/build/AppFeaturePolicy.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/core/build/AppFeaturePolicy.desktop.kt
@@ -2,7 +2,7 @@ package com.nuvio.app.core.build
 
 actual object AppFeaturePolicy {
     actual val pluginsEnabled: Boolean = true
-    actual val downloadsEnabled: Boolean = false
+    actual val downloadsEnabled: Boolean = true
     actual val notificationsEnabled: Boolean = false
     actual val p2pEnabled: Boolean = false
     actual val externalPlayerSupported: Boolean = false

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
@@ -81,9 +81,17 @@ internal class NativePlayerController(
             disposePlayerHandle()
             runCatching {
                 val hostViewPtr = AwtNativeViewResolver.resolveNativeViewPointer(host)
+                val resolvedSource = if (pending.sourceUrl.startsWith("file:", ignoreCase = true)) {
+                    runCatching { java.io.File(java.net.URI(pending.sourceUrl)).absolutePath }.getOrElse {
+                        val stripped = pending.sourceUrl.replaceFirst(Regex("^file:/{1,3}", RegexOption.IGNORE_CASE), "")
+                        runCatching { java.net.URLDecoder.decode(stripped, "UTF-8") }.getOrDefault(stripped)
+                    }
+                } else {
+                    pending.sourceUrl
+                }
                 handle = NativePlayerBridge.create(
                     hostViewPtr = hostViewPtr,
-                    sourceUrl = pending.sourceUrl,
+                    sourceUrl = resolvedSource,
                     headerLines = pending.headerLines.toTypedArray(),
                     playWhenReady = pending.playWhenReady,
                     initialPositionMs = pending.initialPositionMs,


### PR DESCRIPTION
## Summary

This PR resolves a playback issue in Nuvio Desktop where downloaded local media files failed to load and became stuck on the loading/poster screen.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

**1. Desktop Download Playback Fix:**
* **The Problem:** When playing downloaded content, the system resolves the local file as a `file:` URI (e.g. `file:/D:/Development/.../video.mp4` or `file:///D:/Development/.../video%20file.mp4`). The desktop native player utilizes `libmpv` via a C++ JNI bridge (`player_bridge.dll`), which expects standard native absolute paths. Passing the raw `file:` URI string (and its URL-encoded entities like `%20`) directly to `libmpv` caused the player to fail to load the media and get stuck on the opening poster.
* **The Fix:** Integrated a robust, cross-platform path resolution block inside `NativePlayerController.kt`. It first attempts to parse the source URL via `java.net.URI` to retrieve the fully URL-decoded absolute path (`java.io.File(uri).absolutePath`). If parsing fails due to syntax edge cases, it strips the scheme and uses `java.net.URLDecoder` to parse the path. This ensures `libmpv` receives a clean, native absolute file path.

## Desktop scope

This PR is strictly confined to the desktop native player controller. No mobile platform codebase (Android/iOS) is affected.

* Modified NativePlayerController & AppFeaturePolicy (Desktop) 
* Enabled the existing download feature.
* Fixed the Playback issue due to incorrect URI

## Issue or approval

https://github.com/NuvioMedia/NuvioDesktop/issues/76 - Core player bug resolution for local download playback.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

None.

## Testing

Manually verified:
1. Activated `downloadsEnabled` for desktop.
2. Downloaded a media stream containing spaces in the filename.
3. Initiated internal playback for the downloaded file on Windows.
4. Confirmed the player successfully resolves the path, skips the poster, and plays the local file.

## Screenshots / Video

<img width="1881" height="506" alt="image" src="https://github.com/user-attachments/assets/2079040f-dbd5-4d2f-b332-2719b5e59618" />
<img width="1887" height="1165" alt="image" src="https://github.com/user-attachments/assets/0c9c8f70-06c7-43df-b050-71b72dd1b656" />

## Breaking changes

None.

## Linked issues

https://github.com/NuvioMedia/NuvioDesktop/issues/76 - Core player bug resolution for local download playback.

Note to Author: Please test and review if I have missed anything. Hopefully the change should not break existing implementation.
