### PR TITLE
Feat: Add setting to split Trakt Library lists by Movies & Series

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -1068,6 +1068,8 @@
     <string name="trakt_library_source_nuvio">Nuvio Library</string>
     <string name="trakt_library_source_trakt_selected">Trakt library selected</string>
     <string name="trakt_library_source_nuvio_selected">Nuvio library selected</string>
+    <string name="trakt_unified_watchlist_title">Unified Trakt Watchlist</string>
+    <string name="trakt_unified_watchlist_subtitle">Display Movies and Series in one unified list</string>
     <string name="trakt_watch_progress_title">Watch Progress</string>
     <string name="trakt_watch_progress_subtitle">Choose which progress source powers resume and continue watching</string>
     <string name="trakt_watch_progress_dialog_title">Watch Progress</string>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
@@ -154,6 +154,7 @@ import com.nuvio.app.features.library.LibraryRepository
 import com.nuvio.app.features.library.LibrarySection
 import com.nuvio.app.features.library.LibrarySourceMode
 import com.nuvio.app.features.library.LibraryScreen
+import com.nuvio.app.features.library.traktListKeyFromSectionType
 import com.nuvio.app.features.library.toLibraryItem
 import com.nuvio.app.features.library.toMetaPreview
 import com.nuvio.app.features.notifications.EpisodeReleaseNotificationsRepository
@@ -1646,7 +1647,7 @@ private fun MainAppContent(
                                                 PosterActionTarget(
                                                     preview = item.toMetaPreview(),
                                                     libraryItem = item,
-                                                    libraryListKey = section.type,
+                                                    libraryListKey = section.listKey,
                                                 ),
                                             )
                                         },
@@ -2679,7 +2680,7 @@ private fun MainAppContent(
                                     PosterActionTarget(
                                         preview = meta,
                                         libraryItem = meta.toLibraryItem(savedAtEpochMs = 0L),
-                                        libraryListKey = target.sectionType,
+                                        libraryListKey = traktListKeyFromSectionType(target.sectionType),
                                     )
                                 } else {
                                     PosterActionTarget(preview = meta)

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryModels.kt
@@ -31,7 +31,13 @@ data class LibrarySection(
     val type: String,
     val displayTitle: String,
     val items: List<LibraryItem>,
+    val listKey: String = type,
 )
+
+const val LIBRARY_SECTION_TYPE_SEPARATOR: String = " "
+
+fun traktListKeyFromSectionType(sectionType: String): String =
+    sectionType.substringBeforeLast(LIBRARY_SECTION_TYPE_SEPARATOR)
 
 enum class LibrarySourceMode {
     LOCAL,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryRepository.kt
@@ -41,6 +41,8 @@ import kotlinx.serialization.json.put
 import nuvio.composeapp.generated.resources.Res
 import nuvio.composeapp.generated.resources.library_local_tab_title
 import nuvio.composeapp.generated.resources.library_other
+import nuvio.composeapp.generated.resources.media_movies
+import nuvio.composeapp.generated.resources.media_series
 import nuvio.composeapp.generated.resources.trakt_lists_update_failed
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.getString
@@ -120,6 +122,12 @@ object LibraryRepository {
                     publish()
                 }
             }
+        }
+        syncScope.launch {
+            TraktSettingsRepository.uiState
+                .map { it.unifiedTraktWatchlist }
+                .distinctUntilChanged()
+                .collectLatest { publish() }
         }
     }
 
