### PR TITLE
feat: add manual next episode button and fix autoplay countdown overl…

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerControls.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerControls.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.rounded.Forward10
 import androidx.compose.material.icons.rounded.Lock
 import androidx.compose.material.icons.rounded.LockOpen
 import androidx.compose.material.icons.rounded.Replay10
+import androidx.compose.material.icons.rounded.SkipNext
 import androidx.compose.material.icons.rounded.Speed
 import androidx.compose.material.icons.rounded.SwapHoriz
 import androidx.compose.material.icons.rounded.VideoLibrary
@@ -90,6 +91,8 @@ internal fun PlayerControlsShell(
     onEpisodesClick: (() -> Unit)? = null,
     onOpenInExternalPlayer: (() -> Unit)? = null,
     onSubmitIntroClick: (() -> Unit)? = null,
+    hasNextEpisode: Boolean = false,
+    onNextEpisodeClick: (() -> Unit)? = null,
     parentalWarnings: List<ParentalWarning> = emptyList(),
     showParentalGuide: Boolean = false,
     onParentalGuideAnimationComplete: () -> Unit = {},
@@ -169,6 +172,8 @@ internal fun PlayerControlsShell(
                     onSeekBack = onSeekBack,
                     onSeekForward = onSeekForward,
                     onTogglePlayback = onTogglePlayback,
+                    hasNextEpisode = hasNextEpisode,
+                    onNextEpisodeClick = onNextEpisodeClick,
                     modifier = Modifier
                         .align(Alignment.Center)
                         .padding(bottom = metrics.centerLift),
@@ -383,6 +388,8 @@ private fun CenterControls(
     onSeekBack: () -> Unit,
     onSeekForward: () -> Unit,
     onTogglePlayback: () -> Unit,
+    hasNextEpisode: Boolean = false,
+    onNextEpisodeClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -408,6 +415,14 @@ private fun CenterControls(
             metrics = metrics,
             onClick = onSeekForward,
         )
+        if (hasNextEpisode && onNextEpisodeClick != null) {
+            SideControlButton(
+                icon = Icons.Rounded.SkipNext,
+                contentDescription = stringResource(Res.string.player_next_episode),
+                metrics = metrics,
+                onClick = onNextEpisodeClick,
+            )
+        }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerEngine.kt
@@ -142,6 +142,7 @@ data class PlayerControlsState(
     val isLocked: Boolean = false,
     val lockedOverlayVisible: Boolean = false,
     val controlsVisible: Boolean = true,
+    val hasNextEpisode: Boolean = false,
     val parentalWarnings: List<ParentalWarning> = emptyList(),
     val showParentalGuide: Boolean = false,
     val showOpeningOverlay: Boolean = false,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeEffects.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeEffects.kt
@@ -460,7 +460,7 @@ private fun PlayerScreenRuntime.BindPlayerMetadataAndSkipEffects() {
             if (playerSettingsUiState.streamAutoPlayNextEpisodeEnabled && nextEpisodeInfo?.hasAired == true) {
                 playNextEpisode()
             }
-        } else if (!shouldShow) {
+        } else if (!shouldShow && !nextEpisodeAutoPlaySearching && nextEpisodeAutoPlayCountdown == null) {
             showNextEpisodeCard = false
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
@@ -163,6 +163,7 @@ internal fun PlayerScreenRuntime.RenderPlayerRuntimeUi() {
         episodeText = episodeText,
         streamTitle = activeStreamTitle,
         providerName = activeProviderName,
+        hasNextEpisode = isEpisode && nextEpisodeInfo != null && nextEpisodeInfo?.hasAired == true,
         pauseOverlayWatchingLabel = stringResource(Res.string.compose_player_youre_watching),
         pauseOverlayLogo = logo,
         pauseOverlayEpisodeInfo = if (seasonNumber != null && episodeNumber != null) {
@@ -472,6 +473,8 @@ private fun PlayerScreenRuntime.RenderPlayerControls(displayedPositionMs: Long, 
             onTogglePlayback = { togglePlayback() },
             onSeekBack = { seekBy(-10_000L) },
             onSeekForward = { seekBy(10_000L) },
+            hasNextEpisode = isEpisode && nextEpisodeInfo != null && nextEpisodeInfo?.hasAired == true,
+            onNextEpisodeClick = { playNextEpisode() },
             onResizeModeClick = { cycleResizeMode() },
             onSpeedClick = { cyclePlaybackSpeed() },
             onSubtitleClick = {
@@ -713,6 +716,7 @@ private fun PlayerScreenRuntime.handlePlayerControlsEvent(type: String, value: D
         }
         "playNextEpisode" -> {
             if (nextEpisodeInfo?.hasAired == true) {
+                showNextEpisodeCard = true
                 nextEpisodeAutoPlayJob?.cancel()
                 playNextEpisode()
             }

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
@@ -715,6 +715,8 @@ private fun PlayerControlsState.toControlsJson(isFullscreen: Boolean): String =
         append(',')
         appendJsonField("controlsVisible", controlsVisible)
         append(',')
+        appendJsonField("hasNextEpisode", hasNextEpisode)
+        append(',')
         appendJsonArrayField("parentalWarnings", parentalWarnings) { appendParentalWarningJson(it) }
         append(',')
         appendJsonField("showParentalGuide", showParentalGuide)

--- a/composeApp/src/desktopMain/resources/player-ui/controls.html
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.html
@@ -206,6 +206,9 @@
             <button class="action playback-action" id="toggle" data-command="toggle" aria-label="Play">
               <svg><use id="toggleIcon" href="#icon-play"></use></svg><span id="toggleLabel">Play</span>
             </button>
+            <button class="action optional" id="nextEpisodeButton" data-command="playNextEpisode" aria-label="Next episode" hidden>
+              <svg><use href="#icon-skip-next"></use></svg><span id="nextEpisodeLabel">Next</span>
+            </button>
             <button class="action" data-command="resize"><svg><use href="#icon-aspect"></use></svg><span id="resizeLabel">Fit</span></button>
             <button class="action" data-command="speed"><svg><use href="#icon-speed"></use></svg><span id="speedLabel">1x</span></button>
             <button class="action" data-command="subtitles"><svg><use href="#icon-subs"></use></svg><span id="subtitlesLabel">Subs</span></button>

--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -22,6 +22,7 @@ const pauseDescription = document.getElementById("pauseDescription");
 const toggle = document.getElementById("toggle");
 const toggleIcon = document.getElementById("toggleIcon");
 const toggleLabel = document.getElementById("toggleLabel");
+const nextEpisodeButton = document.getElementById("nextEpisodeButton");
 const lockIcon = document.getElementById("lockIcon");
 const fullscreenButton = document.getElementById("fullscreenButton");
 const fullscreenIcon = document.getElementById("fullscreenIcon");
@@ -1873,6 +1874,7 @@ const renderChrome = () => {
   setVisible(videoSettingsButton, Boolean(state.showVideoSettings));
   setVisible(sourcesButton, Boolean(state.showSources));
   setVisible(episodesButton, Boolean(state.showEpisodes));
+  setVisible(nextEpisodeButton, Boolean(state.hasNextEpisode));
   syncActionFocusState();
 
   const playPauseLabel = isPlaying ? state.pauseLabel : state.playLabel;
@@ -2571,4 +2573,10 @@ document.addEventListener("keydown", event => {
 setProgress(0, 0);
 focusShortcutRoot();
 render();
+
+nextEpisodeButton.addEventListener("click", event => {
+  event.stopPropagation();
+  send("playNextEpisode", 0);
+});
+
 send("controlsReady", 0);


### PR DESCRIPTION
## Summary

Added a manual "Next Episode" button to the player controls so users can skip to the next episode without waiting for the 99% autoplay threshold. (Also includes a small behavior tweak to ensure the autoplay countdown overlay doesn't instantly disappear when manually triggered).

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [x] Approved larger or directional change

## Why

This change is needed to allow users to manually skip to the next episode using the same visual autoplay flow without waiting until the very end of the current episode. 

## Desktop scope

This branch updates the desktop player UI (`controls.html`, `controls.js`) and the shared desktop-bridging code (`NativePlayerController.kt`, `PlayerScreenRuntimeEffects.kt`, `PlayerEngine.kt`) required to pass the `hasNextEpisode` state to the desktop webview frontend.

## Issue or approval

Approved in conversation / No linked issue.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [x] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Intentionally limited to adding the Next Episode button and its associated visual overlay handling. Did not refactor other player controls.

## Testing

Tested on Windows Desktop. Verified that clicking the Next Episode button when an episode is playing correctly triggers the stream search overlay and plays the next episode.

## Screenshots / Video

<img width="1862" height="789" alt="image" src="https://github.com/user-attachments/assets/9f82ca9e-8ed8-4523-9af3-ecd3eb455073" />

## Breaking changes

None.

## Linked issues

fixes #127 