### PR TITLE
[codex] add desktop mouse navigation controls

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/core/ui/PlatformBackHandler.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/core/ui/PlatformBackHandler.android.kt
@@ -10,3 +10,9 @@ actual fun PlatformBackHandler(
 ) {
     BackHandler(enabled = enabled, onBack = onBack)
 }
+
+@Composable
+actual fun PlatformForwardHandler(
+    enabled: Boolean,
+    onForward: () -> Unit,
+) = Unit

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
@@ -104,6 +104,7 @@ import com.nuvio.app.core.ui.NuvioContinueWatchingActionSheet
 import com.nuvio.app.core.ui.NuvioPosterActionSheet
 import com.nuvio.app.core.ui.NuvioStatusModal
 import com.nuvio.app.core.ui.PlatformBackHandler
+import com.nuvio.app.core.ui.PlatformForwardHandler
 import com.nuvio.app.core.ui.platformExitApp
 import com.nuvio.app.core.ui.configurePlatformImageLoader
 import com.nuvio.app.core.ui.NuvioToastHost
@@ -361,6 +362,28 @@ enum class AppScreenTab {
     Search,
     Library,
     Settings,
+}
+
+private sealed interface AppNavigationHistoryEntry {
+    data class Tab(val tab: AppScreenTab) : AppNavigationHistoryEntry
+    data class Detail(val route: DetailRoute) : AppNavigationHistoryEntry
+    data class PersonDetail(val route: PersonDetailRoute) : AppNavigationHistoryEntry
+    data class EntityBrowse(val route: EntityBrowseRoute) : AppNavigationHistoryEntry
+    data class Stream(val launch: StreamLaunch) : AppNavigationHistoryEntry
+    data class Player(val launch: PlayerLaunch) : AppNavigationHistoryEntry
+    data class Catalog(val launch: CatalogLaunch) : AppNavigationHistoryEntry
+    data object HomescreenSettings : AppNavigationHistoryEntry
+    data object MetaScreenSettings : AppNavigationHistoryEntry
+    data object ContinueWatchingSettings : AppNavigationHistoryEntry
+    data object DownloadsSettings : AppNavigationHistoryEntry
+    data object AddonsSettings : AppNavigationHistoryEntry
+    data object PluginsSettings : AppNavigationHistoryEntry
+    data object AccountSettings : AppNavigationHistoryEntry
+    data object SupportersContributorsSettings : AppNavigationHistoryEntry
+    data object LicensesAttributionsSettings : AppNavigationHistoryEntry
+    data object Collections : AppNavigationHistoryEntry
+    data class CollectionEditor(val route: CollectionEditorRoute) : AppNavigationHistoryEntry
+    data class FolderDetail(val route: FolderDetailRoute) : AppNavigationHistoryEntry
 }
 
 private val DesktopSidebarCollapsedWidth = 84.dp
