### PR TITLE
fix(desktop): restore window fullscreen state and position/size on relaunch

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
@@ -5,14 +5,20 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.WindowPlacement
+import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
 import androidx.compose.ui.unit.dp
 import com.nuvio.app.features.player.PlatformPlayerSurface
 import com.nuvio.app.features.player.desktop.DesktopAppFullscreenController
+import com.nuvio.app.features.player.desktop.DesktopHostOs
+import com.nuvio.app.features.player.desktop.DesktopWindowGeometry
+import com.nuvio.app.features.player.desktop.DesktopWindowModeStorage
 import com.nuvio.app.features.player.desktop.applyNativeDesktopWindowChrome
 import com.nuvio.app.features.player.desktop.installDesktopAppFullscreenShortcuts
 import com.nuvio.app.features.player.desktop.preloadNativePlayerBridgeAsync
@@ -30,11 +36,25 @@ fun main() {
 
     application {
         val smokePlayerUrl = (
-            System.getProperty("nuvio.desktop.smokePlayerUrl")
-                ?: System.getenv("NUVIO_DESKTOP_SMOKE_PLAYER_URL")
-            )
+                System.getProperty("nuvio.desktop.smokePlayerUrl")
+                    ?: System.getenv("NUVIO_DESKTOP_SMOKE_PLAYER_URL")
+                )
             ?.takeIf { it.isNotBlank() }
-        val windowState = rememberWindowState(width = 1280.dp, height = 820.dp)
+        val wasFullscreenOnLastExit = remember { DesktopWindowModeStorage.loadWasFullscreen() }
+        val savedGeometry = remember { DesktopWindowModeStorage.loadWindowedGeometry() }
+        val windowState = rememberWindowState(
+            width = savedGeometry?.width?.dp ?: 1280.dp,
+            height = savedGeometry?.height?.dp ?: 820.dp,
+            position = savedGeometry?.let { WindowPosition.Absolute(x = it.x.dp, y = it.y.dp) }
+                ?: WindowPosition.PlatformDefault,
+            // Windows fullscreen is emulated natively (see DesktopAppFullscreenController)
+            // rather than driven by WindowPlacement, so it's restored separately below.
+            placement = if (wasFullscreenOnLastExit && DesktopHostOs.current != DesktopHostOs.WINDOWS) {
+                WindowPlacement.Fullscreen
+            } else {
+                WindowPlacement.Floating
+            },
+        )
         val fullscreenController = remember { DesktopAppFullscreenController() }
 
         Window(
@@ -51,17 +71,50 @@ fun main() {
             }
             LaunchedEffect(window) {
                 applyNativeDesktopWindowChrome(window)
+                // Windows fullscreen is emulated natively and isn't reflected by
+                // WindowPlacement, so it must be re-applied once the window peer exists.
+                fullscreenController.applyRestoredFullscreenState(window, windowState, wasFullscreenOnLastExit)
+            }
+            LaunchedEffect(windowState) {
+                // Covers OS-driven placement changes too (e.g. the native macOS
+                // green-button fullscreen toggle), not just our own shortcuts.
+                if (DesktopHostOs.current != DesktopHostOs.WINDOWS) {
+                    snapshotFlow { windowState.placement }
+                        .collect { placement ->
+                            DesktopWindowModeStorage.saveWasFullscreen(placement == WindowPlacement.Fullscreen)
+                        }
+                }
+            }
+            LaunchedEffect(windowState) {
+                // Only persist geometry while windowed: fullscreen/native-Windows-fullscreen
+                // coordinates aren't a meaningful "windowed position" to restore later.
+                snapshotFlow { Triple(windowState.placement, windowState.position, windowState.size) }
+                    .collect { (placement, position, size) ->
+                        if (placement == WindowPlacement.Floating && position.isSpecified) {
+                            DesktopWindowModeStorage.saveWindowedGeometry(
+                                DesktopWindowGeometry(
+                                    x = position.x.value,
+                                    y = position.y.value,
+                                    width = size.width.value,
+                                    height = size.height.value,
+                                ),
+                            )
+                        }
+                    }
             }
             DisposableEffect(window, windowState) {
                 val unregisterFullscreenToggle = registerDesktopAppFullscreenToggle(
                     handler = { targetWindow ->
                         if (targetWindow == null || targetWindow === window) {
                             fullscreenController.toggle(window, windowState)
+                            DesktopWindowModeStorage.saveWasFullscreen(
+                                fullscreenController.isFullscreen(window, windowState),
+                            )
                         }
                     },
                     isFullscreen = { targetWindow ->
                         (targetWindow == null || targetWindow === window) &&
-                            fullscreenController.isFullscreen(window, windowState)
+                                fullscreenController.isFullscreen(window, windowState)
                     },
                 )
                 val uninstallFullscreenShortcuts = installDesktopAppFullscreenShortcuts(window)

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopAppFullscreen.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopAppFullscreen.kt
@@ -87,6 +87,23 @@ internal class DesktopAppFullscreenController {
         exitWindowsFullscreen(window)
     }
 
+    /**
+     * Applies a fullscreen state restored from a previous session, before the
+     * window has been interacted with. Only acts when [fullscreen] is true;
+     * windowed is already the default state for a freshly created window.
+     */
+    fun applyRestoredFullscreenState(window: Window, windowState: WindowState, fullscreen: Boolean) {
+        if (!fullscreen) return
+        if (DesktopHostOs.current == DesktopHostOs.WINDOWS) {
+            enterWindowsFullscreen(window)
+        } else {
+            restoreWindowPlacement = windowState.placement
+                .takeUnless { it == WindowPlacement.Fullscreen }
+                ?: WindowPlacement.Floating
+            windowState.placement = WindowPlacement.Fullscreen
+        }
+    }
+
     fun isFullscreen(window: Window, windowState: WindowState): Boolean =
         if (DesktopHostOs.current == DesktopHostOs.WINDOWS) {
             windowsFullscreenState?.window === window

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopWindowModeStorage.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopWindowModeStorage.kt
@@ -1,0 +1,49 @@
+package com.nuvio.app.features.player.desktop
+
+import com.nuvio.app.core.storage.DesktopStorage
+
+/**
+ * Persists desktop window mode/geometry across launches:
+ * - whether the app was last closed in fullscreen mode
+ * - the last windowed (non-fullscreen) position and size
+ *
+ * This is intentionally a global (non profile-scoped) preference: it reflects
+ * the state of the OS window itself rather than per-user app data.
+ */
+internal data class DesktopWindowGeometry(
+    val x: Float,
+    val y: Float,
+    val width: Float,
+    val height: Float,
+)
+
+internal object DesktopWindowModeStorage {
+    private const val WasFullscreenKey = "was_fullscreen"
+    private const val WindowXKey = "window_x"
+    private const val WindowYKey = "window_y"
+    private const val WindowWidthKey = "window_width"
+    private const val WindowHeightKey = "window_height"
+    private val store = DesktopStorage.store("nuvio_window_state")
+
+    fun loadWasFullscreen(): Boolean =
+        store.getBoolean(WasFullscreenKey) ?: false
+
+    fun saveWasFullscreen(fullscreen: Boolean) {
+        store.putBoolean(WasFullscreenKey, fullscreen)
+    }
+
+    fun loadWindowedGeometry(): DesktopWindowGeometry? {
+        val x = store.getFloat(WindowXKey) ?: return null
+        val y = store.getFloat(WindowYKey) ?: return null
+        val width = store.getFloat(WindowWidthKey) ?: return null
+        val height = store.getFloat(WindowHeightKey) ?: return null
+        return DesktopWindowGeometry(x = x, y = y, width = width, height = height)
+    }
+
+    fun saveWindowedGeometry(geometry: DesktopWindowGeometry) {
+        store.putFloat(WindowXKey, geometry.x)
+        store.putFloat(WindowYKey, geometry.y)
+        store.putFloat(WindowWidthKey, geometry.width)
+        store.putFloat(WindowHeightKey, geometry.height)
+    }
+}


### PR DESCRIPTION
## Summary

The desktop app's window state (fullscreen vs. windowed, and windowed position/size) was not persisted across launches. Every launch opened windowed, at a default size, positioned in the top-left corner, regardless of how the window was left in the previous session.

This PR adds a small persistence layer (`DesktopWindowModeStorage`) that saves the window's mode (fullscreen/windowed) and windowed geometry (x, y, width, height) to local app storage whenever they change, and restores them the next time the app launches — before the first frame is drawn, so this applies to the app's single top-level window from startup regardless of which screen is shown first.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

On every launch, the desktop app ignored how the user last left the window and always opened windowed, at a fixed default size, anchored to the top-left corner of the screen. Users who work in fullscreen, or who position/resize the window to a preferred spot, had to redo that setup every single time they opened the app. This is a reproducible, user-visible annoyance with no workaround, and standard desktop-app behavior is to remember window placement across launches.

## Desktop scope

Affects all desktop platforms (Windows, macOS, Linux), since the change lives in `desktopMain`'s single application entry point (`Main.kt`) and the shared `DesktopAppFullscreenController`.

- **Windows**: fullscreen is emulated natively (borderless window trick) rather than via Compose's `WindowPlacement`, so restoring it requires calling into `DesktopAppFullscreenController` once the native window peer exists (`window.isDisplayable`), which is handled in a `LaunchedEffect(window)`.
- **macOS/Linux**: fullscreen is native `WindowPlacement.Fullscreen`, so it can be set directly at `rememberWindowState` creation time. Also listens for OS-driven fullscreen changes (e.g. the native macOS green-button toggle) via `snapshotFlow` so those get persisted too, not just app-triggered toggles.
- Windowed position/size is restored/saved identically across all three platforms via Compose's `WindowState.position`/`WindowState.size`, gated to only persist while `placement == Floating` so fullscreen coordinates never overwrite the last real windowed position.

## Issue or approval

Fixes #30, Fixes #193 

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

- No new dependencies added; reuses the existing `DesktopStorage` key-value persistence utility already used elsewhere in the desktop codebase (e.g. `ThemeSettingsStorage`).
- No changes to fullscreen *toggle* behavior (F11 / Cmd+Ctrl+F) itself, only to what gets remembered across launches.
- No changes to any other window chrome, styling, or layout.
- Multi-monitor edge cases (e.g. restoring a position on a monitor that's since been disconnected) are not specifically handled; Compose's own window placement clamping applies as before.

## Testing

Manually tested on Windows 10/11 (via `.\gradlew.bat :composeApp:run` and a packaged `.msi` build):
- Toggled fullscreen (F11), closed the app, relaunched — reopened in fullscreen.
- Exited fullscreen (F11), closed, relaunched — reopened windowed.
- Moved and resized the window to a custom position/size, closed, relaunched — reopened at the same position and size.
- Went fullscreen then exited — window returned to the last saved windowed position rather than a default/top-left position.
- Verified first-ever launch (no prior saved state) still falls back to the previous default behavior (1280×820, platform-default position).

## Screenshots / Video

Not a UI change

## Breaking changes

None.

## Linked issues

Fixes #30
Fixes #193
