### PR TITLE
Fix desktop addon request failures after repeated fetches

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.desktop.kt
@@ -35,9 +35,20 @@ internal actual object AddonStorage {
 }
 
 private val desktopHttpClient: HttpClient = HttpClient.newBuilder()
+    .version(HttpClient.Version.HTTP_1_1)
     .connectTimeout(Duration.ofSeconds(30))
     .followRedirects(HttpClient.Redirect.NORMAL)
     .build()
+
+private val desktopNoRedirectHttpClient: HttpClient = HttpClient.newBuilder()
+    .version(HttpClient.Version.HTTP_1_1)
+    .connectTimeout(Duration.ofSeconds(30))
+    .followRedirects(HttpClient.Redirect.NEVER)
+    .build()
+
+private val desktopHttpTransport = DesktopAddonHttpTransport(
+    send = ::sendDesktopHttpRequest,
+)
 
 actual suspend fun httpGetText(url: String): String =
     httpGetTextWithHeaders(url, emptyMap())
@@ -70,35 +81,40 @@ actual suspend fun httpRequestRaw(
     body: String,
     followRedirects: Boolean,
 ): RawHttpResponse = withContext(Dispatchers.IO) {
-    val client = if (followRedirects) {
-        desktopHttpClient
-    } else {
-        HttpClient.newBuilder()
-            .connectTimeout(Duration.ofSeconds(30))
-            .followRedirects(HttpClient.Redirect.NEVER)
-            .build()
-    }
-    val normalizedMethod = method.trim().uppercase().ifBlank { "GET" }
+    desktopHttpTransport.execute(
+        DesktopAddonHttpRequest(
+            method = method,
+            url = url,
+            headers = headers,
+            body = body,
+            followRedirects = followRedirects,
+        ),
+    )
+}
+
+private fun sendDesktopHttpRequest(request: DesktopAddonHttpRequest): RawHttpResponse {
+    val client = if (request.followRedirects) desktopHttpClient else desktopNoRedirectHttpClient
+    val normalizedMethod = request.method.trim().uppercase().ifBlank { "GET" }
     val requestBuilder = HttpRequest.newBuilder()
-        .uri(URI(url.encodeUnsafeHttpUrlCharacters()))
+        .uri(URI(request.url.encodeUnsafeHttpUrlCharacters()))
         .timeout(Duration.ofSeconds(60))
         .method(
             normalizedMethod,
             if (normalizedMethod == "GET" || normalizedMethod == "HEAD") {
                 HttpRequest.BodyPublishers.noBody()
             } else {
-                HttpRequest.BodyPublishers.ofString(body)
+                HttpRequest.BodyPublishers.ofString(request.body)
             },
         )
 
-    headers.forEach { (key, value) ->
+    request.headers.forEach { (key, value) ->
         if (key.isNotBlank() && value.isNotBlank()) {
             requestBuilder.header(key, value)
         }
     }
 
     val response = client.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
-    RawHttpResponse(
+    return RawHttpResponse(
         status = response.statusCode(),
         statusText = "HTTP ${response.statusCode()}",
         url = response.uri().toString(),

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/addons/DesktopAddonHttpTransport.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/addons/DesktopAddonHttpTransport.kt
@@ -1,0 +1,83 @@
+package com.nuvio.app.features.addons
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import java.io.IOException
+import java.net.URI
+
+internal data class DesktopAddonHttpRequest(
+    val method: String,
+    val url: String,
+    val headers: Map<String, String>,
+    val body: String,
+    val followRedirects: Boolean,
+)
+
+internal class DesktopAddonHttpTransport(
+    maxConcurrentRequests: Int = DEFAULT_MAX_CONCURRENT_REQUESTS,
+    private val retryDelaysMillis: List<Long> = DEFAULT_RETRY_DELAYS_MILLIS,
+    private val delayBeforeRetry: suspend (Long) -> Unit = { delay(it) },
+    private val send: suspend (DesktopAddonHttpRequest) -> RawHttpResponse,
+) {
+    private val semaphore = Semaphore(maxConcurrentRequests.coerceAtLeast(1))
+
+    suspend fun execute(request: DesktopAddonHttpRequest): RawHttpResponse =
+        semaphore.withPermit {
+            var retryIndex = 0
+            while (true) {
+                try {
+                    return@withPermit send(request)
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (error: IOException) {
+                    val delayMillis = retryDelaysMillis.getOrNull(retryIndex)
+                    if (delayMillis == null || !isTransientDesktopAddonHttpFailure(error)) {
+                        throw error
+                    }
+                    log.w(error) {
+                        "Retrying desktop addon HTTP ${request.method} request to ${request.sanitizedHost()} " +
+                            "after transient failure (${retryIndex + 1}/${retryDelaysMillis.size}): ${error.message}"
+                    }
+                    retryIndex += 1
+                    delayBeforeRetry(delayMillis)
+                }
+            }
+            error("unreachable")
+        }
+
+    private fun DesktopAddonHttpRequest.sanitizedHost(): String =
+        runCatching { URI(url).host }
+            .getOrNull()
+            ?.takeIf { it.isNotBlank() }
+            ?: "unknown-host"
+
+    companion object {
+        private val log = Logger.withTag("DesktopAddonHttp")
+        private const val DEFAULT_MAX_CONCURRENT_REQUESTS = 8
+        private val DEFAULT_RETRY_DELAYS_MILLIS = listOf(150L, 400L)
+    }
+}
+
+internal fun isTransientDesktopAddonHttpFailure(error: Throwable): Boolean {
+    if (error !is IOException) return false
+
+    val message = generateSequence(error as Throwable?) { it.cause }
+        .mapNotNull { it.message }
+        .joinToString(separator = " ")
+        .lowercase()
+
+    return transientSocketMessages.any { it in message }
+}
+
+private val transientSocketMessages = listOf(
+    "can't assign requested address",
+    "cannot assign requested address",
+    "address not available",
+    "connection reset",
+    "broken pipe",
+    "connection timed out",
+    "read timed out",
+)

--- a/composeApp/src/desktopTest/kotlin/com/nuvio/app/features/addons/DesktopAddonHttpTransportTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/nuvio/app/features/addons/DesktopAddonHttpTransportTest.kt
@@ -1,0 +1,127 @@
+package com.nuvio.app.features.addons
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import java.io.IOException
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class DesktopAddonHttpTransportTest {
+    @Test
+    fun `retries transient address assignment failures`() = runBlocking {
+        var attempts = 0
+        val transport = DesktopAddonHttpTransport(
+            send = {
+                attempts += 1
+                if (attempts < 3) {
+                    throw IOException("Can't assign requested address")
+                }
+                rawResponse()
+            },
+            retryDelaysMillis = listOf(1L, 1L),
+            delayBeforeRetry = {},
+        )
+
+        val response = transport.execute(request())
+
+        assertEquals(3, attempts)
+        assertEquals("ok", response.body)
+    }
+
+    @Test
+    fun `does not retry non transient failures`() = runBlocking {
+        var attempts = 0
+        val transport = DesktopAddonHttpTransport(
+            send = {
+                attempts += 1
+                throw IOException("Malformed response")
+            },
+            retryDelaysMillis = listOf(1L, 1L),
+            delayBeforeRetry = {},
+        )
+
+        assertFailsWith<IOException> {
+            transport.execute(request())
+        }
+        assertEquals(1, attempts)
+    }
+
+    @Test
+    fun `does not retry cancellation`() = runBlocking {
+        var attempts = 0
+        val transport = DesktopAddonHttpTransport(
+            send = {
+                attempts += 1
+                throw CancellationException("cancelled")
+            },
+            retryDelaysMillis = listOf(1L, 1L),
+            delayBeforeRetry = {},
+        )
+
+        assertFailsWith<CancellationException> {
+            transport.execute(request())
+        }
+        assertEquals(1, attempts)
+    }
+
+    @Test
+    fun `limits concurrent requests`() = runBlocking {
+        val active = AtomicInteger(0)
+        val maxActive = AtomicInteger(0)
+        val twoRequestsActive = CompletableDeferred<Unit>()
+        val releaseRequests = CompletableDeferred<Unit>()
+        val transport = DesktopAddonHttpTransport(
+            maxConcurrentRequests = 2,
+            send = {
+                val current = active.incrementAndGet()
+                maxActive.updateAndGet { previous -> maxOf(previous, current) }
+                if (current == 2) {
+                    twoRequestsActive.complete(Unit)
+                }
+                releaseRequests.await()
+                active.decrementAndGet()
+                rawResponse()
+            },
+            retryDelaysMillis = emptyList(),
+            delayBeforeRetry = {},
+        )
+
+        coroutineScope {
+            val jobs = (1..5).map {
+                async(Dispatchers.Default) {
+                    transport.execute(request())
+                }
+            }
+            twoRequestsActive.await()
+            delay(50L)
+            assertEquals(2, maxActive.get())
+            releaseRequests.complete(Unit)
+            jobs.awaitAll()
+        }
+        Unit
+    }
+}
+
+private fun request() = DesktopAddonHttpRequest(
+    method = "GET",
+    url = "https://example.test/manifest.json",
+    headers = emptyMap(),
+    body = "",
+    followRedirects = true,
+)
+
+private fun rawResponse() = RawHttpResponse(
+    status = 200,
+    statusText = "HTTP 200",
+    url = "https://example.test/manifest.json",
+    body = "ok",
+    headers = emptyMap(),
+)


### PR DESCRIPTION
## Summary

Fixes repeated desktop addon request failures where metadata and stream fetching can start failing with:

`java.io.IOException: Can't assign requested address`

The fix reuses desktop HTTP clients, limits concurrent addon HTTP requests, and retries transient socket-level failures.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

After repeated metadata and stream fetches, desktop addon requests can fail with `Can't assign requested address`. When this happens, addons such as AIOStreams and AIOMetadata may return no streams or stop loading metadata until the app is restarted.

The old desktop implementation also created a new no-redirect `HttpClient` for requests that disabled redirects. This PR keeps the fix focused on desktop addon request reliability.

## Desktop scope

Desktop shared addon networking code is affected.

This was reported on macOS, but the changed code is in the desktop source set and applies to desktop addon HTTP requests generally.

## Issue or approval

Fixes #78

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

This PR only changes desktop addon HTTP request handling.

It does not change UI, stream ranking, addon parsing, metadata parsing, playback behavior, release versioning, dependencies, or packaging configuration.

## Testing

Tested on macOS.

Commands run:

```bash
./gradlew :composeApp:desktopTest -x :composeApp:buildMacosPlayerBridge --no-daemon
```

Result: passed.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #78
