### PR TITLE
fix(player): open audio/subtitle/source panels near their button, not screen center

### DIFF
--- a/composeApp/src/desktopMain/resources/player-ui/controls.css
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.css
@@ -1665,6 +1665,11 @@ button:disabled {
   transition: opacity var(--motion-standard) ease;
 }
 
+.modal-layer.modal-anchored {
+  display: block;
+  place-items: unset;
+}
+
 .modal-layer.modal-visible {
   opacity: 1;
   pointer-events: auto;
@@ -1687,21 +1692,32 @@ button:disabled {
   color: #fff;
   box-shadow: 0 20px 70px rgba(0, 0, 0, .45);
   opacity: 0;
-  transform: translateY(14px) scale(.985);
+  transform: translateX(var(--anchor-shift, 0)) translateY(14px) scale(.985);
   transition:
     transform var(--motion-panel) var(--ease-out),
     opacity var(--motion-standard) ease;
   will-change: transform, opacity;
 }
 
+/* Anchored modals (audio/subtitles/sources/episodes) open near the
+   trigger button instead of the center of the screen, so the mouse
+   doesn't have to travel across the whole player to reach them. */
+.modal-layer.modal-anchored .track-panel {
+  position: absolute;
+  left: var(--anchor-left, 50%);
+  bottom: var(--anchor-bottom, 24px);
+  top: auto;
+  --anchor-shift: -50%;
+}
+
 .modal-layer.modal-visible .track-panel {
   opacity: 1;
-  transform: translateY(0) scale(1);
+  transform: translateX(var(--anchor-shift, 0)) translateY(0) scale(1);
 }
 
 .modal-layer.modal-closing .track-panel {
   opacity: 0;
-  transform: translateY(10px) scale(.99);
+  transform: translateX(var(--anchor-shift, 0)) translateY(10px) scale(.99);
 }
 
 .track-panel.wide {
@@ -2342,6 +2358,16 @@ button.action:focus-visible {
 
   .modal-layer {
     padding: 14px;
+  }
+
+  .modal-layer.modal-anchored {
+    display: grid;
+    place-items: center;
+  }
+
+  .modal-layer.modal-anchored .track-panel {
+    position: static;
+    --anchor-shift: 0;
   }
 
   .episode-thumb {

--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -856,6 +856,64 @@ const closePlayerModal = (notifyDismiss = false, animated = true) => {
   renderChrome();
 };
 
+// Modals opened from an action-row button anchor to that button instead of
+// centering in the middle of the screen, so the pointer doesn't have to
+// travel from the bottom bar to the center to reach the selector.
+const modalAnchorCommand = {
+  audio: "audio",
+  subtitles: "subtitles",
+  sources: "sources",
+  episodes: "episodes",
+};
+
+const getModalAnchorButton = modal => {
+  const command = modalAnchorCommand[modal];
+  if (!command) return null;
+  return document.querySelector(`.action[data-command="${command}"]`);
+};
+
+const positionAnchoredModal = (modalElement, anchorButton) => {
+  const trackPanel = modalElement.querySelector(".track-panel");
+  if (!trackPanel || !anchorButton) return;
+
+  const playerRect = root.getBoundingClientRect();
+  const buttonRect = anchorButton.getBoundingClientRect();
+  if (!playerRect.width || !playerRect.height) return;
+
+  const margin = 16;
+  const gap = 10;
+  const panelWidth = trackPanel.offsetWidth;
+  const panelHeight = trackPanel.offsetHeight;
+
+  let left = buttonRect.left - playerRect.left + buttonRect.width / 2;
+  const minLeft = margin + panelWidth / 2;
+  const maxLeft = playerRect.width - margin - panelWidth / 2;
+  if (maxLeft >= minLeft) {
+    left = Math.min(Math.max(left, minLeft), maxLeft);
+  }
+
+  // Anchor to just above the seek bar (metadata text sits right above it),
+  // so the panel's bottom edge lines up with the bottom of the metadata
+  // text instead of the button itself.
+  const seekBar = document.getElementById("seek");
+  const clearanceTop = seekBar ? seekBar.getBoundingClientRect().top : buttonRect.top;
+
+  let bottom = playerRect.bottom - clearanceTop + gap;
+  const maxBottom = Math.max(margin, playerRect.height - margin - panelHeight);
+  bottom = Math.min(Math.max(bottom, margin), maxBottom);
+
+  trackPanel.style.setProperty("--anchor-left", `${left}px`);
+  trackPanel.style.setProperty("--anchor-bottom", `${bottom}px`);
+};
+
+const repositionActiveModalIfAnchored = () => {
+  if (!activeModal) return;
+  const modalElement = modalByName[activeModal];
+  if (!modalElement || !modalElement.classList.contains("modal-anchored")) return;
+  const anchorButton = getModalAnchorButton(activeModal);
+  if (anchorButton) positionAnchoredModal(modalElement, anchorButton);
+};
+
 const openPlayerModal = modal => {
   const targetModal = modalByName[modal];
   if (!targetModal) {
@@ -872,7 +930,12 @@ const openPlayerModal = modal => {
     };
   }
   renderActiveModal();
+  const anchorButton = getModalAnchorButton(modal);
   modalElements.forEach(modalElement => {
+    modalElement.classList.toggle(
+      "modal-anchored",
+      modalElement === targetModal && Boolean(anchorButton),
+    );
     setModalVisibility(modalElement, modalElement === targetModal);
   });
   renderChrome();
@@ -1545,6 +1608,7 @@ const renderActiveModal = () => {
   if (activeModal === "episodes") renderEpisodesModal();
   if (activeModal === "submitIntro") renderSubmitIntroModal();
   if (activeModal === "p2pConsent") renderP2pConsentModal();
+  window.requestAnimationFrame(repositionActiveModalIfAnchored);
 };
 
 window.nuvioNativeViewportChanged = () => {
@@ -1554,7 +1618,12 @@ window.nuvioNativeViewportChanged = () => {
     root.classList.remove("native-resizing");
   }, 180);
   if (activeModal) renderActiveModal();
+  window.requestAnimationFrame(repositionActiveModalIfAnchored);
 };
+
+window.addEventListener("resize", () => {
+  window.requestAnimationFrame(repositionActiveModalIfAnchored);
+});
 
 const trackListSignature = tracks =>
   normalizeTracks(tracks)
@@ -2208,6 +2277,7 @@ modalElements.forEach(modal => {
 const selectSubtitleTab = (tab, index) => {
   state = { ...state, subtitleActiveTab: tab };
   renderSubtitleModal();
+  window.requestAnimationFrame(repositionActiveModalIfAnchored);
   send("subtitleTab", index);
 };
 


### PR DESCRIPTION
  ## Summary
  
Repositions the desktop player's audio, subtitle, and sources selector panels (and episodes) to open anchored above their trigger button in the bottom action bar, instead of centered on screen. This removes the long diagonal mouse travel from a bottom-bar button to a screen-centered panel, and fixes the panel overlapping the seek bar/metadata text.
  
  ## PR type
  
  <!-- Check exactly one. PRs outside these types are not accepted. -->
  - [ ] Reproducible bug fix
  - [x] UI glitch/bug fix
  - [ ] Behavior bug/regression fix
  - [ ] Small maintenance only, with no UI or behavior change
  - [ ] Docs accuracy fix
  - [ ] Translation/localization only
  - [ ] Approved larger or directional change
  
  ## Why
  
On desktop, clicking Audio/Subtitles/Sources opened the selector centered in the middle of the screen, far from the button that triggered it, forcing the user to move the mouse all the way from the bottom action bar to the center of the window just to make a selection. Additionally, an early anchored-positioning attempt caused the panel to visibly slide in diagonally from the bottom-center, and then to overlap the seek bar and stream metadata text.
  
  ## Desktop scope
  
Desktop shared UI: src/desktopMain/resources/player-ui/controls.js and controls.css, the HTML/CSS/JS overlay rendered inside the native WebView player on Windows, macOS, and Linux. Not platform-specific — applies uniformly across all desktop targets since the player UI is shared web code hosted in the native player window.
  
  ## Issue or approval
  
  Fixes #137
  
  ## UI / behavior impact
  
  <!-- Check every box that applies. At least one must be checked. -->
  - [ ] No UI change
  - [ ] No behavior change
  - [x] UI changed only to fix a documented glitch/bug
  - [ ] Behavior changed only to fix a documented bug/regression
  - [ ] UI change has explicit maintainer approval
  - [ ] Behavior change has explicit maintainer approval
  
  ## Policy check
  
  <!-- ALL boxes must be checked or the PR will be closed without review. -->
  - [x] I have read and understood `CONTRIBUTING.md`.
  - [x] This PR is small, focused, and limited to one problem.
  - [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
  - [x] This PR is not cosmetic-only.
  - [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
  - [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
  - [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
  - [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
  - [x] I listed the testing performed below.
  
  > UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.
  
  ## Scope boundaries
  
 Only positioning of the audio/subtitles/sources/episodes selector panels was changed. No changes to panel content, track-selection logic, styling of list rows, or the submitIntro/p2pConsent modals (which remain centered by design, since they aren't triggered from a bottom-bar button). No unrelated refactors or formatting changes.
  
  ## Testing
  
- Tested on Windows (both the packaged MSI install and running from source via ./gradlew run for the desktop target).
- Manually verified Audio, Subtitles (Built-in/Addons/Style tabs), Sources, and Episodes panels open anchored to their trigger button in the bottom action bar.
- Verified panel opens with a straight vertical grow/fade animation — no diagonal slide from screen-center.
- Verified panel is clamped within the window bounds at both narrow and wide window widths (including maximized and restored window states on Windows).
- Verified panel's bottom edge sits just above the seek bar/metadata text with no overlap, across audio, subtitles, and sources panels.
- Verified repositioning holds up across: switching subtitle tabs, live state updates (track list changes), and native window resize (dragged window edges to resize on Windows).
- Verified narrow-viewport (max-width: 760px) fallback still renders the original centered sheet layout.
- Verified node --check controls.js passes (JS syntax validation, per repo convention).
  
  ## Screenshots / Video
  
| Before | After |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/999f9406-4cc5-4445-a49c-85c84cb6b219" width="600" alt="Before Update" /> | <img src="https://github.com/user-attachments/assets/faaa49cd-6d00-4243-9c78-134a6ceb9af9" width="600" alt="After Update" /> |

| Before | After |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/e5406d42-3e4d-4cd0-8165-4bee48f65b2b" width="600" alt="Before Update" /> | <img src="https://github.com/user-attachments/assets/bab41dcd-545f-44a2-a2e0-6e15f2fc0000" width="600" alt="After Update" /> |

| Before | After |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/0374aa68-5f85-4e33-8ead-b4e4d784c791" width="600" alt="Before Update" /> | <img src="https://github.com/user-attachments/assets/3e5629e2-87d8-44b1-9901-125838b244b3" width="600" alt="After Update" /> |



  
  ## Breaking changes
  
None.
  
  ## Linked issues
  
Fixes #137
