### PR TITLE
fix(player): seek to clicked position on the timeline

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerControls.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerControls.kt
@@ -43,6 +43,8 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -505,14 +507,21 @@ private fun ProgressControls(
     val audioPainter = appIconPainter(AppIconResource.PlayerAudioFilled)
 
     Column(modifier = modifier) {
+        // Track the latest value from onValueChange: on a single track-click the Slider fires
+        // onValueChange then onValueChangeFinished within one frame, before displayedPositionMs
+        // recomposes — so seeking to displayedPositionMs would use the stale (pre-click) position.
+        val pendingScrubMs = remember { mutableStateOf(displayedPositionMs) }
         Slider(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(metrics.sliderTouchHeight)
                 .graphicsLayer(scaleY = metrics.sliderScaleY),
             value = displayedPositionMs.coerceIn(0L, durationMs).toFloat(),
-            onValueChange = { value -> onScrubChange(value.toLong()) },
-            onValueChangeFinished = { onScrubFinished(displayedPositionMs.coerceIn(0L, durationMs)) },
+            onValueChange = { value ->
+                pendingScrubMs.value = value.toLong()
+                onScrubChange(value.toLong())
+            },
+            onValueChangeFinished = { onScrubFinished(pendingScrubMs.value.coerceIn(0L, durationMs)) },
             valueRange = 0f..durationMs.toFloat(),
         )
         Row(


### PR DESCRIPTION
## Why
Clicking somewhere on the playback timeline (instead of dragging the thumb) did not seek — the playhead snapped back. Only dragging worked. Most noticeable on desktop with a mouse, but the bug is in common code.

## Root cause
`Slider.onValueChangeFinished` seeked to `displayedPositionMs` (= `scrubbingPositionMs ?: playbackSnapshot.positionMs`). On a single track-click the Slider fires `onValueChange` then `onValueChangeFinished` within one frame — before recomposition updates `displayedPositionMs` — so it seeked to the stale pre-click position. Dragging worked because its many `onValueChange` events recompose between frames.

## Fix
Remember the latest value from `onValueChange` and seek to that in `onValueChangeFinished`. One file, `PlayerControls.kt` (commonMain).

## Testing
Verified on Linux desktop (AMD, KDE Plasma): clicking anywhere on the timeline now seeks there; dragging still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpeWTpQt1uRvEEkDYAeULP
