### PR TITLE
feat(player): toggle play/pause with Space on desktop

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
@@ -650,6 +650,9 @@ private fun PlayerScreenRuntime.handlePlayerControlsEvent(type: String, value: D
         "hideChrome" -> {
             controlsVisible = false
         }
+        "togglePlayback" -> {
+            if (!playerControlsLocked) togglePlayback()
+        }
         "keepChromeVisible" -> {
             controlsVisible = true
             controlsActivityTick += 1

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/PlayerEngine.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/PlayerEngine.desktop.kt
@@ -24,6 +24,10 @@ import com.nuvio.app.features.player.desktop.DesktopPlayerLaunchShield
 import com.nuvio.app.features.player.desktop.NativePlayerController
 import com.nuvio.app.features.player.desktop.NativePlayerHost
 import com.nuvio.app.features.player.desktop.desktopFullscreenChanges
+import java.awt.KeyEventDispatcher
+import java.awt.KeyboardFocusManager
+import java.awt.event.KeyEvent
+import javax.swing.text.JTextComponent
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.drop
 
@@ -50,6 +54,8 @@ actual fun PlatformPlayerSurface(
     onSnapshot: (PlayerPlaybackSnapshot) -> Unit,
     onError: (String?) -> Unit,
 ) {
+    DesktopSpaceTogglesPlayback(onPlayerControlsEvent)
+
     if (DesktopHostOs.current == DesktopHostOs.MACOS || DesktopHostOs.current == DesktopHostOs.WINDOWS) {
         NativePlayerSurface(
             sourceUrl = sourceUrl,
@@ -75,6 +81,34 @@ actual fun PlatformPlayerSurface(
         onControllerReady = onControllerReady,
         onSnapshot = onSnapshot,
     )
+}
+
+/**
+ * Space toggles play/pause for any desktop player surface. Uses a global
+ * KeyEventDispatcher (not an AWTEventListener) so the event can be consumed —
+ * otherwise Space would also activate a focused button or scroll the page.
+ * Debounced by event timestamp to ignore key auto-repeat (X11 emits repeated
+ * press/release pairs while held), and skips text components so Space still
+ * types in inputs (e.g. subtitle search).
+ */
+@Composable
+private fun DesktopSpaceTogglesPlayback(onPlayerControlsEvent: (String, Double) -> Boolean) {
+    val latestOnEvent = rememberUpdatedState(onPlayerControlsEvent)
+    DisposableEffect(Unit) {
+        val kfm = KeyboardFocusManager.getCurrentKeyboardFocusManager()
+        var lastToggle = 0L
+        val dispatcher = KeyEventDispatcher { e ->
+            if (e.keyCode != KeyEvent.VK_SPACE) return@KeyEventDispatcher false
+            if (kfm.focusOwner is JTextComponent) return@KeyEventDispatcher false
+            if (e.id == KeyEvent.KEY_PRESSED && e.getWhen() - lastToggle > 300L) {
+                lastToggle = e.getWhen()
+                latestOnEvent.value("togglePlayback", 0.0)
+            }
+            true
+        }
+        kfm.addKeyEventDispatcher(dispatcher)
+        onDispose { kfm.removeKeyEventDispatcher(dispatcher) }
+    }
 }
 
 @Composable


### PR DESCRIPTION
## Why
No keyboard shortcut to play/pause on the desktop player. Space is the universal expectation.

## Change
Install a global `KeyEventDispatcher` at the shared desktop entry (`PlatformPlayerSurface`) so Space toggles play/pause on all desktop surfaces. Details:
- Uses a `KeyEventDispatcher` (not an `AWTEventListener`) so the event is **consumed** — Space won't also activate a focused button or scroll.
- **Debounced** by event timestamp to ignore key auto-repeat (X11 emits repeated press/release pairs while held).
- **Skips text components** (`JTextComponent` focus) so Space still types in inputs (e.g. subtitle search).
- Wires a new `"togglePlayback"` controls event in common code that calls the existing `togglePlayback()`.

## Testing
Verified on **Linux** desktop (AMD, KDE Plasma): Space toggles play/pause, no double-toggle on hold, typing in inputs unaffected.
⚠️ macOS/Windows use the native player surface (`NativePlayerSurface`); the dispatcher is installed for them too but I could not test those platforms — maintainer verification on macOS/Windows appreciated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpeWTpQt1uRvEEkDYAeULP
