### PR TITLE
fix(desktop): load provider external subtitles into native player

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/PlayerEngine.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/PlayerEngine.desktop.kt
@@ -54,6 +54,7 @@ actual fun PlatformPlayerSurface(
         NativePlayerSurface(
             sourceUrl = sourceUrl,
             sourceHeaders = sourceHeaders,
+            externalSubtitles = externalSubtitles,
             modifier = modifier,
             playWhenReady = playWhenReady,
             resizeMode = resizeMode,
@@ -81,6 +82,7 @@ actual fun PlatformPlayerSurface(
 private fun NativePlayerSurface(
     sourceUrl: String,
     sourceHeaders: Map<String, String>,
+    externalSubtitles: List<com.nuvio.app.features.streams.StreamSubtitle>,
     modifier: Modifier,
     playWhenReady: Boolean,
     resizeMode: PlayerResizeMode,
@@ -165,6 +167,20 @@ private fun NativePlayerSurface(
             onError = { message -> latestOnError.value(message) },
         )
         onControllerReady(controller)
+    }
+
+    LaunchedEffect(controller, sourceUrl, externalSubtitles, hostFirstFullSizePaintComplete.value) {
+        if (!hostFirstFullSizePaintComplete.value) {
+            return@LaunchedEffect
+        }
+        if (externalSubtitles.isEmpty()) {
+            return@LaunchedEffect
+        }
+        // Give the native player a moment to load the media before attaching subs.
+        delay(600L)
+        externalSubtitles.forEach { subtitle ->
+            controller.setSubtitleUri(subtitle.url)
+        }
     }
 
     LaunchedEffect(controller, playWhenReady) {


### PR DESCRIPTION
## Summary

On macOS/Windows the desktop native player surface received the `externalSubtitles` list in `PlatformPlayerSurface` but never forwarded it to `NativePlayerSurface`, so subtitles supplied by stream providers (`getStreams` → `externalSubtitles`) never reached mpv. As a result the in-player subtitle menu showed nothing under **Built-in**, even though the provider returned valid subtitle tracks.

This change:
- Forwards `externalSubtitles` from `PlatformPlayerSurface` into `NativePlayerSurface`.
- After the native player has attached the media, adds each subtitle URL via the existing `setSubtitleUri` → `NativePlayerBridge.addSubtitleUrl` (mpv `sub-add ... select`) path.

The Android engine (`PlayerEngine.android.kt`) already wires `externalSubtitles` into the player via `MediaItem.SubtitleConfiguration`; this brings the desktop native engine to parity.

## Implementation notes

- Pure Kotlin change in `composeApp/src/desktopMain/.../player/PlayerEngine.desktop.kt`; no native (`.mm` / `.cpp`) changes required since `addSubtitleUrl` already exists in the bridge.
- Subtitles are added in a `LaunchedEffect` keyed on `controller`, `sourceUrl`, `externalSubtitles` and gated on `hostFirstFullSizePaintComplete`, with a short delay so the player has loaded the media before `sub-add` is issued.

## Test plan

- [x] Built locally on macOS arm64 (`./gradlew :composeApp:run`).
- [x] Played a stream from a provider that returns `externalSubtitles`; logs show `setSubtitleUri` being invoked with a valid player handle and the subtitle track appearing/selectable under **Built-in** (previously empty).
- [ ] Verify on Windows native player.

Made with [Cursor](https://cursor.com)