### PR TITLE
Fix plugin provider freeze caused by blocking fetch on the QuickJS runtime thread

### DIFF
--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/runtime/js/JsBindings.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/runtime/js/JsBindings.kt
@@ -47,7 +47,7 @@ internal object JsBindings {
             var headers = __normalize_fetch_headers(options.headers);
             var body = options.body || '';
             var followRedirects = options.redirect !== 'manual';
-            var result = __native_fetch(url, method, JSON.stringify(headers), body, followRedirects);
+            var result = await __native_fetch(url, method, JSON.stringify(headers), body, followRedirects);
             var parsed = JSON.parse(result);
             return {
                 ok: parsed.ok,

--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/runtime/network/FetchBridge.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/runtime/network/FetchBridge.kt
@@ -2,10 +2,10 @@ package com.nuvio.app.features.plugins.runtime.network
 
 import co.touchlab.kermit.Logger
 import com.dokar.quickjs.QuickJs
-import com.dokar.quickjs.binding.function
+import com.dokar.quickjs.binding.asyncFunction
 import com.nuvio.app.features.addons.httpRequestRaw
 import com.nuvio.app.features.plugins.runtime.host.HostModule
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -20,7 +20,7 @@ internal class FetchBridge : HostModule {
     private val json = Json { ignoreUnknownKeys = true }
 
     override fun register(runtime: QuickJs) {
-        runtime.function("__native_fetch") { args ->
+        runtime.asyncFunction("__native_fetch") { args ->
             val url = args.getOrNull(0)?.toString() ?: ""
             val method = args.getOrNull(1)?.toString() ?: "GET"
             val headersJson = args.getOrNull(2)?.toString() ?: "{}"
@@ -28,6 +28,8 @@ internal class FetchBridge : HostModule {
             val followRedirects = args.getOrNull(4) as? Boolean ?: true
             try {
                 performNativeFetch(url, method, headersJson, body, followRedirects)
+            } catch (ce: CancellationException) {
+                throw ce
             } catch (t: Throwable) {
                 log.e(t) { "Fetch bridge error for $method $url" }
                 JsonObject(
@@ -44,7 +46,7 @@ internal class FetchBridge : HostModule {
         }
     }
 
-    private fun performNativeFetch(
+    private suspend fun performNativeFetch(
         url: String,
         method: String,
         headersJson: String,
@@ -56,15 +58,13 @@ internal class FetchBridge : HostModule {
             headers["User-Agent"] = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
         }
 
-        val response = runBlocking {
-            httpRequestRaw(
-                method = method,
-                url = url,
-                headers = headers,
-                body = body,
-                followRedirects = followRedirects,
-            )
-        }
+        val response = httpRequestRaw(
+            method = method,
+            url = url,
+            headers = headers,
+            body = body,
+            followRedirects = followRedirects,
+        )
 
         val responseHeaders = response.headers.mapKeys { (key, _) -> key.lowercase() }
             .mapValues { (_, value) -> truncateString(value, MAX_FETCH_HEADER_VALUE_CHARS) }


### PR DESCRIPTION
## Summary

Fixes a freeze where JS **plugin** scrapers stop returning streams after a while and only recover after a full app restart. The streams screen gets stuck in the loading state and no plugin ever completes, even though the same providers worked moments earlier.

The root cause is in the plugin runtime's fetch bridge: `__native_fetch` was a synchronous binding that wrapped the suspending `httpRequestRaw` in `runBlocking`, so every plugin network request blocked a `Dispatchers.Default` thread for the whole request and ignored cancellation. Under concurrency (or a stalled endpoint) the bounded Default pool gets fully blocked and the runtime can no longer make progress.

This PR binds `__native_fetch` as an async (suspend) binding and calls `httpRequestRaw` directly (no `runBlocking`), and `await`s it from the JS `fetch` polyfill.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

`JsRuntime` runs QuickJS on the shared `Dispatchers.Default` dispatcher:

```kotlin
// JsRuntime.kt
quickJs(dispatcher) { block() } // dispatcher = Dispatchers.Default
```

`FetchBridge` then registered the network entry point as a **synchronous** function that blocks on the suspending HTTP call:

```kotlin
// before
runtime.function("__native_fetch") { args ->
    ...
    performNativeFetch(...) // val response = runBlocking { httpRequestRaw(...) }
}
```

Consequences:

- Each plugin `fetch()` parks one `Dispatchers.Default` thread for the entire request duration.
- `Dispatchers.Default` is bounded by the CPU core count, so a handful of concurrent or slow plugin requests can block every thread in the pool at once.
- `runBlocking` does not observe coroutine cancellation, so neither the per-plugin `withTimeout(PLUGIN_TIMEOUT_MS)` in `PluginRuntime` nor `activeJob.cancel()` in `StreamsRepository` can interrupt an in-flight request.

Once the pool is starved, no other coroutine scheduled on `Dispatchers.Default` can run and the plugin runtime appears frozen until the process is restarted. This is easy to hit when several plugins run together (e.g. moving to the next episode a few times) or when a provider talks to a slow/cold endpoint.

### Old vs new behavior

- **Old:** a plugin network call blocks a Default-pool thread until it returns; enough concurrent/slow calls starve the dispatcher and freeze all plugins until restart.
- **Broken/unwanted:** plugins stop returning streams; timeouts and cancellation have no effect; only a restart recovers.
- **New:** the network call suspends instead of holding a thread, so the dispatcher keeps making progress, and `withTimeout` / cancellation can actually interrupt a stuck request.

## The fix

`composeApp/src/fullCommonMain/kotlin/.../network/FetchBridge.kt`
- Register `__native_fetch` with `asyncFunction` instead of `function`.
- Make `performNativeFetch` a `suspend` function and call `httpRequestRaw(...)` directly instead of through `runBlocking`.
- Rethrow `CancellationException` so cancellation is not swallowed by the existing error-mapping `catch`.

`composeApp/src/fullCommonMain/kotlin/.../js/JsBindings.kt`
- `await __native_fetch(...)` in the `fetch` polyfill, since the binding now returns a promise. The polyfill function is already `async`, so this is a one-line change.

No public API, dependency, or architecture change. `quickjs-kt` already supports async bindings (`asyncFunction`), so no new dependency is introduced.

## Desktop scope

The changed files are in the plugin runtime (`fullCommonMain`) used by the desktop app. This is a desktop stability fix for installed JS scrapers.

## Issue or approval

Related to #78 (same user-visible symptom: provider requests stop working until the app is restarted). That report and #104 target the addon HTTP path (socket/port exhaustion from per-request `HttpClient`); this PR fixes a **separate** root cause in the plugin runtime (Default-pool starvation from blocking fetch), so the two are complementary and do not overlap in code.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression

## Testing

- Built and ran the desktop app on macOS (Apple Silicon).
- Before: after a few rounds of concurrent plugin fetches (switching episodes), plugins stopped returning streams and the screen stayed in the loading state until restart.
- After: plugins keep returning streams; a single slow/stalled request times out on its own without taking down the rest of the runtime, and switching episodes repeatedly no longer freezes plugin fetching.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app and shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Behavior change fixes a documented bug/regression.
- [x] This PR does not bundle unrelated refactors, cleanups, or formatting.
- [x] This PR does not add dependencies, architecture changes, or migrations.
- [x] I listed the testing performed above.

Made with [Cursor](https://cursor.com)