### PR TITLE
Touchscreen drag scrolling does not work on Windows desktop

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/NuvioComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/NuvioComponents.kt
@@ -9,6 +9,8 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -66,13 +68,15 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import com.nuvio.app.isWindows
 import nuvio.composeapp.generated.resources.Res
 import nuvio.composeapp.generated.resources.action_back
 import nuvio.composeapp.generated.resources.action_ok
-import org.jetbrains.compose.resources.stringResource
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import org.jetbrains.compose.resources.stringResource
+import kotlin.math.abs
 
 @Composable
 fun NuvioScreen(
@@ -88,6 +92,7 @@ fun NuvioScreen(
         state = listState,
         modifier = modifier
             .fillMaxSize()
+            .nuvioWindowsTouchVerticalDragScroll(listState)
             .background(tokens.colors.background),
         contentPadding = PaddingValues(
             start = horizontalPadding,
@@ -98,6 +103,47 @@ fun NuvioScreen(
         verticalArrangement = Arrangement.spacedBy(tokens.spacing.listGap),
         content = content,
     )
+}
+
+internal fun Modifier.nuvioWindowsTouchVerticalDragScroll(
+    state: LazyListState,
+): Modifier {
+    if (!isWindows) return this
+
+    return pointerInput(state) {
+        awaitEachGesture {
+            val down = awaitFirstDown(pass = PointerEventPass.Initial)
+            var totalDx = 0f
+            var totalDy = 0f
+            var dragging = false
+
+            while (true) {
+                val event = awaitPointerEvent(pass = PointerEventPass.Initial)
+                val change = event.changes.firstOrNull { it.id == down.id } ?: break
+                if (!change.pressed) break
+
+                val delta = change.position - change.previousPosition
+                totalDx += delta.x
+                totalDy += delta.y
+
+                if (!dragging) {
+                    val horizontalDrag =
+                        abs(totalDx) > viewConfiguration.touchSlop && abs(totalDx) > abs(totalDy)
+                    val verticalDrag =
+                        abs(totalDy) > viewConfiguration.touchSlop && abs(totalDy) > abs(totalDx)
+
+                    when {
+                        horizontalDrag -> break
+                        verticalDrag -> dragging = true
+                        else -> continue
+                    }
+                }
+
+                state.dispatchRawDelta(-delta.y)
+                change.consume()
+            }
+        }
+    }
 }
 
 internal fun Modifier.nuvioConsumePointerEvents(): Modifier =

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamsScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -78,6 +79,7 @@ import com.nuvio.app.core.ui.NuvioBottomSheetDivider
 import com.nuvio.app.core.ui.NuvioModalBottomSheet
 import com.nuvio.app.core.ui.NuvioToastController
 import com.nuvio.app.core.ui.dismissNuvioBottomSheet
+import com.nuvio.app.core.ui.nuvioWindowsTouchVerticalDragScroll
 import com.nuvio.app.core.ui.nuvioDesktopDragScroll
 import com.nuvio.app.core.ui.secondaryClick
 import com.nuvio.app.features.downloads.DownloadsRepository
@@ -871,9 +873,13 @@ internal fun StreamList(
         StreamBadgeSettingsRepository.ensureLoaded()
         StreamBadgeSettingsRepository.uiState
     }.collectAsStateWithLifecycle()
+    val listState = rememberLazyListState()
 
     LazyColumn(
-        modifier = modifier.fillMaxWidth(),
+        state = listState,
+        modifier = modifier
+            .fillMaxWidth()
+            .nuvioWindowsTouchVerticalDragScroll(listState),
         contentPadding = PaddingValues(
             horizontal = 12.dp,
             vertical = 12.dp,


### PR DESCRIPTION
## Summary

Fixes vertical touchscreen drag scrolling on Windows desktop.

This adds a Windows-only vertical touch drag bridge for shared vertical LazyColumn screens and the stream picker list.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

On Windows touchscreen laptops, tapping works and horizontal touch dragging works on carousel rows, but vertical touch dragging does not scroll pages. This affects the Home screen and the stream picker list. Mouse wheel and trackpad scrolling already work.

## Desktop scope

Windows desktop.
This also touches shared common UI code because NuvioScreen is the shared vertical screen wrapper used by desktop pages. The added behavior is gated to Windows only.

## Issue or approval

Fixes #143

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

This PR only fixes vertical touchscreen drag scrolling on Windows desktop.

It does not:
- change UI appearance
- add fling or momentum scrolling
- change horizontal carousel dragging
- change mouse wheel or trackpad scrolling
- change stream selection, sorting, or filtering
- add dependencies
- refactor unrelated code

## Testing

Tested on a Windows touchscreen laptop.

Manual testing:
- Home page vertical touchscreen drag scrolls
- Stream picker vertical touchscreen drag scrolls
- Horizontal carousel touch dragging still works
- Poster taps still work
- Stream item taps still work
- Mouse wheel scrolling still works
- Trackpad scrolling still works
- No visual changes observed

Build/run:
- Ran local desktop development build with Gradle
- Verified the fix on the same Windows touchscreen device where the issue reproduced

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #143