@@ -754,6 +777,8 @@ private fun MainAppContent(
         val focusManager = LocalFocusManager.current
         val coroutineScope = rememberCoroutineScope()
         var selectedTab by rememberSaveable { mutableStateOf(AppScreenTab.Home) }
+        var forwardHistory by remember { mutableStateOf<List<AppNavigationHistoryEntry>>(emptyList()) }
+        var suppressForwardHistoryClearForRouteChange by remember { mutableStateOf(false) }
         var searchFocusRequestCount by remember { mutableStateOf(0) }
         val homeScrollToTopRequests = remember { MutableSharedFlow<Unit>(extraBufferCapacity = 1) }
         val searchScrollToTopRequests = remember { MutableSharedFlow<Unit>(extraBufferCapacity = 1) }
@@ -815,8 +840,94 @@ private fun MainAppContent(
     var networkToastBaselineReady by rememberSaveable { mutableStateOf(false) }
     var lastNetworkToastCondition by rememberSaveable { mutableStateOf(NetworkCondition.Unknown.name) }
 
+    fun clearForwardHistory() {
+        if (forwardHistory.isNotEmpty()) {
+            forwardHistory = emptyList()
+        }
+    }
+
+    fun pushForwardHistory(entry: AppNavigationHistoryEntry) {
+        forwardHistory = (forwardHistory + entry).takeLast(50)
+    }
+
+    fun PlayerLaunch.withLatestResumePosition(): PlayerLaunch {
+        val progress = videoId
+            ?.let(WatchProgressRepository::progressForVideo)
+            ?.takeIf { it.isResumable }
+        return if (progress == null) {
+            this
+        } else {
+            copy(
+                initialPositionMs = progress.lastPositionMs,
+                initialProgressFraction = progress.progressFraction,
+            )
+        }
+    }
+
+    fun restoreHistoryEntry(entry: AppNavigationHistoryEntry) {
+        when (entry) {
+            is AppNavigationHistoryEntry.Tab -> {
+                selectedTab = entry.tab
+            }
+            is AppNavigationHistoryEntry.Detail -> {
+                navController.navigate(entry.route)
+            }
+            is AppNavigationHistoryEntry.PersonDetail -> {
+                navController.navigate(entry.route)
+            }
+            is AppNavigationHistoryEntry.EntityBrowse -> {
+                navController.navigate(entry.route)
+            }
+            is AppNavigationHistoryEntry.Stream -> {
+                val launchId = StreamLaunchStore.put(entry.launch)
+                navController.navigate(StreamRoute(launchId = launchId))
+            }
+            is AppNavigationHistoryEntry.Player -> {
+                val launchId = PlayerLaunchStore.put(entry.launch.withLatestResumePosition())
+                navController.navigate(PlayerRoute(launchId = launchId))
+            }
+            is AppNavigationHistoryEntry.Catalog -> {
+                val launchId = CatalogLaunchStore.put(entry.launch)
+                navController.navigate(CatalogRoute(launchId = launchId))
+            }
+            AppNavigationHistoryEntry.HomescreenSettings -> navController.navigate(HomescreenSettingsRoute)
+            AppNavigationHistoryEntry.MetaScreenSettings -> navController.navigate(MetaScreenSettingsRoute)
+            AppNavigationHistoryEntry.ContinueWatchingSettings -> navController.navigate(ContinueWatchingSettingsRoute)
+            AppNavigationHistoryEntry.DownloadsSettings -> navController.navigate(DownloadsSettingsRoute)
+            AppNavigationHistoryEntry.AddonsSettings -> navController.navigate(AddonsSettingsRoute)
+            AppNavigationHistoryEntry.PluginsSettings -> navController.navigate(PluginsSettingsRoute)
+            AppNavigationHistoryEntry.AccountSettings -> navController.navigate(AccountSettingsRoute)
+            AppNavigationHistoryEntry.SupportersContributorsSettings -> navController.navigate(SupportersContributorsSettingsRoute)
+            AppNavigationHistoryEntry.LicensesAttributionsSettings -> navController.navigate(LicensesAttributionsSettingsRoute)
+            AppNavigationHistoryEntry.Collections -> navController.navigate(CollectionsRoute)
+            is AppNavigationHistoryEntry.CollectionEditor -> navController.navigate(entry.route)
+            is AppNavigationHistoryEntry.FolderDetail -> navController.navigate(entry.route)
+        }
+    }
+
+    fun restoreForwardHistory() {
+        val entry = forwardHistory.lastOrNull() ?: return
+        forwardHistory = forwardHistory.dropLast(1)
+        suppressForwardHistoryClearForRouteChange = entry !is AppNavigationHistoryEntry.Tab
+        restoreHistoryEntry(entry)
+    }
+
+    fun navigateBackWithHistory(
+        entry: AppNavigationHistoryEntry,
+        beforePop: () -> Unit = {},
+    ) {
+        pushForwardHistory(entry)
+        beforePop()
+        suppressForwardHistoryClearForRouteChange = true
+        if (!navController.popBackStack()) {
+            forwardHistory = forwardHistory.dropLast(1)
+            suppressForwardHistoryClearForRouteChange = false
+        }
+    }
+
     fun handleRootTabClick(tab: AppScreenTab) {
         if (selectedTab != tab) {
+            clearForwardHistory()
             selectedTab = tab
             return
         }
@@ -863,6 +974,11 @@ private fun MainAppContent(
 
         val destinationChangedListener = NavController.OnDestinationChangedListener { _, _, _ ->
             publishNativeTabVisibilityForCurrentRoute()
+            if (suppressForwardHistoryClearForRouteChange) {
+                suppressForwardHistoryClearForRouteChange = false
+            } else {
+                clearForwardHistory()
+            }
         }
 
         publishNativeTabVisibilityForCurrentRoute()
@@ -949,6 +1065,7 @@ private fun MainAppContent(
                     DownloadsRepository.playableLocalFileUri(it) != null
                 }
                 if (hasPlayableDownload) {
+                    clearForwardHistory()
                     selectedTab = AppScreenTab.Settings
                     navController.navigate(DownloadsSettingsRoute) {
                         launchSingleTop = true
@@ -1063,6 +1180,7 @@ private fun MainAppContent(
             AppDeepLinkRepository.pendingDeepLink.collectLatest { deepLink ->
                 when (deepLink) {
                     is AppDeepLink.Meta -> {
+                        clearForwardHistory()
                         selectedTab = AppScreenTab.Home
                         navController.navigate(DetailRoute(type = deepLink.type, id = deepLink.id)) {
                             launchSingleTop = true
@@ -1072,6 +1190,7 @@ private fun MainAppContent(
 
                     AppDeepLink.Downloads -> {
                         if (AppFeaturePolicy.downloadsEnabled) {
+                            clearForwardHistory()
                             selectedTab = AppScreenTab.Settings
                             navController.navigate(DownloadsSettingsRoute) {
                                 launchSingleTop = true
@@ -1443,6 +1562,17 @@ private fun MainAppContent(
             selectedContinueWatchingForActions = item
         }
 
+        val transientOverlayVisible = showLibraryListPicker ||
+            selectedPosterActionTarget != null ||
+            selectedContinueWatchingForActions != null ||
+            resumePromptItem != null ||
+            showExitConfirmation
+
+        PlatformForwardHandler(
+            enabled = forwardHistory.isNotEmpty() && !transientOverlayVisible,
+            onForward = { restoreForwardHistory() },
+        )
+
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -1459,6 +1589,7 @@ private fun MainAppContent(
                         enabled = true,
                         onBack = {
                             if (selectedTab != AppScreenTab.Home) {
+                                pushForwardHistory(AppNavigationHistoryEntry.Tab(selectedTab))
                                 selectedTab = AppScreenTab.Home
                             } else {
                                 showExitConfirmation = !showExitConfirmation
@@ -1484,6 +1615,7 @@ private fun MainAppContent(
                         val tabsRouteActive = currentBackStackEntry?.destination?.hasRoute<TabsRoute>() == true
                         val onProfileSelected: (NuvioProfile) -> Unit = { profile ->
                             profileSwitchLoading = true
+                            clearForwardHistory()
                             selectedTab = AppScreenTab.Home
                             coroutineScope.launch {
                                 try {
@@ -1596,6 +1728,7 @@ private fun MainAppContent(
                                             }
                                         },
                                         onConnectCloudClick = {
+                                            clearForwardHistory()
                                             requestedSettingsPageName = "Debrid"
                                             selectedTab = AppScreenTab.Settings
                                         },
@@ -1669,12 +1802,14 @@ private fun MainAppContent(
                     val directorRole = stringResource(Res.string.person_role_director)
                     val writerRole = stringResource(Res.string.person_role_writer)
                     val creatorRole = stringResource(Res.string.person_role_creator)
+                    val onBack: () -> Unit = {
+                        navigateBackWithHistory(AppNavigationHistoryEntry.Detail(route))
+                    }
+                    PlatformBackHandler(enabled = true, onBack = onBack)
                     MetaDetailsScreen(
                         type = route.type,
                         id = route.id,
-                        onBack = {
-                            navController.popBackStack()
-                        },
+                        onBack = onBack,
                         onPlay = onPlay,
                         onPlayManually = onPlayManually,
                         onOpenMeta = { preview ->
@@ -1739,13 +1874,17 @@ private fun MainAppContent(
                 }
                 composable<PersonDetailRoute> { backStackEntry ->
                     val route = backStackEntry.toRoute<PersonDetailRoute>()
+                    val onBack: () -> Unit = {
+                        navigateBackWithHistory(AppNavigationHistoryEntry.PersonDetail(route))
+                    }
+                    PlatformBackHandler(enabled = true, onBack = onBack)
                     PersonDetailScreen(
                         personId = route.personId,
                         personName = route.personName,
                         initialProfilePhoto = route.personPhoto,
                         avatarTransitionKey = route.castAvatarTransitionKey,
                         preferCrew = route.preferCrew,
-                        onBack = { navController.popBackStack() },
+                        onBack = onBack,
                         onOpenMeta = { preview ->
                             coroutineScope.launch {
                                 val resolvedId = if (preview.id.startsWith("tmdb:")) {
@@ -1774,12 +1913,16 @@ private fun MainAppContent(
                 }
                 composable<EntityBrowseRoute> { backStackEntry ->
                     val route = backStackEntry.toRoute<EntityBrowseRoute>()
+                    val onBack: () -> Unit = {
+                        navigateBackWithHistory(AppNavigationHistoryEntry.EntityBrowse(route))
+                    }
+                    PlatformBackHandler(enabled = true, onBack = onBack)
                     TmdbEntityBrowseScreen(
                         entityKind = TmdbEntityKind.fromRouteValue(route.entityKind),
                         entityId = route.entityId,
                         entityName = route.entityName,
                         sourceType = route.sourceType,
-                        onBack = { navController.popBackStack() },
+                        onBack = onBack,
                         onOpenMeta = { preview ->
                             coroutineScope.launch {
                                 val resolvedId = if (preview.id.startsWith("tmdb:")) {
@@ -2354,6 +2497,17 @@ private fun MainAppContent(
                         }
                     }
 
+                    val onBack: () -> Unit = {
+                        if (pendingP2pStreamOpen != null) {
+                            pendingP2pStreamOpen = null
+                        } else {
+                            navigateBackWithHistory(AppNavigationHistoryEntry.Stream(launch)) {
+                                StreamsRepository.clear()
+                            }
+                        }
+                    }
+                    PlatformBackHandler(enabled = true, onBack = onBack)
+
                     Box(modifier = Modifier.fillMaxSize()) {
                         StreamsScreen(
                             type = launch.type,
@@ -2390,10 +2544,7 @@ private fun MainAppContent(
                                     forceInternal = !openExternally,
                                 )
                             },
-                            onBack = {
-                                StreamsRepository.clear()
-                                navController.popBackStack()
-                            },
+                            onBack = onBack,
                             modifier = Modifier.fillMaxSize(),
                         )
                         pendingP2pStreamOpen?.let { pending ->
@@ -2465,6 +2616,12 @@ private fun MainAppContent(
                     LaunchedEffect(launch.videoId) {
                         launch.videoId?.let { ResumePromptRepository.markPlayerEntered(it) }
                     }
+                    val onBack: () -> Unit = {
+                        navigateBackWithHistory(AppNavigationHistoryEntry.Player(launch)) {
+                            ResumePromptRepository.markPlayerExitedNormally()
+                            PlayerLaunchStore.remove(route.launchId)
+                        }
+                    }
                     PlayerScreen(
                         profileId = launch.profileId,
                         title = launch.title,
@@ -2497,11 +2654,7 @@ private fun MainAppContent(
                         initialPositionMs = launch.initialPositionMs,
                         initialProgressFraction = launch.initialProgressFraction,
                         contentLanguage = launch.contentLanguage,
-                        onBack = {
-                            ResumePromptRepository.markPlayerExitedNormally()
-                            PlayerLaunchStore.remove(route.launchId)
-                            navController.popBackStack()
-                        },
+                        onBack = onBack,
                         onOpenInExternalPlayer = if (externalPlayerSupported) { { request ->
                             val playerLaunch = PlayerLaunch(
                                 profileId = launch.profileId,
@@ -2560,15 +2713,18 @@ private fun MainAppContent(
                         return@composable
                     }
                     val target = launch.target
+                    val onBack: () -> Unit = {
+                        navigateBackWithHistory(AppNavigationHistoryEntry.Catalog(launch)) {
+                            CatalogRepository.clear()
+                            CatalogLaunchStore.remove(route.launchId)
+                        }
+                    }
+                    PlatformBackHandler(enabled = true, onBack = onBack)
                     CatalogScreen(
                         title = launch.title,
                         subtitle = launch.subtitle,
                         target = target,
-                        onBack = {
-                            CatalogRepository.clear()
-                            CatalogLaunchStore.remove(route.launchId)
-                            navController.popBackStack()
-                        },
+                        onBack = onBack,
                         onPosterClick = { meta ->
                             navController.navigate(DetailRoute(type = meta.type, id = meta.id))
                         },
@@ -2592,7 +2748,9 @@ private fun MainAppContent(
                     val onBack = rememberGuardedPopBackStack(
                         navController = navController,
                         backStackEntry = it,
+                        onPop = { navigateBackWithHistory(AppNavigationHistoryEntry.HomescreenSettings) },
                     )
+                    PlatformBackHandler(enabled = true, onBack = onBack)
                     HomescreenSettingsScreen(
                         onBack = onBack,
                     )
@@ -2601,7 +2759,9 @@ private fun MainAppContent(
                     val onBack = rememberGuardedPopBackStack(
                         navController = navController,
                         backStackEntry = backStackEntry,
+                        onPop = { navigateBackWithHistory(AppNavigationHistoryEntry.MetaScreenSettings) },
                     )
+                    PlatformBackHandler(enabled = true, onBack = onBack)
                     MetaScreenSettingsScreen(
                         onBack = onBack,
                     )
@@ -2610,7 +2770,9 @@ private fun MainAppContent(
                     val onBack = rememberGuardedPopBackStack(
                         navController = navController,
                         backStackEntry = backStackEntry,
+                        onPop = { navigateBackWithHistory(AppNavigationHistoryEntry.ContinueWatchingSettings) },
                     )
+                    PlatformBackHandler(enabled = true, onBack = onBack)
                     ContinueWatchingSettingsScreen(
                         onBack = onBack,
                     )
@@ -2620,7 +2782,9 @@ private fun MainAppContent(
                         val onBack = rememberGuardedPopBackStack(
                             navController = navController,
                             backStackEntry = backStackEntry,
+                            onPop = { navigateBackWithHistory(AppNavigationHistoryEntry.DownloadsSettings) },
                         )
+                        PlatformBackHandler(enabled = true, onBack = onBack)
                         DownloadsScreen(
                             onBack = onBack,
                             onOpenDownload = { item ->
@@ -2668,7 +2832,9 @@ private fun MainAppContent(
                     val onBack = rememberGuardedPopBackStack(
                         navController = navController,
                         backStackEntry = backStackEntry,
+                        onPop = { navigateBackWithHistory(AppNavigationHistoryEntry.AddonsSettings) },
                     )
+                    PlatformBackHandler(enabled = true, onBack = onBack)
                     AddonsSettingsScreen(
                         onBack = onBack,
                     )
@@ -2678,7 +2844,9 @@ private fun MainAppContent(
                         val onBack = rememberGuardedPopBackStack(
                             navController = navController,
                             backStackEntry = backStackEntry,
+                            onPop = { navigateBackWithHistory(AppNavigationHistoryEntry.PluginsSettings) },
                         )
+                        PlatformBackHandler(enabled = true, onBack = onBack)
                         PluginsSettingsScreen(
                             onBack = onBack,
                         )
@@ -2688,7 +2856,9 @@ private fun MainAppContent(
                     val onBack = rememberGuardedPopBackStack(
                         navController = navController,
                         backStackEntry = backStackEntry,
+                        onPop = { navigateBackWithHistory(AppNavigationHistoryEntry.AccountSettings) },
                     )
+                    PlatformBackHandler(enabled = true, onBack = onBack)
                     AccountSettingsScreen(
                         onBack = onBack,
                     )
@@ -2697,7 +2867,9 @@ private fun MainAppContent(
                     val onBack = rememberGuardedPopBackStack(
                         navController = navController,
                         backStackEntry = backStackEntry,
+                        onPop = { navigateBackWithHistory(AppNavigationHistoryEntry.SupportersContributorsSettings) },
                     )
+                    PlatformBackHandler(enabled = true, onBack = onBack)
                     SupportersContributorsSettingsScreen(
                         onBack = onBack,
                     )
@@ -2706,7 +2878,9 @@ private fun MainAppContent(
                     val onBack = rememberGuardedPopBackStack(
                         navController = navController,
                         backStackEntry = backStackEntry,
+                        onPop = { navigateBackWithHistory(AppNavigationHistoryEntry.LicensesAttributionsSettings) },
                     )
+                    PlatformBackHandler(enabled = true, onBack = onBack)
                     LicensesAttributionsSettingsScreen(
                         onBack = onBack,
                     )
@@ -2715,7 +2889,9 @@ private fun MainAppContent(
                     val onBack = rememberGuardedPopBackStack(
                         navController = navController,
                         backStackEntry = backStackEntry,
+                        onPop = { navigateBackWithHistory(AppNavigationHistoryEntry.Collections) },
                     )
+                    PlatformBackHandler(enabled = true, onBack = onBack)
                     CollectionManagementScreen(
                         onBack = onBack,
                         onNavigateToEditor = { collectionId ->
@@ -2725,12 +2901,15 @@ private fun MainAppContent(
                 }
                 composable<CollectionEditorRoute> { backStackEntry ->
                     val route = backStackEntry.toRoute<CollectionEditorRoute>()
+                    val onBack: () -> Unit = {
+                        navigateBackWithHistory(AppNavigationHistoryEntry.CollectionEditor(route)) {
+                            CollectionEditorRepository.clear()
+                        }
+                    }
+                    PlatformBackHandler(enabled = true, onBack = onBack)
                     CollectionEditorScreen(
                         collectionId = route.collectionId,
-                        onBack = {
-                            CollectionEditorRepository.clear()
-                            navController.popBackStack()
-                        },
+                        onBack = onBack,
                     )
                 }
                 composable<FolderDetailRoute> { backStackEntry ->
@@ -2738,11 +2917,14 @@ private fun MainAppContent(
                     LaunchedEffect(route.collectionId, route.folderId) {
                         FolderDetailRepository.initialize(route.collectionId, route.folderId)
                     }
-                    FolderDetailScreen(
-                        onBack = {
+                    val onBack: () -> Unit = {
+                        navigateBackWithHistory(AppNavigationHistoryEntry.FolderDetail(route)) {
                             FolderDetailRepository.clear()
-                            navController.popBackStack()
-                        },
+                        }
+                    }
+                    PlatformBackHandler(enabled = true, onBack = onBack)
+                    FolderDetailScreen(
+                        onBack = onBack,
                         onCatalogClick = onCatalogClick,
                         onPosterClick = { meta ->
                             navController.navigate(DetailRoute(type = meta.type, id = meta.id))
@@ -2751,6 +2933,23 @@ private fun MainAppContent(
                 }
                 }
             }
+
+            PlatformBackHandler(
+                enabled = transientOverlayVisible,
+                onBack = {
+                    when {
+                        showLibraryListPicker -> {
+                            showLibraryListPicker = false
+                            pickerError = null
+                            pickerPending = false
+                        }
+                        selectedPosterActionTarget != null -> selectedPosterActionTarget = null
+                        selectedContinueWatchingForActions != null -> selectedContinueWatchingForActions = null
+                        resumePromptItem != null -> resumePromptItem = null
+                        showExitConfirmation -> showExitConfirmation = false
+                    }
+                },
+            )
 
             NuvioPosterActionSheet(
                 item = selectedPosterActionTarget?.preview,
@@ -2967,16 +3166,21 @@ private fun rememberGuardedPopBackStack(
     navController: NavHostController,
     backStackEntry: NavBackStackEntry,
     beforePop: () -> Unit = {},
+    onPop: (() -> Unit)? = null,
 ): () -> Unit {
     val currentBackStackEntry by navController.currentBackStackEntryAsState()
     var popHandled by remember(backStackEntry) { mutableStateOf(false) }
 
-    return remember(navController, backStackEntry, currentBackStackEntry, popHandled, beforePop) {
+    return remember(navController, backStackEntry, currentBackStackEntry, popHandled, beforePop, onPop) {
         {
             if (!popHandled && currentBackStackEntry == backStackEntry) {
                 popHandled = true
                 beforePop()
-                navController.popBackStack()
+                if (onPop == null) {
+                    navController.popBackStack()
+                } else {
+                    onPop()
+                }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/PlatformBackHandler.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/PlatformBackHandler.kt
@@ -7,3 +7,9 @@ expect fun PlatformBackHandler(
     enabled: Boolean,
     onBack: () -> Unit,
 )
+
+@Composable
+expect fun PlatformForwardHandler(
+    enabled: Boolean,
+    onForward: () -> Unit,
+)

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/SettingsScreen.kt
@@ -52,6 +52,7 @@ import com.nuvio.app.core.ui.LocalNuvioBottomNavigationOverlayPadding
 import com.nuvio.app.core.ui.NuvioScreen
 import com.nuvio.app.core.ui.NuvioScreenHeader
 import com.nuvio.app.core.ui.PlatformBackHandler
+import com.nuvio.app.core.ui.PlatformForwardHandler
 import com.nuvio.app.core.ui.isLiquidGlassNativeTabBarSupported
 import com.nuvio.app.features.addons.AddonRepository
 import com.nuvio.app.features.details.MetaScreenSettingsRepository
@@ -213,22 +214,56 @@ fun SettingsScreen(
         }
 
         var currentPage by rememberSaveable { mutableStateOf(SettingsPage.Root.name) }
+        var backPages by rememberSaveable { mutableStateOf<List<String>>(emptyList()) }
+        var forwardPages by rememberSaveable { mutableStateOf<List<String>>(emptyList()) }
         val scrollToTopRequests = remember { MutableSharedFlow<Unit>(extraBufferCapacity = 1) }
         val page = remember(currentPage) { SettingsPage.valueOf(currentPage) }
         val previousPage = page.previousPage()
 
+        fun navigateToSettingsPage(targetPage: SettingsPage, recordHistory: Boolean = true) {
+            if (!targetPage.isEnabledByFeaturePolicy() || targetPage.name == currentPage) return
+            if (recordHistory) {
+                backPages = (backPages + currentPage).takeLast(50)
+                forwardPages = emptyList()
+            }
+            currentPage = targetPage.name
+        }
+
+        fun navigateSettingsBack() {
+            val historyPageName = backPages.lastOrNull()
+            if (historyPageName != null) {
+                backPages = backPages.dropLast(1)
+                forwardPages = (forwardPages + currentPage).takeLast(50)
+                currentPage = historyPageName
+                return
+            }
+
+            previousPage?.let { parentPage ->
+                forwardPages = (forwardPages + currentPage).takeLast(50)
+                currentPage = parentPage.name
+            }
+        }
+
+        fun navigateSettingsForward() {
+            val forwardPageName = forwardPages.lastOrNull() ?: return
+            forwardPages = forwardPages.dropLast(1)
+            backPages = (backPages + currentPage).takeLast(50)
+            currentPage = forwardPageName
+        }
+
         LaunchedEffect(page) {
             if (!page.isEnabledByFeaturePolicy()) {
-                currentPage = SettingsPage.Root.name
+                backPages = emptyList()
+                forwardPages = emptyList()
+                navigateToSettingsPage(SettingsPage.Root, recordHistory = false)
             }
         }
 
         LaunchedEffect(rootActionRequests, rootActionsEnabled, page) {
             rootActionRequests.collect {
                 if (!rootActionsEnabled) return@collect
-                val pageToOpen = page.previousPage()
-                if (pageToOpen != null) {
-                    currentPage = pageToOpen.name
+                if (backPages.isNotEmpty() || previousPage != null) {
+                    navigateSettingsBack()
                 } else {
                     scrollToTopRequests.tryEmit(Unit)
                 }
@@ -241,21 +276,26 @@ fun SettingsScreen(
                 ?: return@LaunchedEffect
             if (!rootActionsEnabled) return@LaunchedEffect
             if (targetPage.isEnabledByFeaturePolicy()) {
-                currentPage = targetPage.name
+                navigateToSettingsPage(targetPage)
             }
             onRequestedPageConsumed()
         }
 
         PlatformBackHandler(
-            enabled = rootActionsEnabled && previousPage != null,
-            onBack = { previousPage?.let { currentPage = it.name } },
+            enabled = rootActionsEnabled && (backPages.isNotEmpty() || previousPage != null),
+            onBack = ::navigateSettingsBack,
+        )
+
+        PlatformForwardHandler(
+            enabled = rootActionsEnabled && forwardPages.isNotEmpty(),
+            onForward = ::navigateSettingsForward,
         )
 
         if (maxWidth >= 768.dp) {
             TabletSettingsScreen(
                 page = page,
                 scrollToTopRequests = scrollToTopRequests,
-                onPageChange = { currentPage = it.name },
+                onPageChange = ::navigateToSettingsPage,
                 showLoadingOverlay = playerSettingsUiState.showLoadingOverlay,
                 holdToSpeedEnabled = playerSettingsUiState.holdToSpeedEnabled,
                 holdToSpeedValue = playerSettingsUiState.holdToSpeedValue,
@@ -306,7 +346,7 @@ fun SettingsScreen(
             MobileSettingsScreen(
                 page = page,
                 scrollToTopRequests = scrollToTopRequests,
-                onPageChange = { currentPage = it.name },
+                onPageChange = ::navigateToSettingsPage,
                 showLoadingOverlay = playerSettingsUiState.showLoadingOverlay,
                 holdToSpeedEnabled = playerSettingsUiState.holdToSpeedEnabled,
                 holdToSpeedValue = playerSettingsUiState.holdToSpeedValue,

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
 import androidx.compose.ui.unit.dp
+import com.nuvio.app.core.ui.installDesktopMiddleMouseDragScroll
 import com.nuvio.app.features.player.PlatformPlayerSurface
 import com.nuvio.app.features.player.desktop.DesktopAppFullscreenController
 import com.nuvio.app.features.player.desktop.applyNativeDesktopWindowChrome
@@ -65,7 +66,13 @@ fun main() {
                     },
                 )
                 val uninstallFullscreenShortcuts = installDesktopAppFullscreenShortcuts(window)
+                val uninstallMiddleMouseDragScroll = if (smokePlayerUrl == null) {
+                    installDesktopMiddleMouseDragScroll(window)
+                } else {
+                    {}
+                }
                 onDispose {
+                    uninstallMiddleMouseDragScroll()
                     fullscreenController.dispose(window)
                     uninstallFullscreenShortcuts()
                     unregisterFullscreenToggle()

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/core/ui/DesktopMiddleMouseDragScroll.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/core/ui/DesktopMiddleMouseDragScroll.kt
@@ -1,0 +1,168 @@
+package com.nuvio.app.core.ui
+
+import java.awt.AWTEvent
+import java.awt.Component
+import java.awt.Cursor
+import java.awt.Toolkit
+import java.awt.Window
+import java.awt.event.AWTEventListener
+import java.awt.event.MouseEvent
+import java.awt.event.MouseWheelEvent
+import javax.swing.SwingUtilities
+import kotlin.math.abs
+import kotlin.math.truncate
+
+private const val DragStartThresholdPx = 3.0
+private const val PixelsPerWheelStep = 18.0
+private const val WheelScrollAmount = 3
+
+fun installDesktopMiddleMouseDragScroll(window: Window): () -> Unit {
+    val handler = DesktopMiddleMouseDragScroll(window)
+    handler.install()
+    return handler::uninstall
+}
+
+private class DesktopMiddleMouseDragScroll(
+    private val window: Window,
+) {
+    private var installed = false
+    private var dragTarget: Component? = null
+    private var sourceComponent: Component? = null
+    private var previousCursor: Cursor? = null
+    private var lastYOnScreen = 0
+    private var accumulatedPixels = 0.0
+    private var dragStarted = false
+
+    private val listener = AWTEventListener { event ->
+        val mouseEvent = event as? MouseEvent ?: return@AWTEventListener
+        when (mouseEvent.id) {
+            MouseEvent.MOUSE_PRESSED -> handlePressed(mouseEvent)
+            MouseEvent.MOUSE_DRAGGED -> handleDragged(mouseEvent)
+            MouseEvent.MOUSE_RELEASED -> handleReleased(mouseEvent)
+        }
+    }
+
+    fun install() {
+        if (installed) return
+        Toolkit.getDefaultToolkit().addAWTEventListener(
+            listener,
+            AWTEvent.MOUSE_EVENT_MASK or AWTEvent.MOUSE_MOTION_EVENT_MASK,
+        )
+        installed = true
+    }
+
+    fun uninstall() {
+        if (!installed) return
+        Toolkit.getDefaultToolkit().removeAWTEventListener(listener)
+        finishDrag()
+        installed = false
+    }
+
+    private fun handlePressed(event: MouseEvent) {
+        if (event.button != MouseEvent.BUTTON2) return
+        val component = event.componentOrNull() ?: return
+        if (!component.belongsToWindow(window) || component.isNativePlayerSurface()) return
+
+        sourceComponent = component
+        dragTarget = component.targetAt(event) ?: component
+        previousCursor = window.cursor
+        window.cursor = Cursor.getPredefinedCursor(Cursor.MOVE_CURSOR)
+        lastYOnScreen = event.yOnScreen
+        accumulatedPixels = 0.0
+        dragStarted = false
+        event.consume()
+    }
+
+    private fun handleDragged(event: MouseEvent) {
+        val target = dragTarget ?: return
+        if ((event.modifiersEx and MouseEvent.BUTTON2_DOWN_MASK) == 0) {
+            finishDrag()
+            return
+        }
+        val component = event.componentOrNull() ?: sourceComponent ?: return
+        if (!component.belongsToWindow(window) || component.isNativePlayerSurface()) {
+            finishDrag()
+            return
+        }
+
+        val deltaY = event.yOnScreen - lastYOnScreen
+        lastYOnScreen = event.yOnScreen
+        if (deltaY == 0) {
+            event.consume()
+            return
+        }
+
+        accumulatedPixels += deltaY.toDouble()
+        if (!dragStarted && abs(accumulatedPixels) < DragStartThresholdPx) {
+            event.consume()
+            return
+        }
+        dragStarted = true
+
+        val wheelSteps = truncate(accumulatedPixels / PixelsPerWheelStep).toInt()
+        if (wheelSteps != 0) {
+            accumulatedPixels -= wheelSteps * PixelsPerWheelStep
+            dispatchWheel(event, target, wheelSteps)
+        }
+        event.consume()
+    }
+
+    private fun handleReleased(event: MouseEvent) {
+        if (event.button == MouseEvent.BUTTON2 || dragTarget != null) {
+            event.consume()
+            finishDrag()
+        }
+    }
+
+    private fun finishDrag() {
+        dragTarget = null
+        sourceComponent = null
+        accumulatedPixels = 0.0
+        dragStarted = false
+        window.cursor = previousCursor ?: Cursor.getDefaultCursor()
+        previousCursor = null
+    }
+
+    private fun dispatchWheel(event: MouseEvent, target: Component, wheelSteps: Int) {
+        val source = event.componentOrNull() ?: target
+        val targetPoint = SwingUtilities.convertPoint(source, event.point, target)
+        val wheelEvent = MouseWheelEvent(
+            target,
+            MouseEvent.MOUSE_WHEEL,
+            event.`when`,
+            event.modifiersEx,
+            targetPoint.x,
+            targetPoint.y,
+            event.xOnScreen,
+            event.yOnScreen,
+            0,
+            false,
+            MouseWheelEvent.WHEEL_UNIT_SCROLL,
+            WheelScrollAmount,
+            wheelSteps,
+            wheelSteps.toDouble(),
+        )
+        target.dispatchEvent(wheelEvent)
+    }
+
+    private fun Component.targetAt(event: MouseEvent): Component? {
+        val windowPoint = SwingUtilities.convertPoint(this, event.point, window)
+        return SwingUtilities.getDeepestComponentAt(window, windowPoint.x, windowPoint.y)
+    }
+
+    private fun MouseEvent.componentOrNull(): Component? = component ?: source as? Component
+
+    private fun Component.belongsToWindow(targetWindow: Window): Boolean =
+        this == targetWindow || SwingUtilities.getWindowAncestor(this) == targetWindow
+
+    private fun Component.isNativePlayerSurface(): Boolean {
+        var current: Component? = this
+        while (current != null) {
+            if (current.javaClass.name == "com.nuvio.app.features.player.desktop.NativePlayerHost") {
+                return true
+            }
+            current = current.parent
+        }
+        return false
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/core/ui/PlatformBackHandler.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/core/ui/PlatformBackHandler.desktop.kt
@@ -1,9 +1,127 @@
 package com.nuvio.app.core.ui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.remember
+import java.awt.AWTEvent
+import java.awt.Toolkit
+import java.awt.event.AWTEventListener
+import java.awt.event.MouseEvent
+import javax.swing.SwingUtilities
 
 @Composable
 actual fun PlatformBackHandler(
     enabled: Boolean,
     onBack: () -> Unit,
-) = Unit
+) {
+    val entry = remember { DesktopNavigationHandlerRegistry.Entry() }
+
+    SideEffect {
+        entry.backEnabled = enabled
+        entry.onBack = onBack
+    }
+
+    DisposableEffect(entry) {
+        DesktopNavigationHandlerRegistry.register(entry)
+        onDispose {
+            DesktopNavigationHandlerRegistry.unregister(entry)
+        }
+    }
+}
+
+@Composable
+actual fun PlatformForwardHandler(
+    enabled: Boolean,
+    onForward: () -> Unit,
+) {
+    val entry = remember { DesktopNavigationHandlerRegistry.Entry() }
+
+    SideEffect {
+        entry.forwardEnabled = enabled
+        entry.onForward = onForward
+    }
+
+    DisposableEffect(entry) {
+        DesktopNavigationHandlerRegistry.register(entry)
+        onDispose {
+            DesktopNavigationHandlerRegistry.unregister(entry)
+        }
+    }
+}
+
+private object DesktopNavigationHandlerRegistry {
+    private const val BackSideButton = 4
+    private const val ForwardSideButton = 5
+    private const val LastSideButton = 9
+
+    private val lock = Any()
+    private val entries = mutableListOf<Entry>()
+    private var listenerInstalled = false
+
+    private val listener = AWTEventListener { event ->
+        val mouseEvent = event as? MouseEvent ?: return@AWTEventListener
+        if (mouseEvent.id != MouseEvent.MOUSE_PRESSED) return@AWTEventListener
+        if (mouseEvent.button !in BackSideButton..LastSideButton) return@AWTEventListener
+
+        val navigation = when (mouseEvent.button) {
+            ForwardSideButton -> NavigationDirection.Forward
+            else -> NavigationDirection.Back
+        }
+        val callback = synchronized(lock) {
+            when (navigation) {
+                NavigationDirection.Back -> entries.asReversed()
+                    .firstOrNull { it.backEnabled }
+                    ?.onBack
+                NavigationDirection.Forward -> entries.asReversed()
+                    .firstOrNull { it.forwardEnabled }
+                    ?.onForward
+            }
+        } ?: return@AWTEventListener
+
+        mouseEvent.consume()
+        SwingUtilities.invokeLater {
+            callback()
+        }
+    }
+
+    fun register(entry: Entry) {
+        synchronized(lock) {
+            if (entry in entries) return
+            entries += entry
+            if (!listenerInstalled) {
+                Toolkit.getDefaultToolkit().addAWTEventListener(listener, AWTEvent.MOUSE_EVENT_MASK)
+                listenerInstalled = true
+            }
+        }
+    }
+
+    fun unregister(entry: Entry) {
+        synchronized(lock) {
+            entries -= entry
+            if (entries.isEmpty() && listenerInstalled) {
+                Toolkit.getDefaultToolkit().removeAWTEventListener(listener)
+                listenerInstalled = false
+            }
+        }
+    }
+
+    class Entry {
+        @Volatile
+        var backEnabled: Boolean = false
+
+        @Volatile
+        var forwardEnabled: Boolean = false
+
+        @Volatile
+        var onBack: () -> Unit = {}
+
+        @Volatile
+        var onForward: () -> Unit = {}
+    }
+
+    private enum class NavigationDirection {
+        Back,
+        Forward,
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
@@ -26,6 +26,7 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import javax.swing.SwingUtilities
 import kotlin.concurrent.Volatile
+import kotlin.math.roundToLong
 
 internal class NativePlayerController(
     private val host: NativePlayerHost,
@@ -47,6 +48,13 @@ internal class NativePlayerController(
         SwingUtilities.invokeLater {
             handlePlayerEvent(type, value)
         }
+    }
+
+    init {
+        host.onSurfacePointerActivity = { handleSurfacePointerActivity() }
+        host.onSurfacePrimaryClick = { handleSurfacePrimaryClick() }
+        host.onSurfaceDoubleClick = { handlePlayerEvent("toggleFullscreen", 0.0) }
+        host.onSurfaceHorizontalDragSeek = { handleSurfaceHorizontalDragSeek(it) }
     }
 
     fun attach(
@@ -173,6 +181,8 @@ internal class NativePlayerController(
                 lastSentControlsStructureKey = null
                 updateControls(controlsState)
             }
+            "volumeDelta" -> handleVolumeDelta(value)
+            "dragSeekBy" -> handleDragSeekBy(value)
             else -> {
                 val eventHandled = onEvent(type, value)
                 if (eventHandled) return
@@ -183,6 +193,53 @@ internal class NativePlayerController(
                     handleFallbackAction(action)
                 }
             }
+        }
+    }
+
+    private fun handleVolumeDelta(deltaPercent: Double) {
+        if (!deltaPercent.isFinite() || deltaPercent == 0.0) return
+        if (controlsState.playbackErrorMessage.isNotBlank()) return
+        if (controlsState.isLocked) {
+            onAction(PlayerControlsAction.RevealLockedOverlay)
+            return
+        }
+        adjustFallbackVolume(deltaPercent.coerceIn(-20.0, 20.0).toFloat())
+    }
+
+    private fun handleDragSeekBy(offsetMs: Double) {
+        if (!offsetMs.isFinite() || offsetMs == 0.0) return
+        if (controlsState.playbackErrorMessage.isNotBlank()) return
+        if (controlsState.isLocked) {
+            onAction(PlayerControlsAction.RevealLockedOverlay)
+            return
+        }
+        val cleanOffset = offsetMs.roundToLong().coerceIn(-30_000L, 30_000L)
+        if (cleanOffset == 0L) return
+        fallbackSeekBy(cleanOffset)
+        val durationMs = controlsState.durationMs
+        if (durationMs > 0L) {
+            updateLocalProgress((controlsState.positionMs + cleanOffset).coerceIn(0L, durationMs))
+        }
+    }
+
+    private fun handleSurfacePointerActivity() {
+        if (controlsState.playbackErrorMessage.isNotBlank()) return
+        onEvent("keepChromeVisible", 0.0)
+    }
+
+    private fun handleSurfaceHorizontalDragSeek(offsetMs: Long) {
+        handleDragSeekBy(offsetMs.toDouble())
+    }
+
+    private fun handleSurfacePrimaryClick() {
+        if (controlsState.playbackErrorMessage.isNotBlank()) return
+        if (controlsState.isLocked) {
+            onAction(PlayerControlsAction.RevealLockedOverlay)
+            return
+        }
+        val actionHandled = onAction(PlayerControlsAction.TogglePlayback)
+        if (!actionHandled) {
+            handleFallbackAction(PlayerControlsAction.TogglePlayback)
         }
     }
 
@@ -263,6 +320,11 @@ internal class NativePlayerController(
     }
 
     fun dispose() {
+        host.onCursorActivity = null
+        host.onSurfacePointerActivity = null
+        host.onSurfacePrimaryClick = null
+        host.onSurfaceDoubleClick = null
+        host.onSurfaceHorizontalDragSeek = null
         host.resetCursorVisibility()
         disposePlayerHandle()
     }

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerHost.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerHost.kt
@@ -6,9 +6,14 @@ import java.awt.Cursor
 import java.awt.Graphics
 import java.awt.Point
 import java.awt.Toolkit
+import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import java.awt.event.MouseMotionAdapter
 import java.awt.image.BufferedImage
+import javax.swing.SwingUtilities
+import javax.swing.Timer
+import kotlin.math.abs
+import kotlin.math.roundToLong
 
 internal class NativePlayerHost : Canvas() {
     var onPeerReady: (() -> Unit)? = null
@@ -16,12 +21,32 @@ internal class NativePlayerHost : Canvas() {
     var onFirstPaint: (() -> Unit)? = null
     var onFirstFullSizePaint: (() -> Unit)? = null
     var onCursorActivity: (() -> Unit)? = null
+    var onSurfacePointerActivity: (() -> Unit)? = null
+    var onSurfacePrimaryClick: (() -> Unit)? = null
+    var onSurfaceDoubleClick: (() -> Unit)? = null
+    var onSurfaceHorizontalDragSeek: ((Long) -> Unit)? = null
     private var firstPaintNotified = false
     private var firstFullSizePaintNotified = false
     private var controlsVisible = true
     private var cursorVisible = true
+    private var cursorHideTimer: Timer? = null
+    private var surfaceClickTimer: Timer? = null
+    private var suppressSurfaceClickTimer: Timer? = null
+    private var surfaceDragStartX = 0
+    private var surfaceDragStartY = 0
+    private var surfaceDragCurrentX = 0
+    private var surfaceDragSeekActive = false
+    private var surfaceDragSeekTimer: Timer? = null
+    private var suppressNextSurfaceClick = false
 
     private companion object {
+        const val CursorIdleHideDelayMs = 3_000
+        const val SurfaceSingleClickDelayMs = 220
+        const val SurfaceSuppressClickDelayMs = 350
+        const val SurfaceDragSeekStartThresholdPx = 12.0
+        const val SurfaceDragSeekMaxStepMs = 30_000L
+        const val SurfaceDragSeekTickMs = 120
+
         val hiddenCursor: Cursor by lazy {
             val image = BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB)
             Toolkit.getDefaultToolkit().createCustomCursor(image, Point(0, 0), "nuvio-hidden-cursor")
@@ -31,6 +56,36 @@ internal class NativePlayerHost : Canvas() {
     init {
         background = Color.BLACK
         ignoreRepaint = false
+        addMouseListener(object : MouseAdapter() {
+            override fun mousePressed(event: MouseEvent) {
+                if (SwingUtilities.isLeftMouseButton(event)) {
+                    beginSurfaceDragSeek(event)
+                    noteCursorActivity()
+                }
+            }
+
+            override fun mouseReleased(event: MouseEvent) {
+                if (SwingUtilities.isLeftMouseButton(event) && finishSurfaceDragSeek()) {
+                    event.consume()
+                }
+            }
+
+            override fun mouseClicked(event: MouseEvent) {
+                if (!SwingUtilities.isLeftMouseButton(event)) return
+                noteCursorActivity()
+                if (suppressNextSurfaceClick) {
+                    suppressNextSurfaceClick = false
+                    cancelSuppressSurfaceClickTimer()
+                    return
+                }
+                if (event.clickCount >= 2) {
+                    cancelSurfaceClickTimer()
+                    onSurfaceDoubleClick?.invoke()
+                } else {
+                    restartSurfaceClickTimer()
+                }
+            }
+        })
         addMouseMotionListener(object : MouseMotionAdapter() {
             override fun mouseMoved(event: MouseEvent) {
                 noteCursorActivity()
@@ -38,21 +93,36 @@ internal class NativePlayerHost : Canvas() {
 
             override fun mouseDragged(event: MouseEvent) {
                 noteCursorActivity()
+                if ((event.modifiersEx and MouseEvent.BUTTON1_DOWN_MASK) != 0 && updateSurfaceDragSeek(event)) {
+                    event.consume()
+                }
             }
         })
     }
 
     fun setControlsVisible(visible: Boolean) {
+        if (controlsVisible == visible) return
         controlsVisible = visible
+        cancelCursorHideTimer()
         setCursorVisible(visible)
     }
 
     fun noteCursorActivity() {
         onCursorActivity?.invoke()
+        if (controlsVisible) {
+            cancelCursorHideTimer()
+            setCursorVisible(true)
+            onSurfacePointerActivity?.invoke()
+            return
+        }
+        setCursorVisible(true)
+        restartCursorHideTimer()
+        onSurfacePointerActivity?.invoke()
     }
 
     fun resetCursorVisibility() {
         controlsVisible = true
+        cancelCursorHideTimer()
         setCursorVisible(true)
     }
 
@@ -60,6 +130,126 @@ internal class NativePlayerHost : Canvas() {
         if (cursorVisible == visible) return
         cursorVisible = visible
         cursor = if (visible) Cursor.getDefaultCursor() else hiddenCursor
+    }
+
+    private fun restartCursorHideTimer() {
+        cancelCursorHideTimer()
+        cursorHideTimer = Timer(CursorIdleHideDelayMs) {
+            if (!controlsVisible) {
+                setCursorVisible(false)
+            }
+            cancelCursorHideTimer()
+        }.apply {
+            isRepeats = false
+            start()
+        }
+    }
+
+    private fun cancelCursorHideTimer() {
+        cursorHideTimer?.stop()
+        cursorHideTimer = null
+    }
+
+    private fun restartSurfaceClickTimer() {
+        cancelSurfaceClickTimer()
+        surfaceClickTimer = Timer(SurfaceSingleClickDelayMs) {
+            onSurfacePrimaryClick?.invoke()
+            cancelSurfaceClickTimer()
+        }.apply {
+            isRepeats = false
+            start()
+        }
+    }
+
+    private fun cancelSurfaceClickTimer() {
+        surfaceClickTimer?.stop()
+        surfaceClickTimer = null
+    }
+
+    private fun beginSurfaceDragSeek(event: MouseEvent) {
+        surfaceDragStartX = event.x
+        surfaceDragStartY = event.y
+        surfaceDragCurrentX = event.x
+        surfaceDragSeekActive = false
+        stopSurfaceDragSeekTimer()
+    }
+
+    private fun updateSurfaceDragSeek(event: MouseEvent): Boolean {
+        val totalX = (event.x - surfaceDragStartX).toDouble()
+        val totalY = (event.y - surfaceDragStartY).toDouble()
+        surfaceDragCurrentX = event.x
+        if (!surfaceDragSeekActive) {
+            val horizontalEnough = abs(totalX) >= SurfaceDragSeekStartThresholdPx
+            val horizontalIntent = abs(totalX) >= abs(totalY) * 1.1
+            if (!horizontalEnough || !horizontalIntent) return false
+            surfaceDragSeekActive = true
+            suppressNextSurfaceClickBriefly()
+            cancelSurfaceClickTimer()
+            startSurfaceDragSeekTimer()
+        }
+        return true
+    }
+
+    private fun finishSurfaceDragSeek(): Boolean {
+        val wasActive = surfaceDragSeekActive
+        surfaceDragSeekActive = false
+        stopSurfaceDragSeekTimer()
+        if (wasActive) {
+            suppressNextSurfaceClickBriefly()
+            cancelSurfaceClickTimer()
+        }
+        return wasActive
+    }
+
+    private fun startSurfaceDragSeekTimer() {
+        if (surfaceDragSeekTimer != null) return
+        tickSurfaceDragSeek()
+        surfaceDragSeekTimer = Timer(SurfaceDragSeekTickMs) {
+            tickSurfaceDragSeek()
+        }.apply {
+            start()
+        }
+    }
+
+    private fun stopSurfaceDragSeekTimer() {
+        surfaceDragSeekTimer?.stop()
+        surfaceDragSeekTimer = null
+    }
+
+    private fun tickSurfaceDragSeek() {
+        if (!surfaceDragSeekActive) return
+        val deltaMs = surfaceDragSeekDeltaForDistance((surfaceDragCurrentX - surfaceDragStartX).toDouble())
+        if (deltaMs != 0L) {
+            onSurfaceHorizontalDragSeek?.invoke(deltaMs)
+        }
+    }
+
+    private fun surfaceDragSeekDeltaForDistance(totalX: Double): Long {
+        val distancePastThreshold = (abs(totalX) - SurfaceDragSeekStartThresholdPx).coerceAtLeast(0.0)
+        if (distancePastThreshold < 1.0) return 0L
+        val speedMsPerSecond = (Math.pow(distancePastThreshold / 80.0, 1.25) * 12_000.0)
+            .coerceIn(1_500.0, 60_000.0)
+        val deltaMs = (speedMsPerSecond * SurfaceDragSeekTickMs / 1000.0)
+            .roundToLong()
+            .coerceIn(0L, SurfaceDragSeekMaxStepMs)
+        return if (totalX < 0.0) -deltaMs else deltaMs
+    }
+
+    private fun suppressNextSurfaceClickBriefly() {
+        suppressNextSurfaceClick = true
+        cancelSuppressSurfaceClickTimer()
+        suppressSurfaceClickTimer = Timer(SurfaceSuppressClickDelayMs) {
+            suppressNextSurfaceClick = false
+            cancelSuppressSurfaceClickTimer()
+        }.apply {
+            isRepeats = false
+            start()
+        }
+    }
+
+    private fun cancelSuppressSurfaceClickTimer() {
+        suppressSurfaceClickTimer?.stop()
+        suppressSurfaceClickTimer = null
     }
 
     override fun update(graphics: Graphics) {
@@ -93,7 +283,11 @@ internal class NativePlayerHost : Canvas() {
         onPeerReady = null
         onFirstPaint = null
         onFirstFullSizePaint = null
+        onSurfaceHorizontalDragSeek = null
         resetCursorVisibility()
+        cancelSurfaceClickTimer()
+        cancelSuppressSurfaceClickTimer()
+        stopSurfaceDragSeekTimer()
         super.removeNotify()
     }
 }

--- a/composeApp/src/desktopMain/native/windows/player_bridge.cpp
+++ b/composeApp/src/desktopMain/native/windows/player_bridge.cpp
@@ -60,6 +60,7 @@ namespace {
 HMODULE gModule = nullptr;
 constexpr UINT WM_NUVIO_TASK = WM_APP + 0x4E50;
 constexpr UINT_PTR NUVIO_TIMER_ID = 0x4E50;
+constexpr UINT_PTR NUVIO_SEEK_DRAG_TIMER_ID = 0x4E51;
 const wchar_t *kMessageWindowClass = L"NuvioPlayerBridgeMessageWindow";
 const wchar_t *kContainerWindowClass = L"NuvioPlayerBridgeContainerWindow";
 constexpr DWORD kDwmwaUseImmersiveDarkMode = 20;
@@ -67,6 +68,11 @@ constexpr DWORD kDwmwaUseImmersiveDarkModeLegacy = 19;
 constexpr DWORD kDwmwaBorderColor = 34;
 constexpr DWORD kDwmwaCaptionColor = 35;
 constexpr DWORD kDwmwaTextColor = 36;
+constexpr double kVolumeDragStepPx = 28.0;
+constexpr double kVolumePercentPerStep = 5.0;
+constexpr double kSeekDragStartThresholdPx = 12.0;
+constexpr double kSeekDragMaxStepMs = 30000.0;
+constexpr UINT kSeekDragTickMs = 120;
 
 struct BorderlessFullscreenState {
     LONG_PTR style = 0;
@@ -153,6 +159,14 @@ COLORREF rgbIntToColorRef(jint rgb) {
     BYTE green = (BYTE)((rgb >> 8) & 0xFF);
     BYTE blue = (BYTE)(rgb & 0xFF);
     return RGB(red, green, blue);
+}
+
+int mouseYFromLParam(LPARAM lParam) {
+    return (int)(short)HIWORD(lParam);
+}
+
+int mouseXFromLParam(LPARAM lParam) {
+    return (int)(short)LOWORD(lParam);
 }
 
 void setDwmWindowAttribute(HWND hwnd, DWORD attribute, const void *value, DWORD valueSize) {
@@ -841,6 +855,128 @@ public:
         return std::max(0.0, std::min(100.0, doubleProperty("volume", 100.0))) / 100.0;
     }
 
+    void beginMiddleButtonVolumeDrag(int y) {
+        volumeDragActive = true;
+        volumeDragLastY = y;
+        volumeDragAccumulator = 0.0;
+        if (containerHwnd && IsWindow(containerHwnd)) {
+            SetCapture(containerHwnd);
+        }
+        sendPlayerEvent("cursorActivity", 0.0);
+        sendPlayerEvent("keepChromeVisible", 0.0);
+    }
+
+    bool updateMiddleButtonVolumeDrag(int y) {
+        if (!volumeDragActive) return false;
+        const double deltaY = static_cast<double>(volumeDragLastY - y);
+        volumeDragLastY = y;
+        if (std::abs(deltaY) < 0.5) return true;
+
+        volumeDragAccumulator += deltaY;
+        const int steps = static_cast<int>(volumeDragAccumulator / kVolumeDragStepPx);
+        if (steps != 0) {
+            const int clampedSteps = std::max(-4, std::min(4, steps));
+            volumeDragAccumulator -= static_cast<double>(clampedSteps) * kVolumeDragStepPx;
+            sendPlayerEvent("volumeDelta", static_cast<double>(clampedSteps) * kVolumePercentPerStep);
+        }
+        sendPlayerEvent("cursorActivity", 0.0);
+        sendPlayerEvent("keepChromeVisible", 0.0);
+        return true;
+    }
+
+    bool endMiddleButtonVolumeDrag() {
+        if (!volumeDragActive) return false;
+        volumeDragActive = false;
+        volumeDragAccumulator = 0.0;
+        if (containerHwnd && GetCapture() == containerHwnd) {
+            ReleaseCapture();
+        }
+        return true;
+    }
+
+    void cancelMiddleButtonVolumeDrag() {
+        volumeDragActive = false;
+        volumeDragAccumulator = 0.0;
+    }
+
+    void beginLeftButtonSeekDrag(int x, int y) {
+        seekDragActive = true;
+        seekDragStarted = false;
+        seekDragStartX = x;
+        seekDragStartY = y;
+        seekDragCurrentX = x;
+        sendPlayerEvent("cursorActivity", 0.0);
+    }
+
+    bool updateLeftButtonSeekDrag(int x, int y) {
+        if (!seekDragActive) return false;
+        const double totalX = static_cast<double>(x - seekDragStartX);
+        const double totalY = static_cast<double>(y - seekDragStartY);
+        seekDragCurrentX = x;
+        if (!seekDragStarted) {
+            const bool horizontalEnough = std::abs(totalX) >= kSeekDragStartThresholdPx;
+            const bool horizontalIntent = std::abs(totalX) >= std::abs(totalY) * 1.1;
+            if (!horizontalEnough || !horizontalIntent) return false;
+            seekDragStarted = true;
+            if (containerHwnd && IsWindow(containerHwnd)) {
+                SetCapture(containerHwnd);
+                SetTimer(containerHwnd, NUVIO_SEEK_DRAG_TIMER_ID, kSeekDragTickMs, nullptr);
+            }
+            tickLeftButtonSeekDrag();
+        }
+        sendPlayerEvent("cursorActivity", 0.0);
+        sendPlayerEvent("keepChromeVisible", 0.0);
+        return true;
+    }
+
+    void tickLeftButtonSeekDrag() {
+        if (!seekDragStarted) return;
+        const double deltaMs = seekDragDeltaForDistance(static_cast<double>(seekDragCurrentX - seekDragStartX));
+        if (std::abs(deltaMs) >= 1.0) {
+            sendPlayerEvent("dragSeekBy", deltaMs);
+        }
+        sendPlayerEvent("cursorActivity", 0.0);
+        sendPlayerEvent("keepChromeVisible", 0.0);
+    }
+
+    bool endLeftButtonSeekDrag() {
+        if (!seekDragActive) return false;
+        const bool wasStarted = seekDragStarted;
+        seekDragActive = false;
+        seekDragStarted = false;
+        if (containerHwnd) {
+            KillTimer(containerHwnd, NUVIO_SEEK_DRAG_TIMER_ID);
+        }
+        if (containerHwnd && GetCapture() == containerHwnd) {
+            ReleaseCapture();
+        }
+        return wasStarted;
+    }
+
+    void cancelLeftButtonSeekDrag() {
+        seekDragActive = false;
+        seekDragStarted = false;
+        if (containerHwnd) {
+            KillTimer(containerHwnd, NUVIO_SEEK_DRAG_TIMER_ID);
+        }
+    }
+
+    double seekDragDeltaForDistance(double totalX) {
+        const double distancePastThreshold = std::max(0.0, std::abs(totalX) - kSeekDragStartThresholdPx);
+        if (distancePastThreshold < 1.0) return 0.0;
+        const double speedMsPerSecond = std::clamp(
+            std::pow(distancePastThreshold / 80.0, 1.25) * 12000.0,
+            1500.0,
+            60000.0
+        );
+        const double deltaMs = std::clamp(
+            speedMsPerSecond * static_cast<double>(kSeekDragTickMs) / 1000.0,
+            0.0,
+            kSeekDragMaxStepMs
+        );
+        return totalX < 0.0 ? -deltaMs : deltaMs;
+    }
+
     void setResizeMode(int mode) {
         switch (mode) {
             case 1:
@@ -1005,6 +1141,14 @@ private:
     std::mutex controlsMutex;
     std::string pendingControlsJson;
     double initialStartSeconds = 0.0;
+    bool volumeDragActive = false;
+    int volumeDragLastY = 0;
+    double volumeDragAccumulator = 0.0;
+    bool seekDragActive = false;
+    bool seekDragStarted = false;
+    int seekDragStartX = 0;
+    int seekDragStartY = 0;
+    int seekDragCurrentX = 0;
 
     friend LRESULT CALLBACK messageWindowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
     friend LRESULT CALLBACK containerWindowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
@@ -1854,8 +1998,70 @@ LRESULT CALLBACK containerWindowProc(HWND hwnd, UINT message, WPARAM wParam, LPA
                 return 0;
             }
             return DefWindowProcW(hwnd, message, wParam, lParam);
+        case WM_TIMER:
+            if (player && wParam == NUVIO_SEEK_DRAG_TIMER_ID) {
+                player->tickLeftButtonSeekDrag();
+                return 0;
+            }
+            return DefWindowProcW(hwnd, message, wParam, lParam);
         case WM_LBUTTONDBLCLK:
             if (player) player->sendPlayerEvent("toggleFullscreen", 0.0);
+            return 0;
+        case WM_LBUTTONDOWN:
+            if (player) {
+                player->beginLeftButtonSeekDrag(mouseXFromLParam(lParam), mouseYFromLParam(lParam));
+            }
+            return DefWindowProcW(hwnd, message, wParam, lParam);
+        case WM_MBUTTONDOWN:
+            if (player) {
+                player->beginMiddleButtonVolumeDrag(mouseYFromLParam(lParam));
+            }
+            return 0;
+        case WM_MOUSEMOVE:
+            if (player && player->updateMiddleButtonVolumeDrag(mouseYFromLParam(lParam))) {
+                return 0;
+            }
+            if (player) {
+                if ((wParam & MK_LBUTTON) != 0) {
+                    if (player->updateLeftButtonSeekDrag(mouseXFromLParam(lParam), mouseYFromLParam(lParam))) {
+                        return 0;
+                    }
+                } else {
+                    player->cancelLeftButtonSeekDrag();
+                }
+            }
+            return DefWindowProcW(hwnd, message, wParam, lParam);
+        case WM_LBUTTONUP:
+            if (player && player->endLeftButtonSeekDrag()) {
+                return 0;
+            }
+            return DefWindowProcW(hwnd, message, wParam, lParam);
+        case WM_MBUTTONUP:
+            if (player && player->endMiddleButtonVolumeDrag()) {
+                return 0;
+            }
+            return DefWindowProcW(hwnd, message, wParam, lParam);
+        case WM_CAPTURECHANGED:
+            if (player) {
+                player->cancelMiddleButtonVolumeDrag();
+                player->cancelLeftButtonSeekDrag();
+            }
+            return DefWindowProcW(hwnd, message, wParam, lParam);
+        case WM_XBUTTONDOWN: {
+            if (player) {
+                const WORD button = GET_XBUTTON_WPARAM(wParam);
+                player->sendPlayerEvent(button == XBUTTON2 ? "forward" : "back", 0.0);
+            }
+            return TRUE;
+        }
+        case WM_MOUSEWHEEL:
+            if (player) {
+                const int wheelDelta = GET_WHEEL_DELTA_WPARAM(wParam);
+                if (wheelDelta != 0) {
+                    const double steps = std::clamp(static_cast<double>(wheelDelta) / WHEEL_DELTA, -4.0, 4.0);
+                    player->sendPlayerEvent("volumeDelta", steps * kVolumePercentPerStep);
+                }
+            }
             return 0;
         case WM_SIZE:
             return 0;

--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -362,6 +362,23 @@ let playerToastToken = 0;
 let pendingSettingToastCommand = "";
 let pendingSettingToastToken = 0;
 let pendingVolumeToast = false;
+let volumeWheelAccumulator = 0;
+let volumeWheelDirection = 0;
+let volumeWheelResetTimer = 0;
+let volumeDragPointerId = null;
+let volumeDragLastY = 0;
+let volumeDragAccumulator = 0;
+let seekPointerId = null;
+let surfaceDragSeekPointerId = null;
+let surfaceDragSeekTarget = null;
+let surfaceDragSeekStartX = 0;
+let surfaceDragSeekStartY = 0;
+let surfaceDragSeekCurrentX = 0;
+let surfaceDragSeekActive = false;
+let surfaceDragSeekTotalMs = 0;
+let surfaceDragSeekTickTimer = 0;
+let suppressNextRootClick = false;
+let suppressNextRootClickTimer = 0;
 const prefersReducedMotion = window.matchMedia &&
   window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 const modalTransitionMs = prefersReducedMotion ? 1 : 240;
@@ -370,6 +387,13 @@ const chromeActivityThrottleMs = 300;
 const hiddenCursorHideDelayMs = 3000;
 const cursorActivityThrottleMs = 100;
 const playerToastDurationMs = 1400;
+const volumeWheelStepPx = 80;
+const volumeWheelResetDelayMs = 300;
+const volumeDragStepPx = 28;
+const surfaceDragSeekStartThresholdPx = 12;
+const surfaceDragSeekMaxStepMs = 30000;
+const surfaceDragSeekToastDurationMs = 650;
+const surfaceDragSeekTickMs = 120;
 const chromeInteractionSelector = [
   "button",
   "input",
@@ -448,6 +472,285 @@ const nextVolumeToastLabel = delta => {
     return `Volume ${Math.round(nextLevel * 100)}%`;
   }
   return volumeToastLabel(delta);
+};
+
+const sendVolumeSteps = steps => {
+  const cleanSteps = Math.trunc(Number(steps));
+  if (!Number.isFinite(cleanSteps) || cleanSteps === 0) return;
+  pendingVolumeToast = true;
+  showPlayerToast(nextVolumeToastLabel(cleanSteps));
+  send("volumeDelta", cleanSteps * 5);
+};
+
+const normalizedWheelDeltaY = event => {
+  const delta = Number(event.deltaY);
+  if (!Number.isFinite(delta) || delta === 0) return 0;
+  switch (event.deltaMode) {
+    case WheelEvent.DOM_DELTA_LINE:
+      return delta * 40;
+    case WheelEvent.DOM_DELTA_PAGE:
+      return delta * window.innerHeight;
+    default:
+      return delta;
+  }
+};
+
+const isScrollableWheelTarget = target => {
+  let element = target instanceof Element ? target : null;
+  while (element && element !== root && element !== document.body) {
+    const style = window.getComputedStyle(element);
+    const canScrollY = /(auto|scroll)/.test(style.overflowY) && element.scrollHeight > element.clientHeight + 1;
+    const canScrollX = /(auto|scroll)/.test(style.overflowX) && element.scrollWidth > element.clientWidth + 1;
+    if (canScrollY || canScrollX) return true;
+    element = element.parentElement;
+  }
+  return false;
+};
+
+const resetVolumeWheelAccumulatorSoon = () => {
+  window.clearTimeout(volumeWheelResetTimer);
+  volumeWheelResetTimer = window.setTimeout(() => {
+    volumeWheelAccumulator = 0;
+    volumeWheelDirection = 0;
+  }, volumeWheelResetDelayMs);
+};
+
+const handleVolumeWheel = event => {
+  if (playbackErrorText()) return false;
+  if (activeModal) return false;
+  if (isTextEntryTarget(event.target) || isScrollableWheelTarget(event.target)) return false;
+  if (state.isLocked) {
+    event.preventDefault();
+    event.stopPropagation();
+    send("revealLockedOverlay", 0);
+    return true;
+  }
+
+  const deltaY = normalizedWheelDeltaY(event);
+  if (!Number.isFinite(deltaY) || Math.abs(deltaY) < 1) return false;
+  const direction = deltaY < 0 ? 1 : -1;
+  if (direction !== volumeWheelDirection) {
+    volumeWheelAccumulator = 0;
+    volumeWheelDirection = direction;
+  }
+  volumeWheelAccumulator += Math.abs(deltaY);
+  resetVolumeWheelAccumulatorSoon();
+
+  const steps = Math.min(4, Math.floor(volumeWheelAccumulator / volumeWheelStepPx));
+  if (steps <= 0) return false;
+  volumeWheelAccumulator -= steps * volumeWheelStepPx;
+
+  event.preventDefault();
+  event.stopPropagation();
+  noteCursorActivity();
+  revealChromeFromPointerActivity();
+  sendVolumeSteps(direction * steps);
+  return true;
+};
+
+const startVolumeDrag = event => {
+  if (event.button !== 1) return false;
+  event.preventDefault();
+  event.stopPropagation();
+  if (playbackErrorText()) return true;
+  if (activeModal || isTextEntryTarget(event.target)) return true;
+  if (state.isLocked) {
+    send("revealLockedOverlay", 0);
+    return true;
+  }
+  volumeDragPointerId = event.pointerId;
+  volumeDragLastY = Number(event.clientY) || 0;
+  volumeDragAccumulator = 0;
+  noteCursorActivity();
+  revealChromeFromPointerActivity(true);
+  if (event.target && typeof event.target.setPointerCapture === "function") {
+    try {
+      event.target.setPointerCapture(event.pointerId);
+    } catch (_) {
+      // Some WebView builds can reject capture for synthetic pointer IDs.
+    }
+  }
+  return true;
+};
+
+const handleVolumeDragMove = event => {
+  if (volumeDragPointerId === null || event.pointerId !== volumeDragPointerId) return false;
+  event.preventDefault();
+  event.stopPropagation();
+
+  const nextY = Number(event.clientY);
+  if (!Number.isFinite(nextY)) return true;
+  const deltaY = volumeDragLastY - nextY;
+  volumeDragLastY = nextY;
+  if (!Number.isFinite(deltaY) || Math.abs(deltaY) < 0.5) return true;
+
+  volumeDragAccumulator += deltaY;
+  const steps = Math.trunc(volumeDragAccumulator / volumeDragStepPx);
+  if (steps !== 0) {
+    const clampedSteps = Math.max(-4, Math.min(4, steps));
+    volumeDragAccumulator -= clampedSteps * volumeDragStepPx;
+    sendVolumeSteps(clampedSteps);
+  }
+  noteCursorActivity();
+  revealChromeFromPointerActivity();
+  return true;
+};
+
+const finishVolumeDrag = event => {
+  if (volumeDragPointerId === null || (event && event.pointerId !== volumeDragPointerId)) return false;
+  if (event) {
+    event.preventDefault();
+    event.stopPropagation();
+    if (event.target && typeof event.target.releasePointerCapture === "function") {
+      try {
+        event.target.releasePointerCapture(volumeDragPointerId);
+      } catch (_) {
+        // Capture may already have been released by WebView.
+      }
+    }
+  }
+  volumeDragPointerId = null;
+  volumeDragAccumulator = 0;
+  return true;
+};
+
+const canStartSurfaceDragSeek = event => {
+  if (event.button !== 0 || surfaceDragSeekPointerId !== null) return false;
+  if (playbackErrorText() || activeModal) return false;
+  if (isTextEntryTarget(event.target) || isChromeInteractionTarget(event.target)) return false;
+  return Math.max(0, Number(state.durationMs) || 0) > 0;
+};
+
+const signedDurationLabel = milliseconds => {
+  const clean = Math.trunc(Number(milliseconds));
+  if (!Number.isFinite(clean) || clean === 0) return "";
+  return `${clean < 0 ? "-" : "+"}${formatTime(Math.abs(clean))}`;
+};
+
+const suppressNextRootClickBriefly = () => {
+  suppressNextRootClick = true;
+  window.clearTimeout(suppressNextRootClickTimer);
+  suppressNextRootClickTimer = window.setTimeout(() => {
+    suppressNextRootClick = false;
+    suppressNextRootClickTimer = 0;
+  }, 350);
+};
+
+const surfaceDragSeekDeltaForDistance = totalDeltaX => {
+  const cleanDeltaX = Number(totalDeltaX) || 0;
+  const distance = Math.abs(cleanDeltaX);
+  const distancePastThreshold = Math.max(0, distance - surfaceDragSeekStartThresholdPx);
+  if (distancePastThreshold < 1) return 0;
+  const speedMsPerSecond = Math.min(
+    60000,
+    Math.max(1500, Math.pow(distancePastThreshold / 80, 1.25) * 12000),
+  );
+  const deltaMs = Math.trunc(speedMsPerSecond * surfaceDragSeekTickMs / 1000);
+  return (cleanDeltaX < 0 ? -1 : 1) * Math.min(surfaceDragSeekMaxStepMs, deltaMs);
+};
+
+const tickSurfaceDragSeek = () => {
+  if (!surfaceDragSeekActive) return;
+  const deltaMs = surfaceDragSeekDeltaForDistance(surfaceDragSeekCurrentX - surfaceDragSeekStartX);
+  if (deltaMs === 0) return;
+  surfaceDragSeekTotalMs += deltaMs;
+  send("dragSeekBy", deltaMs);
+  const label = signedDurationLabel(surfaceDragSeekTotalMs);
+  if (label) showPlayerToast(label, { durationMs: surfaceDragSeekToastDurationMs });
+  noteCursorActivity();
+  revealChromeFromPointerActivity();
+};
+
+const startSurfaceDragSeekTimer = () => {
+  if (surfaceDragSeekTickTimer) return;
+  tickSurfaceDragSeek();
+  surfaceDragSeekTickTimer = window.setInterval(tickSurfaceDragSeek, surfaceDragSeekTickMs);
+};
+
+const stopSurfaceDragSeekTimer = () => {
+  window.clearInterval(surfaceDragSeekTickTimer);
+  surfaceDragSeekTickTimer = 0;
+};
+
+const beginSurfaceDragSeek = event => {
+  if (event.button !== 0 || isChromeInteractionTarget(event.target) || isTextEntryTarget(event.target)) return false;
+  if (playbackErrorText() || activeModal) return false;
+  if (state.isLocked) {
+    event.preventDefault();
+    event.stopPropagation();
+    suppressNextRootClickBriefly();
+    send("revealLockedOverlay", 0);
+    return true;
+  }
+  if (!canStartSurfaceDragSeek(event)) return false;
+
+  surfaceDragSeekPointerId = event.pointerId;
+  surfaceDragSeekTarget = event.target;
+  surfaceDragSeekStartX = Number(event.clientX) || 0;
+  surfaceDragSeekStartY = Number(event.clientY) || 0;
+  surfaceDragSeekCurrentX = surfaceDragSeekStartX;
+  surfaceDragSeekActive = false;
+  surfaceDragSeekTotalMs = 0;
+  noteCursorActivity();
+  revealChromeFromPointerActivity(true);
+  if (event.target && typeof event.target.setPointerCapture === "function") {
+    try {
+      event.target.setPointerCapture(event.pointerId);
+    } catch (_) {
+      // Some WebView builds can reject capture for synthetic pointer IDs.
+    }
+  }
+  return false;
+};
+
+const handleSurfaceDragSeekMove = event => {
+  if (surfaceDragSeekPointerId === null || event.pointerId !== surfaceDragSeekPointerId) return false;
+  const nextX = Number(event.clientX);
+  const nextY = Number(event.clientY);
+  if (!Number.isFinite(nextX) || !Number.isFinite(nextY)) return false;
+
+  const totalX = nextX - surfaceDragSeekStartX;
+  const totalY = nextY - surfaceDragSeekStartY;
+  surfaceDragSeekCurrentX = nextX;
+  if (!surfaceDragSeekActive) {
+    const horizontalEnough = Math.abs(totalX) >= surfaceDragSeekStartThresholdPx;
+    const horizontalIntent = Math.abs(totalX) >= Math.abs(totalY) * 1.1;
+    if (!horizontalEnough || !horizontalIntent) return false;
+    surfaceDragSeekActive = true;
+    suppressNextRootClickBriefly();
+    window.clearTimeout(tapTimer);
+    startSurfaceDragSeekTimer();
+  }
+
+  event.preventDefault();
+  event.stopPropagation();
+  noteCursorActivity();
+  revealChromeFromPointerActivity();
+  return true;
+};
+
+const finishSurfaceDragSeek = event => {
+  if (surfaceDragSeekPointerId === null || (event && event.pointerId !== surfaceDragSeekPointerId)) return false;
+  const wasActive = surfaceDragSeekActive;
+  if (event && wasActive) {
+    event.preventDefault();
+    event.stopPropagation();
+  }
+  const captureTarget = surfaceDragSeekTarget;
+  if (event && captureTarget && typeof captureTarget.releasePointerCapture === "function") {
+    try {
+      captureTarget.releasePointerCapture(surfaceDragSeekPointerId);
+    } catch (_) {
+      // Capture may already have been released by WebView.
+    }
+  }
+  surfaceDragSeekPointerId = null;
+  surfaceDragSeekTarget = null;
+  surfaceDragSeekActive = false;
+  surfaceDragSeekTotalMs = 0;
+  stopSurfaceDragSeekTimer();
+  if (wasActive) suppressNextRootClickBriefly();
+  return wasActive;
 };
 
 const seekToastLabel = command => {
@@ -776,6 +1079,73 @@ const playbackErrorText = () => String(state.playbackErrorMessage || "").trim();
 const rangePositionMs = () => {
   const durationMs = Math.max(0, Number(state.durationMs) || 0);
   return durationMs > 0 ? Math.round(durationMs * Number(seek.value) / 1000) : 0;
+};
+
+const seekPositionForPointer = event => {
+  const durationMs = Math.max(0, Number(state.durationMs) || 0);
+  if (durationMs <= 0) return 0;
+  const rect = seek.getBoundingClientRect();
+  if (!rect || rect.width <= 0) return rangePositionMs();
+  const fraction = Math.max(0, Math.min(1, (event.clientX - rect.left) / rect.width));
+  return Math.round(durationMs * fraction);
+};
+
+const setSeekPositionFromPointer = event => {
+  scrubPositionMs = seekPositionForPointer(event);
+  const durationMs = Math.max(0, Number(state.durationMs) || 0);
+  const rangeMax = Math.max(1, Number(seek.max) || 1000);
+  seek.value = durationMs > 0 ? Math.round((scrubPositionMs / durationMs) * rangeMax) : 0;
+  setProgress(scrubPositionMs, state.durationMs);
+};
+
+const beginSeekPointerScrub = event => {
+  if (event.button !== 0 || seek.disabled || playbackErrorText()) return;
+  event.preventDefault();
+  event.stopPropagation();
+  seekPointerId = event.pointerId;
+  isScrubbing = true;
+  noteChromeActivity(true);
+  setSeekPositionFromPointer(event);
+  send("scrubChange", scrubPositionMs);
+  if (typeof seek.setPointerCapture === "function") {
+    try {
+      seek.setPointerCapture(event.pointerId);
+    } catch (_) {
+      // WebView can reject capture if the pointer has already been retargeted.
+    }
+  }
+};
+
+const updateSeekPointerScrub = event => {
+  if (seekPointerId === null || event.pointerId !== seekPointerId) return;
+  event.preventDefault();
+  event.stopPropagation();
+  noteChromeActivity();
+  setSeekPositionFromPointer(event);
+  send("scrubChange", scrubPositionMs);
+};
+
+const finishSeekPointerScrub = (event, commit) => {
+  if (seekPointerId === null || (event && event.pointerId !== seekPointerId)) return;
+  if (event) {
+    event.preventDefault();
+    event.stopPropagation();
+    if (typeof seek.releasePointerCapture === "function") {
+      try {
+        seek.releasePointerCapture(seekPointerId);
+      } catch (_) {
+        // Capture may already have been released.
+      }
+    }
+  }
+  if (commit && event) {
+    setSeekPositionFromPointer(event);
+    send("scrubFinish", scrubPositionMs);
+    state.positionMs = scrubPositionMs;
+  }
+  seekPointerId = null;
+  isScrubbing = false;
+  render();
 };
 
 const modalByName = {
@@ -1692,6 +2062,7 @@ const canAutoHideChrome = showOpening => Boolean(
   !state.isLocked &&
   !activeModal &&
   !isScrubbing &&
+  surfaceDragSeekPointerId === null &&
   !isInteractingWithChrome() &&
   !playbackErrorText() &&
   !showOpening,
@@ -1797,6 +2168,20 @@ const noteChromeActivity = (force = false) => {
   chromeAutoHideActivity += 1;
   syncChromeAutoHideTimer(isOpeningOverlayActive());
   send("keepChromeVisible", 0);
+};
+
+const revealChromeFromPointerActivity = (force = false) => {
+  if (playbackErrorText() || state.isLocked || activeModal) return;
+  if (!state.controlsVisible) {
+    state = { ...state, controlsVisible: true };
+    chromeInteractionLastNotedAt = window.performance ? window.performance.now() : Date.now();
+    chromeAutoHideActivity += 1;
+    renderChrome();
+    syncChromeAutoHideTimer(isOpeningOverlayActive());
+    send("keepChromeVisible", 0);
+    return;
+  }
+  noteChromeActivity(force);
 };
 
 const updateChromePointerInside = inside => {
@@ -2112,6 +2497,12 @@ const toggleChrome = () => {
   send("toggleChrome", 0);
 };
 
+const mouseNavigationCommandForEvent = event => {
+  const button = Number(event.button);
+  if (!Number.isFinite(button) || button < 3 || button > 8) return "";
+  return button === 4 ? "forward" : "back";
+};
+
 const clearPressedButton = () => {
   if (!pressedButton) return;
   pressedButton.classList.remove("is-pressed");
@@ -2119,6 +2510,19 @@ const clearPressedButton = () => {
 };
 
 document.addEventListener("pointerdown", event => {
+  const mouseNavigationCommand = mouseNavigationCommandForEvent(event);
+  if (mouseNavigationCommand) {
+    event.preventDefault();
+    event.stopPropagation();
+    send(mouseNavigationCommand, 0);
+    return;
+  }
+  if (startVolumeDrag(event)) {
+    return;
+  }
+  if (beginSurfaceDragSeek(event)) {
+    return;
+  }
   const interactingWithChrome = isChromeInteractionTarget(event.target);
   if (interactingWithChrome) {
     isChromePointerDown = true;
@@ -2128,7 +2532,7 @@ document.addEventListener("pointerdown", event => {
   if (!isTextEntryTarget(event.target)) {
     focusShortcutRoot();
     if (!interactingWithChrome) {
-      noteChromeActivity(true);
+      revealChromeFromPointerActivity(true);
     }
   }
   const button = event.target.closest("button");
@@ -2138,17 +2542,39 @@ document.addEventListener("pointerdown", event => {
   button.classList.add("is-pressed");
 }, true);
 
+document.addEventListener("auxclick", event => {
+  if (event.button !== 1 && !mouseNavigationCommandForEvent(event)) return;
+  event.preventDefault();
+  event.stopPropagation();
+}, true);
+
+document.addEventListener("wheel", event => {
+  handleVolumeWheel(event);
+}, { capture: true, passive: false });
+
 document.addEventListener("pointermove", event => {
+  if (handleVolumeDragMove(event)) return;
+  if (handleSurfaceDragSeekMove(event)) return;
   noteCursorActivity();
   const inside = isChromeInteractionTarget(event.target);
   updateChromePointerInside(inside);
   if (inside) {
     noteChromeActivity();
+  } else {
+    revealChromeFromPointerActivity();
   }
 }, true);
 
-document.addEventListener("pointerup", finishChromePointerInteraction, true);
-document.addEventListener("pointercancel", finishChromePointerInteraction, true);
+document.addEventListener("pointerup", event => {
+  finishVolumeDrag(event);
+  finishSurfaceDragSeek(event);
+  finishChromePointerInteraction(event);
+}, true);
+document.addEventListener("pointercancel", event => {
+  finishVolumeDrag(event);
+  finishSurfaceDragSeek(event);
+  finishChromePointerInteraction(event);
+}, true);
 document.addEventListener("dragend", clearPressedButton, true);
 document.addEventListener("pointerleave", () => {
   updateChromePointerInside(false);
@@ -2173,6 +2599,7 @@ window.addEventListener("blur", () => {
   isChromePointerInside = false;
   isChromePointerDown = false;
   isChromeFocusInside = false;
+  finishSurfaceDragSeek(null);
   clearPressedButton();
   syncChromeAutoHideTimer(isOpeningOverlayActive());
 });
@@ -2445,6 +2872,7 @@ nextEpisodeCard.addEventListener("click", event => {
 });
 
 seek.addEventListener("input", () => {
+  if (seekPointerId !== null) return;
   noteChromeActivity();
   isScrubbing = true;
   scrubPositionMs = rangePositionMs();
@@ -2453,6 +2881,7 @@ seek.addEventListener("input", () => {
 });
 
 seek.addEventListener("change", () => {
+  if (seekPointerId !== null) return;
   noteChromeActivity();
   scrubPositionMs = rangePositionMs();
   isScrubbing = false;
@@ -2460,6 +2889,12 @@ seek.addEventListener("change", () => {
   state.positionMs = scrubPositionMs;
   render();
 });
+
+seek.addEventListener("pointerdown", beginSeekPointerScrub);
+seek.addEventListener("pointermove", updateSeekPointerScrub);
+seek.addEventListener("pointerup", event => finishSeekPointerScrub(event, true));
+seek.addEventListener("pointercancel", event => finishSeekPointerScrub(event, false));
+seek.addEventListener("lostpointercapture", event => finishSeekPointerScrub(event, false));
 
 window.playerUpdate = update => {
   const durationMs = Math.round((Number(update.duration) || 0) * 1000);
@@ -2520,15 +2955,36 @@ window.playerControls = nextState => {
 };
 
 root.addEventListener("click", event => {
+  if (suppressNextRootClick) {
+    suppressNextRootClick = false;
+    window.clearTimeout(suppressNextRootClickTimer);
+    suppressNextRootClickTimer = 0;
+    event.preventDefault();
+    event.stopPropagation();
+    return;
+  }
   if (playbackErrorText()) return;
   if (event.target.closest("button,input")) return;
   window.clearTimeout(tapTimer);
   tapTimer = window.setTimeout(() => {
-    toggleChrome();
+    if (state.isLocked) {
+      send("revealLockedOverlay", 0);
+      return;
+    }
+    revealChromeFromPointerActivity(true);
+    send("toggle", 0);
   }, 220);
 });
 
 root.addEventListener("dblclick", event => {
+  if (suppressNextRootClick) {
+    suppressNextRootClick = false;
+    window.clearTimeout(suppressNextRootClickTimer);
+    suppressNextRootClickTimer = 0;
+    event.preventDefault();
+    event.stopPropagation();
+    return;
+  }
   if (playbackErrorText()) return;
   if (event.target.closest("button,input")) return;
   event.preventDefault();

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/core/ui/PlatformBackHandler.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/core/ui/PlatformBackHandler.ios.kt
@@ -7,3 +7,9 @@ actual fun PlatformBackHandler(
     enabled: Boolean,
     onBack: () -> Unit,
 ) = Unit
+
+@Composable
+actual fun PlatformForwardHandler(
+    enabled: Boolean,
+    onForward: () -> Unit,
+) = Unit


### PR DESCRIPTION
## Summary

Adds a focused desktop mouse/navigation control pass:

- Fixes desktop player mouse seeking/scrubbing so pointer-based timeline seeking commits reliably instead of snapping back.
- Adds desktop mouse side-button back/forward handling and app-level forward history.
- Adds settings-page back/forward history so side buttons work intuitively inside settings subpages.
- Adds desktop middle-mouse drag scrolling for faster pointer-first browsing in app views.
- Improves desktop player mouse controls: click toggles playback, double-click toggles fullscreen, mouse wheel adjusts volume, middle-button drag adjusts volume, and left-click hold/drag scans backward/forward with distance-based speed.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Old behavior:

- Keyboard seek worked, but mouse seek/scrub in the desktop player could fail and snap back, as reported in #87.
- Desktop mouse input was split across Compose/AWT, the WebView controls overlay, and the native mpv child window, so equivalent mouse actions did not behave consistently depending on where the pointer landed.

Broken or unwanted behavior:

- Mouse-first player seeking was unreliable.
- Desktop navigation and player controls did not consistently honor common mouse affordances such as side-button back/forward, wheel volume, middle-button drag, and surface click/drag gestures.

New behavior:

- Timeline pointer scrubbing has a desktop WebView fallback that updates and commits the requested seek position.
- Player surface click toggles playback, double-click toggles fullscreen, wheel adjusts volume, middle-button drag adjusts volume, and left-button hold/drag scans backward/forward with distance-based speed.
- Desktop side mouse buttons can navigate back/forward through app and settings history.
- Middle-button drag scrolling works in desktop app views, excluding the native player surface.

Policy note:

- The mouse seek/scrub fix directly addresses the linked reproducible bug in #87.
- The additional desktop mouse affordances are proposed in #97 and included here as the same mouse-input consistency pass for maintainer review. If maintainers prefer strict #87-only scope, these can be split after review.

## Desktop scope

Affects desktop shared behavior and desktop-specific integrations:

- `commonMain` navigation state is updated so desktop back/forward inputs can restore app and settings history.
- `desktopMain` handles AWT side mouse buttons, middle-mouse drag scrolling, native player surface clicks/drags/wheel input, and Windows mpv container mouse messages.
- Android/iOS actuals are no-op forward handlers to satisfy the shared expect declaration without changing mobile behavior.

## Issue or approval

Fixes #87 for the player mouse seek/scrub bug.

Feature request for broader desktop mouse affordances: #97.

The broader side-button navigation, middle-drag scrolling, and player mouse affordances need maintainer acceptance in #97, or can be split if maintainers require a separate approved request before merging.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

Intentionally not changed:

- No backend, account, or sync behavior changes.
- No visual redesign, styling changes, or new settings UI.
- No dependency additions.
- No release/version metadata changes.
- No mobile behavior changes beyond no-op actuals required by shared desktop navigation hooks.

## Testing

- `node --check composeApp\src\desktopMain\resources\player-ui\controls.js`
- `git diff --check`
- `./gradlew.bat ':composeApp:compileKotlinDesktop' ':composeApp:desktopJar'`
- Installed a local desktop build and smoke-tested player timeline seek, click-to-toggle playback, double-click fullscreen, wheel volume, middle-button volume drag, left-click hold/drag seek, side-button back/forward, settings/app forward history, and middle-mouse drag scrolling.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #87 for player mouse seek/scrub behavior.

Related feature request for broader desktop mouse input affordances: #97.

