### PR TITLE
fix: desktop subtitle style initialization

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
@@ -38,6 +38,8 @@ internal class NativePlayerController(
     private var handle: Long = 0L
     private var pendingSource: PendingSource? = null
     private var controlsState = PlayerControlsState()
+    private var pendingSubtitleDelayMs: Int? = null
+    private var pendingSubtitleStyle: SubtitleStyleState? = null
     private var lastSentControlsStructureKey: NativeControlsStructureKey? = null
     private var onAction: (PlayerControlsAction) -> Boolean = { false }
     private var onEvent: (String, Double) -> Boolean = { _, _ -> false }
@@ -104,6 +106,7 @@ internal class NativePlayerController(
                 )
                 if (handle == 0L) error("Native player did not return a handle.")
                 updateControls(controlsState)
+                applyPendingSubtitleSettings()
             }.onFailure { error ->
                 pending.onError(error.message)
             }
@@ -388,27 +391,41 @@ internal class NativePlayerController(
     }
 
     override fun setSubtitleDelayMs(delayMs: Int) {
+        val clamped = delayMs.coerceIn(SUBTITLE_DELAY_MIN_MS, SUBTITLE_DELAY_MAX_MS)
+        pendingSubtitleDelayMs = clamped
         handle.takeIf { it != 0L }?.let { current ->
-            NativePlayerBridge.setSubtitleDelayMs(
-                current,
-                delayMs.coerceIn(SUBTITLE_DELAY_MIN_MS, SUBTITLE_DELAY_MAX_MS),
-            )
+            NativePlayerBridge.setSubtitleDelayMs(current, clamped)
         }
     }
 
     override fun applySubtitleStyle(style: SubtitleStyleState) {
+        pendingSubtitleStyle = style
         handle.takeIf { it != 0L }?.let { current ->
-            NativePlayerBridge.applySubtitleStyle(
-                handle = current,
-                textColor = style.textColor.toMpvColorString(),
-                backgroundColor = style.backgroundColor.toMpvColorString(),
-                outlineColor = style.outlineColor.toMpvColorString(),
-                outlineSize = if (style.outlineEnabled) style.outlineWidth.toFloat() else 0f,
-                bold = style.bold,
-                fontSize = style.toMpvSubtitleFontSize(),
-                subPos = style.toMpvSubtitlePosition(),
-            )
+            applySubtitleStyle(current, style)
         }
+    }
+
+    private fun applyPendingSubtitleSettings() {
+        val current = handle.takeIf { it != 0L } ?: return
+        pendingSubtitleDelayMs?.let { delayMs ->
+            NativePlayerBridge.setSubtitleDelayMs(current, delayMs)
+        }
+        pendingSubtitleStyle?.let { style ->
+            applySubtitleStyle(current, style)
+        }
+    }
+
+    private fun applySubtitleStyle(handle: Long, style: SubtitleStyleState) {
+        NativePlayerBridge.applySubtitleStyle(
+            handle = handle,
+            textColor = style.textColor.toMpvColorString(),
+            backgroundColor = style.backgroundColor.toMpvColorString(),
+            outlineColor = style.outlineColor.toMpvColorString(),
+            outlineSize = if (style.outlineEnabled) style.outlineWidth.toFloat() else 0f,
+            bold = style.bold,
+            fontSize = style.toMpvSubtitleFontSize(),
+            subPos = style.toMpvSubtitlePosition(),
+        )
     }
 
     private fun decodeTracks(readJson: (Long) -> String): List<NativeMpvTrack> {


### PR DESCRIPTION
## Summary

- Cache pending desktop subtitle style and delay updates when the native MPV player handle is not ready yet.
- Re-apply the pending subtitle settings immediately after the native desktop player handle is created.
- Fixes saved subtitle style settings not being applied at playback start until the user manually changes a subtitle style option.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Desktop native playback can receive the saved `SubtitleStyleState` before the native MPV handle has been created. When that happens, the initial subtitle style update is skipped because there is no active native handle yet.

This causes saved subtitle settings, such as font size and bottom offset, to not apply when playback starts. They only become correct after the user manually changes a subtitle style setting, which sends the style update again after the native player is ready.

## Desktop scope

Affects desktop native playback on Windows and macOS through the shared desktop native player controller.

Only desktop-specific code under `desktopMain` is changed.

## Issue or approval

Fixes #99, #151

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

This PR only changes when existing subtitle style and delay settings are applied to the desktop native player.

It does not change the subtitle settings UI, default values, subtitle rendering options, MPV styling values, or any unrelated playback behavior.

## Testing

Tested on Windows by compiling the desktop target:

```powershell
.\gradlew.bat :composeApp:compileKotlinDesktop