### PR TITLE
escape commas/backslashes in http-header-fields for mpv (macOS + windows)

### DIFF
--- a/composeApp/src/desktopMain/native/macos/player_bridge.mm
+++ b/composeApp/src/desktopMain/native/macos/player_bridge.mm
@@ -1436,7 +1436,13 @@ static void setMpvOptionString(mpv_handle *mpv, const char *name, const char *va
     setMpvOptionString(_mpv, "hr-seek", "no");
 
     if (headerLines.count > 0) {
-        NSString *headers = [headerLines componentsJoinedByString:@","];
+        NSMutableArray *escaped = [NSMutableArray arrayWithCapacity:headerLines.count];
+        for (NSString *line in headerLines) {
+            NSString *esc = [[line stringByReplacingOccurrencesOfString:@"\\" withString:@"\\\\"]
+                             stringByReplacingOccurrencesOfString:@"," withString:@"\\,"];
+            [escaped addObject:esc];
+        }
+        NSString *headers = [escaped componentsJoinedByString:@","];
         setMpvOptionString(_mpv, "http-header-fields", headers.UTF8String);
     }
 

--- a/composeApp/src/desktopMain/native/windows/player_bridge.cpp
+++ b/composeApp/src/desktopMain/native/windows/player_bridge.cpp
@@ -1351,7 +1351,11 @@ private:
                 std::string headers;
                 for (size_t index = 0; index < headerLines.size(); index++) {
                     if (index > 0) headers.push_back(',');
-                    headers += headerLines[index];
+                    // Escape backslashes and commas in header values
+                    for (char c : headerLines[index]) {
+                        if (c == '\\' || c == ',') headers.push_back('\\');
+                        headers.push_back(c);
+                    }
                 }
                 setMpvOptionStringLocked("http-header-fields", headers.c_str());
             }


### PR DESCRIPTION
## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

mpv parses `http-header-fields` as a comma-separated list. Headers containing commas in values (auth tokens, cookies) are split incorrectly, causing broken authenticated streams that fail to load or return 403.

## Desktop scope

macOS (`player_bridge.mm`) and Windows (`player_bridge.cpp`). Both join header lines with `,` but don't escape commas or backslashes in header values.

## Issue or approval

Same fix already applied in NuvioTV (commit [`108bb6fe`](https://github.com/NuvioMedia/NuvioTV/commit/108bb6fe767362cb3a5ff04f34bf23dd62ea9f38)) and NuvioMobile (`MPVPlayerBridge.swift`). This aligns the desktop native bridges.


## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Only header escaping logic changed
- No other mpv options, player logic, or UI touched
- Linux bridge already fixed in separate PR

## Testing

- Cannot build macOS/Windows on this machine
- Fix is identical pattern to NuvioTV (tested and merged) and NuvioMobile (shipped)
- Needs build verification on macOS and Windows

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Same root cause as NuvioTV fix (commit `108bb6fe7`). No standalone issue - discovered during Linux player implementation #142
