### PR TITLE
fix: Windows fullscreen restore from maximized

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopAppFullscreen.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopAppFullscreen.kt
@@ -2,9 +2,12 @@ package com.nuvio.app.features.player.desktop
 
 import androidx.compose.ui.window.WindowPlacement
 import androidx.compose.ui.window.WindowState
+import java.awt.Frame
 import java.awt.GraphicsEnvironment
 import java.awt.KeyEventDispatcher
 import java.awt.KeyboardFocusManager
+import java.awt.Rectangle
+import java.awt.Toolkit
 import java.awt.Window
 import java.awt.event.KeyEvent
 import javax.swing.SwingUtilities
@@ -77,7 +80,7 @@ internal class DesktopAppFullscreenController {
 
     fun toggle(window: Window, windowState: WindowState) {
         if (DesktopHostOs.current == DesktopHostOs.WINDOWS) {
-            toggleWindowsFullscreen(window)
+            toggleWindowsFullscreen(window, windowState)
         } else {
             toggleComposeFullscreen(windowState)
         }
@@ -105,15 +108,20 @@ internal class DesktopAppFullscreenController {
         }
     }
 
-    private fun toggleWindowsFullscreen(window: Window) {
+    private fun toggleWindowsFullscreen(window: Window, windowState: WindowState) {
         if (windowsFullscreenState?.window === window) {
-            exitWindowsFullscreen(window)
+            exitWindowsFullscreen(window, windowState)
         } else {
-            enterWindowsFullscreen(window)
+            enterWindowsFullscreen(window, windowState)
         }
     }
 
-    private fun enterWindowsFullscreen(window: Window) {
+    private fun enterWindowsFullscreen(window: Window, windowState: WindowState) {
+        val restorePlacement = window.restorePlacement(windowState)
+        if (restorePlacement == WindowPlacement.Maximized) {
+            (window as? Frame)?.maximizedBounds = window.workAreaBounds()
+        }
+
         val gc = window.graphicsConfiguration
             ?: GraphicsEnvironment.getLocalGraphicsEnvironment().defaultScreenDevice.defaultConfiguration
         val screenBounds = gc.bounds
@@ -130,12 +138,16 @@ internal class DesktopAppFullscreenController {
             width = (screenBounds.width * scaleX).toInt(),
             height = (screenBounds.height * scaleY).toInt(),
         )
-        windowsFullscreenState = WindowsFullscreenState(window = window, windowHwnd = hwnd)
+        windowsFullscreenState = WindowsFullscreenState(
+            window = window,
+            windowHwnd = hwnd,
+            restorePlacement = restorePlacement,
+        )
         window.toFront()
         window.requestFocus()
     }
 
-    private fun exitWindowsFullscreen(window: Window) {
+    private fun exitWindowsFullscreen(window: Window, windowState: WindowState? = null) {
         val fullscreenState = windowsFullscreenState?.takeIf { it.window === window } ?: return
         NativePlayerBridge.setWindowBorderlessFullscreen(
             windowHwnd = fullscreenState.windowHwnd,
@@ -146,13 +158,72 @@ internal class DesktopAppFullscreenController {
             height = 0,
         )
         windowsFullscreenState = null
+        window.restorePlacementAfterNativeFullscreen(windowState, fullscreenState.restorePlacement)
     }
 
     private data class WindowsFullscreenState(
         val window: Window,
         val windowHwnd: Long,
+        val restorePlacement: WindowPlacement,
     )
 }
+
+private fun Window.restorePlacement(windowState: WindowState): WindowPlacement {
+    val frame = this as? Frame
+    val isNativeMaximized = frame?.extendedState?.let { state ->
+        state and Frame.MAXIMIZED_BOTH == Frame.MAXIMIZED_BOTH
+    } == true
+    if (isNativeMaximized) return WindowPlacement.Maximized
+    return windowState.placement.takeUnless { it == WindowPlacement.Fullscreen }
+        ?: WindowPlacement.Floating
+}
+
+private fun Window.restorePlacementAfterNativeFullscreen(
+    windowState: WindowState?,
+    placement: WindowPlacement,
+) {
+    SwingUtilities.invokeLater {
+        val frame = this as? Frame
+        if (placement == WindowPlacement.Maximized && frame != null) {
+            val workArea = workAreaBounds()
+            frame.maximizedBounds = workArea
+            frame.extendedState = frame.extendedState or Frame.MAXIMIZED_BOTH
+            windowState?.placement = WindowPlacement.Maximized
+
+            SwingUtilities.invokeLater {
+                if (frame.bounds.exceeds(workArea)) {
+                    frame.extendedState = frame.extendedState and Frame.MAXIMIZED_BOTH.inv()
+                    frame.bounds = workArea
+                    frame.extendedState = frame.extendedState or Frame.MAXIMIZED_BOTH
+                }
+                frame.invalidate()
+                frame.validate()
+                frame.repaint()
+            }
+        } else {
+            windowState?.placement = placement
+        }
+    }
+}
+
+private fun Window.workAreaBounds(): Rectangle {
+    val gc = graphicsConfiguration
+        ?: GraphicsEnvironment.getLocalGraphicsEnvironment().defaultScreenDevice.defaultConfiguration
+    val bounds = gc.bounds
+    val insets = Toolkit.getDefaultToolkit().getScreenInsets(gc)
+    return Rectangle(
+        bounds.x + insets.left,
+        bounds.y + insets.top,
+        (bounds.width - insets.left - insets.right).coerceAtLeast(1),
+        (bounds.height - insets.top - insets.bottom).coerceAtLeast(1),
+    )
+}
+
+private fun Rectangle.exceeds(bounds: Rectangle): Boolean =
+    x < bounds.x ||
+        y < bounds.y ||
+        x + width > bounds.x + bounds.width ||
+        y + height > bounds.y + bounds.height
 
 internal fun installDesktopAppFullscreenShortcuts(window: Window): () -> Unit {
     val dispatcher = KeyEventDispatcher { event ->

--- a/composeApp/src/desktopMain/native/windows/player_bridge.cpp
+++ b/composeApp/src/desktopMain/native/windows/player_bridge.cpp
@@ -72,6 +72,7 @@ struct BorderlessFullscreenState {
     LONG_PTR style = 0;
     LONG_PTR exStyle = 0;
     WINDOWPLACEMENT placement = {};
+    bool wasMaximized = false;
 };
 
 std::mutex gBorderlessFullscreenMutex;
@@ -190,6 +191,7 @@ void setBorderlessFullscreen(HWND hwnd, bool fullscreen, int x, int y, int width
                 state.exStyle = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
                 state.placement.length = sizeof(WINDOWPLACEMENT);
                 GetWindowPlacement(hwnd, &state.placement);
+                state.wasMaximized = IsZoomed(hwnd);
                 gBorderlessFullscreenStates.emplace(hwnd, state);
             }
         }
@@ -232,6 +234,29 @@ void setBorderlessFullscreen(HWND hwnd, bool fullscreen, int x, int y, int width
 
     SetWindowLongPtrW(hwnd, GWL_STYLE, state.style);
     SetWindowLongPtrW(hwnd, GWL_EXSTYLE, state.exStyle);
+    if (state.wasMaximized) {
+        state.placement.length = sizeof(WINDOWPLACEMENT);
+        state.placement.showCmd = SW_SHOWMAXIMIZED;
+        SetWindowPlacement(hwnd, &state.placement);
+
+        HMONITOR monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+        MONITORINFO monitorInfo;
+        monitorInfo.cbSize = sizeof(MONITORINFO);
+        if (GetMonitorInfoW(monitor, &monitorInfo)) {
+            const RECT &work = monitorInfo.rcWork;
+            SetWindowPos(
+                hwnd,
+                nullptr,
+                work.left,
+                work.top,
+                std::max(1L, work.right - work.left),
+                std::max(1L, work.bottom - work.top),
+                SWP_FRAMECHANGED | SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_NOACTIVATE
+            );
+        }
+        return;
+    }
+
     state.placement.length = sizeof(WINDOWPLACEMENT);
     SetWindowPlacement(hwnd, &state.placement);
     SetWindowPos(


### PR DESCRIPTION
## Summary

Fix Windows desktop fullscreen restore when the app was maximized before entering borderless fullscreen.

The change preserves the previous maximized placement, restores the native window style/placement on fullscreen exit, and constrains the restored maximized window to the Windows work area so it does not overlap the taskbar.

## PR type

- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

When the Windows desktop app is maximized, entering fullscreen and then exiting fullscreen can restore the window with incorrect bounds. The app appears maximized but the bottom area overlaps/extends behind the Windows taskbar instead of returning to the normal maximized work area.

This fixes the visible fullscreen/window restore glitch and keeps the app in the expected maximized state after exiting fullscreen.

## Desktop scope

Windows desktop only.

The change is limited to Windows desktop fullscreen/window restore handling in the desktop fullscreen controller and Windows native player bridge.

## Issue or approval

Fixes #135

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

This PR only fixes Windows fullscreen restore from a previously maximized window.

It does not change fullscreen UX, player controls, styling, animations, shortcuts, macOS/Linux behavior, packaging, or unrelated playback behavior.

## Testing

Tested on Windows desktop from source.

Commands run:

```powershell
.\gradlew.bat :composeApp:compileKotlinDesktop
.\gradlew.bat :composeApp:buildWindowsPlayerBridge
```

## Manual flow tested:
1. Launch desktop app.
2. Maximize the app window.
3. Enter fullscreen from the maximized state.
4. Exit fullscreen.
5. Confirm the app returns to maximized window bounds and no longer extends behind the Windows taskbar.

## Screenshots / Video
Before:
https://github.com/user-attachments/assets/a1ed5c28-4340-4b49-b185-7c2e8fdd5e5a

After:
https://github.com/user-attachments/assets/91a67e58-326f-4fa1-aac0-1927ebf98d6e


## Breaking changes
None.

## Linked issues
Fixes #135, #108, #53