@@ -425,16 +433,36 @@ object LibraryRepository {
     private fun publish() {
         if (isTraktLibrarySourceActive()) {
             val traktState = TraktLibraryRepository.uiState.value
-            val sections = traktState.listTabs.mapNotNull { tab ->
-                val listItems = traktState.entriesByList[tab.key].orEmpty()
-                if (listItems.isEmpty()) {
-                    null
-                } else {
-                    LibrarySection(
-                        type = tab.key,
-                        displayTitle = tab.title,
-                        items = listItems,
-                    )
+            val splitByType = !TraktSettingsRepository.uiState.value.unifiedTraktWatchlist
+
+            val sections = if (splitByType) {
+                traktState.listTabs.flatMap { tab ->
+                    val listItems = traktState.entriesByList[tab.key].orEmpty()
+                    listItems
+                        .groupBy { it.type }
+                        .entries
+                        .sortedBy { it.key }
+                        .map { (itemType, typeItems) ->
+                            LibrarySection(
+                                type = "${tab.key}$LIBRARY_SECTION_TYPE_SEPARATOR$itemType",
+                                displayTitle = "${tab.title} (${libraryContentTypeLabel(itemType)})",
+                                items = typeItems,
+                                listKey = tab.key,
+                            )
+                        }
+                }
+            } else {
+                traktState.listTabs.mapNotNull { tab ->
+                    val listItems = traktState.entriesByList[tab.key].orEmpty()
+                    if (listItems.isEmpty()) {
+                        null
+                    } else {
+                        LibrarySection(
+                            type = tab.key,
+                            displayTitle = tab.title,
+                            items = listItems,
+                        )
+                    }
                 }
             }
 
@@ -608,3 +636,10 @@ private fun localizedLibraryOtherTitle(): String =
 private fun localizedStringOrDefault(resource: StringResource, fallback: String): String =
     runCatching { runBlocking { getString(resource) } }
         .getOrDefault(fallback)
+
+private fun libraryContentTypeLabel(type: String): String =
+    when (type.lowercase()) {
+        "movie" -> localizedStringOrDefault(Res.string.media_movies, "Movies")
+        "series" -> localizedStringOrDefault(Res.string.media_series, "Series")
+        else -> type.toLibraryDisplayTitle()
+    }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/SettingsScreen.kt
@@ -693,6 +693,7 @@ private fun MobileSettingsScreen(
                     settingsUiState = traktSettingsUiState,
                     commentsEnabled = traktCommentsEnabled,
                     onCommentsEnabledChange = TraktCommentsSettings::setEnabled,
+                    onUnifiedTraktWatchlistChange = TraktSettingsRepository::setUnifiedTraktWatchlist,
                 )
             }
         }
@@ -1106,6 +1107,7 @@ private fun TabletSettingsScreen(
                         settingsUiState = traktSettingsUiState,
                         commentsEnabled = traktCommentsEnabled,
                         onCommentsEnabledChange = TraktCommentsSettings::setEnabled,
+                        onUnifiedTraktWatchlistChange = TraktSettingsRepository::setUnifiedTraktWatchlist,
                     )
                 }
             }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/TraktSettingsPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/TraktSettingsPage.kt
@@ -89,6 +89,8 @@ import nuvio.composeapp.generated.resources.trakt_library_source_subtitle
 import nuvio.composeapp.generated.resources.trakt_library_source_title
 import nuvio.composeapp.generated.resources.trakt_library_source_trakt
 import nuvio.composeapp.generated.resources.trakt_library_source_trakt_selected
+import nuvio.composeapp.generated.resources.trakt_unified_watchlist_subtitle
+import nuvio.composeapp.generated.resources.trakt_unified_watchlist_title
 import nuvio.composeapp.generated.resources.trakt_more_like_this_source_dialog_subtitle
 import nuvio.composeapp.generated.resources.trakt_more_like_this_source_dialog_title
 import nuvio.composeapp.generated.resources.trakt_more_like_this_source_subtitle
@@ -111,6 +113,7 @@ internal fun LazyListScope.traktSettingsContent(
     settingsUiState: TraktSettingsUiState,
     commentsEnabled: Boolean,
     onCommentsEnabledChange: (Boolean) -> Unit,
+    onUnifiedTraktWatchlistChange: (Boolean) -> Unit,
 ) {
     item {
         SettingsGroup(isTablet = isTablet) {
@@ -144,6 +147,7 @@ internal fun LazyListScope.traktSettingsContent(
                         settingsUiState = settingsUiState,
                         commentsEnabled = commentsEnabled,
                         onCommentsEnabledChange = onCommentsEnabledChange,
+                        onUnifiedTraktWatchlistChange = onUnifiedTraktWatchlistChange,
                     )
                 }
             }
@@ -157,6 +161,7 @@ private fun TraktFeatureRows(
     settingsUiState: TraktSettingsUiState,
     commentsEnabled: Boolean,
     onCommentsEnabledChange: (Boolean) -> Unit,
+    onUnifiedTraktWatchlistChange: (Boolean) -> Unit,
 ) {
     var showLibrarySourceDialog by rememberSaveable { mutableStateOf(false) }
     var showWatchProgressDialog by rememberSaveable { mutableStateOf(false) }
@@ -180,6 +185,16 @@ private fun TraktFeatureRows(
         isTablet = isTablet,
         onClick = { showLibrarySourceDialog = true },
     )
+    if (settingsUiState.librarySourceMode == LibrarySourceMode.TRAKT) {
+        SettingsGroupDivider(isTablet = isTablet)
+        SettingsSwitchRow(
+            title = stringResource(Res.string.trakt_unified_watchlist_title),
+            description = stringResource(Res.string.trakt_unified_watchlist_subtitle),
+            checked = settingsUiState.unifiedTraktWatchlist,
+            isTablet = isTablet,
+            onCheckedChange = onUnifiedTraktWatchlistChange,
+        )
+    }
     SettingsGroupDivider(isTablet = isTablet)
     TraktSettingsActionRow(
         title = stringResource(Res.string.trakt_watch_progress_title),

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/trakt/TraktSettingsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/trakt/TraktSettingsRepository.kt
@@ -59,6 +59,7 @@ data class TraktSettingsUiState(
     val continueWatchingDaysCap: Int = TRAKT_DEFAULT_CONTINUE_WATCHING_DAYS_CAP,
     val librarySourceMode: LibrarySourceMode = DEFAULT_LIBRARY_SOURCE_MODE,
     val moreLikeThisSource: MoreLikeThisSourcePreference = DEFAULT_MORE_LIKE_THIS_SOURCE,
+    val unifiedTraktWatchlist: Boolean = true,
 )
 
 @Serializable
@@ -67,6 +68,7 @@ private data class StoredTraktSettings(
     val continueWatchingDaysCap: Int = TRAKT_DEFAULT_CONTINUE_WATCHING_DAYS_CAP,
     val librarySourceMode: String? = null,
     val moreLikeThisSource: String? = null,
+    val unifiedTraktWatchlist: Boolean? = null,
 )
 
 object TraktSettingsRepository {
@@ -123,6 +125,13 @@ object TraktSettingsRepository {
         persist()
     }
 
+    fun setUnifiedTraktWatchlist(enabled: Boolean) {
+        ensureLoaded()
+        if (_uiState.value.unifiedTraktWatchlist == enabled) return
+        _uiState.value = _uiState.value.copy(unifiedTraktWatchlist = enabled)
+        persist()
+    }
+
     private fun loadFromDisk() {
         hasLoaded = true
 
@@ -142,6 +151,7 @@ object TraktSettingsRepository {
                 continueWatchingDaysCap = normalizeTraktContinueWatchingDaysCap(stored.continueWatchingDaysCap),
                 librarySourceMode = librarySourceModeFromStorage(stored.librarySourceMode),
                 moreLikeThisSource = MoreLikeThisSourcePreference.fromStorage(stored.moreLikeThisSource),
+                unifiedTraktWatchlist = stored.unifiedTraktWatchlist ?: true,
             )
         } else {
             TraktSettingsUiState()
@@ -156,6 +166,7 @@ object TraktSettingsRepository {
                     continueWatchingDaysCap = _uiState.value.continueWatchingDaysCap,
                     librarySourceMode = _uiState.value.librarySourceMode.name,
                     moreLikeThisSource = _uiState.value.moreLikeThisSource.name,
+                    unifiedTraktWatchlist = _uiState.value.unifiedTraktWatchlist,
                 ),
             ),
         )


### PR DESCRIPTION
## Summary

Adds a **Unified Trakt Watchlist** toggle in Settings → Account → Trakt, visible only when Trakt is set as the Library Source. When the toggle is **on** (default), each Trakt list (Watchlist, personal lists, etc.) displays as a single combined section — the original behavior. When the toggle is **off**, each Trakt list is split into two separate sections: "ListName (Movies)" and "ListName (Series)", mirroring how the Nuvio local Library source already groups content.

Internal changes to support this: `LibrarySection` gained a `listKey` field (distinct from `type`) so that "Remove from library" always targets the correct Trakt list key when split mode is active; two helper utilities (`LIBRARY_SECTION_TYPE_SEPARATOR`, `traktListKeyFromSectionType`) were added to `LibraryModels.kt`; `LibraryRepository` gained a reactive collector so the Library screen updates immediately when the toggle is changed without requiring an app restart.

---

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [x] Approved larger or directional change

---

## Why

When using the Trakt Library Source, the Library screen mixed movies and series into a single section per list, while the built-in Nuvio Library source already separates them by content type. Users who prefer the separated layout had no way to achieve this with Trakt. The new toggle gives users the choice while preserving the existing unified behavior as the default so no current experience is disrupted.

---

## Desktop scope

Shared code (`commonMain`) only. The toggle, section-building logic, and `LibrarySection` model are all in `commonMain`.

---

## Scope boundaries

- Trakt syncing, membership API calls, and watchlist/list data fetching are completely unchanged.
- The Nuvio local Library source behavior is unchanged.
- No changes to watch progress, watched state, or any other Trakt feature.
- The "Remove from library" action semantics are preserved: it still targets the specific Trakt list the item belongs to.
- No new network requests or storage schemas introduced; the new boolean field in `StoredTraktSettings` is nullable with a default, so existing saved settings deserialize correctly.

---

## Testing

Tested manually on **Windows 11** using a debug run (`.\gradlew.bat :composeApp:run`) with a live Trakt account:

- Signed in to Trakt, set Library Source → Trakt; confirmed "Unified Trakt Watchlist" toggle appears below the Library Source row.
- Confirmed toggle is hidden when Library Source is set to Nuvio Library.
- With toggle **on**: Library shows one combined section per Trakt list (Watchlist + any personal lists) — matches prior behavior.
- With toggle **off**: each Trakt list splits into "Watchlist (Movies)" and "Watchlist (Series)" sections (and equivalently for personal lists); sections appear immediately without restarting.
- Long-pressed a poster in a split section → "Remove from library" → confirmed item removed from the correct Trakt list.
- Confirmed "View All" on a split section correctly shows only that type's items.
- Confirmed toggling back to **on** immediately restores the combined view.
- `.\gradlew.bat :composeApp:compileKotlinDesktop` → `BUILD SUCCESSFUL`.

---

## Screenshots / Video

<img width="1553" height="630" alt="Screenshot 2026-06-28 200654" src="https://github.com/user-attachments/assets/5b46fcd0-bde0-4bed-8174-d8aebeb30d77" />
<img width="1558" height="731" alt="Screenshot 2026-06-28 200725" src="https://github.com/user-attachments/assets/ae66ad85-049d-4681-8ef1-83c23cf6365d" />
<img width="1920" height="866" alt="Screenshot 2026-06-28 200752" src="https://github.com/user-attachments/assets/da0acd1e-f0f1-4300-a59a-937260e6cc71" />
<img width="1559" height="672" alt="Screenshot 2026-06-28 200600" src="https://github.com/user-attachments/assets/57e9c73d-8cf8-416c-9b9d-37cecbbc41ed" />
<img width="1920" height="882" alt="Screenshot 2026-06-28 200459" src="https://github.com/user-attachments/assets/2cc5037c-582a-48da-a9b5-defd12588363" />


---

## Breaking changes

None. The `unifiedTraktWatchlist` field in persisted settings defaults to `true` (unified), so existing users see no change on first launch after update. The `listKey` field on `LibrarySection` defaults to `type`, leaving all non-Trakt and non-split code paths unaffected.

---

## Linked issues

https://github.com/NuvioMedia/NuvioDesktop/issues/45

---

## Note

This was done with the help of Claude Code. I apologize if I got something wrong. I am just trying to help make this app be the best it can be. If there is something I need to do for this feature to be approved, please let me know.

Thank you for taking a look.