### PR TITLE
fix(desktop): now the clear logo of movies/TV shows visible in hero section of home

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeRepository.kt
@@ -11,6 +11,8 @@ import com.nuvio.app.features.collection.CollectionSource
 import com.nuvio.app.features.collection.TmdbCollectionSourceResolver
 import com.nuvio.app.features.collection.catalogRouteKey
 import com.nuvio.app.features.collection.findCollectionCatalog
+import com.nuvio.app.features.tmdb.TmdbMetadataService
+import com.nuvio.app.features.tmdb.TmdbSettingsRepository
 import com.nuvio.app.features.trakt.TraktPublicListSourceResolver
 import com.nuvio.app.features.watchprogress.CurrentDateProvider
 import kotlinx.coroutines.CoroutineScope
@@ -42,6 +44,8 @@ object HomeRepository {
     private var collectionHeroRequestKey: String? = null
     private var lastPublishedCatalogHeroEmpty: Boolean = true
     private var lastErrorMessage: String? = null
+    private var heroLogoCache: Map<String, String?> = emptyMap()
+    private var heroLogoJob: Job? = null
 
     fun refresh(addons: List<ManagedAddon>, force: Boolean = false) {
         val activeAddons = addons.enabledAddons()
@@ -182,6 +186,9 @@ object HomeRepository {
         collectionHeroRequestKey = null
         lastPublishedCatalogHeroEmpty = true
         lastErrorMessage = null
+        heroLogoCache = emptyMap()
+        heroLogoJob?.cancel()
+        heroLogoJob = null
         _uiState.value = HomeUiState()
     }
 
@@ -227,7 +234,7 @@ object HomeRepository {
         }
         lastPublishedCatalogHeroEmpty = snapshot.heroEnabled && catalogHeroItems.isEmpty()
         val heroItems = if (snapshot.heroEnabled) {
-            catalogHeroItems.ifEmpty { cachedCollectionHeroItems }
+            catalogHeroItems.ifEmpty { cachedCollectionHeroItems }.map { it.withCachedHeroLogo() }
         } else {
             emptyList()
         }
@@ -238,6 +245,47 @@ object HomeRepository {
             sections = sections,
             errorMessage = if (sections.isEmpty()) lastErrorMessage else null,
         )
+
+        if (snapshot.heroEnabled && heroItems.isNotEmpty()) {
+            ensureHeroLogos(items = heroItems, requestKey = requestKey)
+        }
+    }
+
+    private fun MetaPreview.withCachedHeroLogo(): MetaPreview {
+        if (!logo.isNullOrBlank()) return this
+        val cachedLogo = heroLogoCache[stableKey()] ?: return this
+        return copy(logo = cachedLogo)
+    }
+
+    private fun ensureHeroLogos(items: List<MetaPreview>, requestKey: String?) {
+        val settings = TmdbSettingsRepository.snapshot()
+        if (!settings.enabled || !settings.hasApiKey || !settings.useArtwork) return
+
+        val pending = items.filter { item ->
+            item.logo.isNullOrBlank() && !heroLogoCache.containsKey(item.stableKey())
+        }
+        if (pending.isEmpty()) return
+
+        heroLogoJob?.cancel()
+        heroLogoJob = scope.launch {
+            val results = pending.map { item ->
+                async {
+                    item.stableKey() to runCatching {
+                        TmdbMetadataService.fetchLogo(
+                            type = item.type,
+                            id = item.id,
+                            settings = settings,
+                        )
+                    }.getOrNull()
+                }
+            }.awaitAll()
+
+            heroLogoCache = heroLogoCache + results.toMap()
+            publishCurrentState(
+                isLoading = _uiState.value.isLoading,
+                requestKey = requestKey,
+            )
+        }
     }
 
     private suspend fun HomeCatalogDefinition.toSection(): HomeCatalogSection {
@@ -340,7 +388,7 @@ object HomeRepository {
         return CollectionRepository.collections.value
             .filter { collection ->
                 collection.folders.isNotEmpty() &&
-                    preferences["collection_${collection.id}"]?.enabled != false
+                        preferences["collection_${collection.id}"]?.enabled != false
             }
             .sortedBy { collection ->
                 preferences["collection_${collection.id}"]?.order ?: Int.MAX_VALUE

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt
@@ -36,6 +36,41 @@ object TmdbMetadataService {
     private val entityBrowseCache = mutableMapOf<String, TmdbEntityBrowseData>()
     private val entityHeaderCache = mutableMapOf<String, TmdbEntityHeader>()
     private val entityRailCache = mutableMapOf<String, List<MetaPreview>>()
+    private val logoCache = mutableMapOf<String, String?>()
+
+    /**
+     * Lightweight variant of [enrichMeta] that only hits the `/images` endpoint,
+     * skipping details/credits/episodes/etc. Used to backfill missing clearlogos
+     * (e.g. for Home hero items whose catalog payload has no logo field).
+     */
+    suspend fun fetchLogo(
+        type: String,
+        id: String,
+        settings: TmdbSettings,
+    ): String? {
+        if (!settings.enabled || !settings.hasApiKey || !settings.useArtwork) return null
+
+        val tmdbType = normalizeMetaType(type)
+        val tmdbId = TmdbService.ensureTmdbId(id, tmdbType) ?: return null
+        val normalizedLanguage = normalizeTmdbLanguage(settings.language)
+        val cacheKey = "$tmdbId:$tmdbType:$normalizedLanguage"
+        if (logoCache.containsKey(cacheKey)) return logoCache[cacheKey]
+
+        val numericId = tmdbId.toIntOrNull() ?: return null
+        val includeImageLanguage = buildString {
+            append(normalizedLanguage.substringBefore("-"))
+            append(",")
+            append(normalizedLanguage)
+            append(",en,null")
+        }
+        val images = fetch<TmdbImagesResponse>(
+            endpoint = "$tmdbType/$numericId/images",
+            query = mapOf("include_image_language" to includeImageLanguage),
+        )
+        val logo = buildImageUrl(images?.logos.orEmpty().selectBestLocalizedImagePath(normalizedLanguage), "w500")
+        logoCache[cacheKey] = logo
+        return logo
+    }
 
     suspend fun fetchPersonDetail(
         personId: Int,
@@ -1166,27 +1201,27 @@ internal data class TmdbEnrichment(
 ) {
     fun hasContent(): Boolean =
         localizedTitle != null ||
-            description != null ||
-            genres.isNotEmpty() ||
-            backdrop != null ||
-            logo != null ||
-            poster != null ||
-            people.isNotEmpty() ||
-            director.isNotEmpty() ||
-            writer.isNotEmpty() ||
-            releaseInfo != null ||
-            lastAirDate != null ||
-            rating != null ||
-            runtimeMinutes != null ||
-            ageRating != null ||
-            status != null ||
-            countries.isNotEmpty() ||
-            language != null ||
-            productionCompanies.isNotEmpty() ||
-            networks.isNotEmpty() ||
-            collectionItems.isNotEmpty() ||
-            moreLikeThis.isNotEmpty() ||
-            trailers.isNotEmpty()
+                description != null ||
+                genres.isNotEmpty() ||
+                backdrop != null ||
+                logo != null ||
+                poster != null ||
+                people.isNotEmpty() ||
+                director.isNotEmpty() ||
+                writer.isNotEmpty() ||
+                releaseInfo != null ||
+                lastAirDate != null ||
+                rating != null ||
+                runtimeMinutes != null ||
+                ageRating != null ||
+                status != null ||
+                countries.isNotEmpty() ||
+                language != null ||
+                productionCompanies.isNotEmpty() ||
+                networks.isNotEmpty() ||
+                collectionItems.isNotEmpty() ||
+                moreLikeThis.isNotEmpty() ||
+                trailers.isNotEmpty()
 }
 
 private data class EnrichmentPayload(


### PR DESCRIPTION
## Summary

Fixes missing clearlogos on the Home screen hero section. Hero items were falling back to plain text titles because the catalog JSON from most addons (Cinemeta, etc.) doesn't include a logo field on list responses — only the Details screen's TMDB enrichment fetched logos. Added a lightweight TMDB logo backfill: TmdbMetadataService.fetchLogo() hits only the /images endpoint (no details/credits/episodes), and HomeRepository caches results by item key and republishes hero state once logos resolve, so the clearlogo pops in shortly after first paint instead of the title staying as text forever.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

On the desktop Home screen, the hero section is supposed to show each title's clearlogo (per DesktopHeroContentBlock's existing fallback logic), but it always rendered plain text instead. Root cause: item.logo was null because catalog list payloads rarely include a logo field, and the app's existing TMDB enrichment pipeline (which does have logos) was never invoked for Home hero items — only for the Details screen. This fix wires Home into the same TMDB artwork settings already used elsewhere, with no new enrichment pattern introduced.

## Desktop scope

This affects commonMain shared code (HomeRepository.kt, TmdbMetadataService.kt) that backs the desktop Home hero section (HomeHeroSection.kt / DesktopHeroContentBlock). The shared code change is required because the hero data pipeline (catalog fetch → TMDB enrichment → published UI state) lives in commonMain and is consumed directly by the desktop hero composable; there is no desktop-only code path for this data flow.

## Issue or approval

Fixes #157

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

- No changes to HomeHeroSection.kt — its logo-rendering/fallback logic was already correct and untouched.
- No changes to hero layout, sizing, animation, or other visual styling.
- No new enrichment pattern introduced; reuses the existing TmdbSettingsRepository / TmdbMetadataService artwork pipeline as-is.
- Continue Watching / other rails are intentionally not covered by this fix (separate, unapproved follow-up).
- No changes to mobile-specific (HeroContentBlock) rendering path beyond it also benefiting from the same shared cache.

## Testing

- Manually verified: with TMDB enabled + API key + "Use Artwork" on, hero items missing logo from catalog JSON now display the clearlogo shortly after initial paint, with title text as instant first-paint fallback (no added latency).
- Verified with TMDB disabled / no API key: behavior unchanged, falls back to text title (no crash, no unnecessary network calls — fetchLogo early-returns).
- Verified repeat renders (e.g. toggling settings, revisiting Home) apply cached logos instantly via heroLogoCache without re-fetching.
- Verified clear() resets heroLogoCache/heroLogoJob correctly (e.g. on sign-out/profile switch) with no stale logos leaking across profiles.
- Reviewed final HomeRepository.kt and TmdbMetadataService.kt for logical/compile correctness (existing awaitAll/async imports reused, no new imports needed beyond TmdbMetadataService/TmdbSettingsRepository).

## Screenshots / Video

| Before | After |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/5649f0e4-53a9-4f2a-91e8-a78fdd87ed0c" width="600" alt="Before Update" /> | <img src="https://github.com/user-attachments/assets/9a1b63de-5d79-415f-96cb-49aa4f1f64d0" width="600" alt="After Update" /> |


## Breaking changes

<!-- Any breaking behavior/config/schema changes? If none, write: None. -->

## Linked issues

Fixes #157
