### PR TITLE
Fix desktop HTTP errors and plugin stream badges

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerStreamsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerStreamsRepository.kt
@@ -458,10 +458,12 @@ object PlayerStreamsRepository {
                                         } else {
                                             null
                                         }
-                                        group.copy(
-                                            streams = mergedStreams,
-                                            isLoading = stillLoading,
-                                            error = finalError,
+                                        presentStreamGroup(
+                                            group.copy(
+                                                streams = mergedStreams,
+                                                isLoading = stillLoading,
+                                                error = finalError,
+                                            ),
                                         )
                                     }
                                 },

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamsRepository.kt
@@ -545,10 +545,12 @@ object StreamsRepository {
                                         } else {
                                             null
                                         }
-                                        group.copy(
-                                            streams = mergedStreams,
-                                            isLoading = stillLoading,
-                                            error = finalError,
+                                        presentStreamGroup(
+                                            group.copy(
+                                                streams = mergedStreams,
+                                                isLoading = stillLoading,
+                                                error = finalError,
+                                            ),
                                         )
                                     }
                                 },

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.desktop.kt
@@ -49,7 +49,7 @@ actual suspend fun httpGetTextWithHeaders(
     url: String,
     headers: Map<String, String>,
 ): String =
-    httpRequestRaw("GET", url, headers, body = "").body
+    httpRequestRaw("GET", url, headers, body = "").bodyOrThrow()
 
 actual suspend fun httpPostJsonWithHeaders(
     url: String,
@@ -61,7 +61,17 @@ actual suspend fun httpPostJsonWithHeaders(
         url = url,
         headers = mapOf("Content-Type" to "application/json") + headers,
         body = body,
-    ).body
+    ).bodyOrThrow()
+
+private fun RawHttpResponse.bodyOrThrow(): String {
+    if (status !in 200..299) {
+        error("HTTP $status while fetching $url")
+    }
+    if (body.isBlank()) {
+        throw IllegalStateException("Empty response body")
+    }
+    return body
+}
 
 actual suspend fun httpRequestRaw(
     method: String,


### PR DESCRIPTION
## Summary

- Make desktop text HTTP helpers fail on non-2xx responses before returning response bodies.
- Keep desktop behavior closer to Android/iOS so GitHub `404: Not Found` bodies are not parsed as plugin/badge JSON.
- Run merged plugin stream groups through the existing stream presentation path so stream badges/debrid presentation are applied to plugin results too.

Closes #208

## Testing

- `git diff --check` ✅
- Installed/configured Homebrew OpenJDK 17 locally for Gradle.
- `./gradlew :composeApp:compileKotlinDesktop --no-daemon --console=plain` ⚠️ starts with Java now, but fails on an unrelated existing desktop expect/actual mismatch:

  ```txt
  DownloadsPlatformDownloader.desktop.kt:25:24
  actual object DownloadsPlatformDownloader has no corresponding members for expected class members:
      expect fun openDownloadsDirectory(): Boolean
  ```

- `./gradlew :composeApp:desktopTest --no-daemon` not run after the compile failure above.

