### PR TITLE
feat(player): hide controls faster (2s) on desktop

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeEffects.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeEffects.kt
@@ -287,7 +287,8 @@ private fun PlayerScreenRuntime.BindPlayerUiVisibilityEffects() {
         ) {
             return@LaunchedEffect
         }
-        delay(3500)
+        // Desktop hides faster after the cursor stops/leaves; touch keeps the longer dwell.
+        delay(if (isDesktop) 2000 else 3500)
         controlsVisible = false
     }
 


### PR DESCRIPTION
## Why
On desktop the control overlay lingered ~3.5s after the cursor stopped/left the player, which feels sluggish with a mouse.

## Change
Reduce the inactivity auto-hide to 2s on desktop, scoped via the existing `isDesktop` flag. Touch platforms keep the 3.5s dwell (longer is appropriate for tap interaction). One file, `PlayerScreenRuntimeEffects.kt` (commonMain).

## Testing
Verified on Linux desktop: controls hide ~2s after the cursor goes idle/leaves; the timer still resets on activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpeWTpQt1uRvEEkDYAeULP
