### PR TITLE
Show watched checkmarks in player episode switcher

### DIFF
--- a/composeApp/src/desktopMain/resources/player-ui/controls.css
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.css
@@ -2200,6 +2200,34 @@ button:disabled {
   display: block;
 }
 
+.episode-watched-badge {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: var(--theme-accent);
+  color: var(--theme-on-accent);
+  pointer-events: none;
+}
+
+.episode-row-top .episode-watched-badge {
+  position: static;
+}
+
+.episode-watched-check {
+  width: 12px;
+  height: 12px;
+  flex: 0 0 auto;
+  color: inherit;
+  opacity: 1;
+}
+
 .track-check {
   width: 18px;
   height: 18px;

--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -1370,8 +1370,9 @@ const appendEpisodeRow = (container, item) => {
     send("selectEpisode", Number(item.index) || 0);
   });
 
+  let thumb = null;
   if (item.thumbnail) {
-    const thumb = document.createElement("span");
+    thumb = document.createElement("span");
     thumb.className = "episode-thumb";
     const image = document.createElement("img");
     image.alt = "";
@@ -1409,6 +1410,21 @@ const appendEpisodeRow = (container, item) => {
     copy.appendChild(overview);
   }
   row.appendChild(copy);
+
+  if (item.isWatched) {
+    const badge = document.createElement("span");
+    badge.className = "episode-watched-badge";
+    badge.setAttribute("aria-hidden", "true");
+    const check = buildCheckIcon();
+    check.setAttribute("class", "episode-watched-check");
+    badge.appendChild(check);
+    if (thumb) {
+      thumb.appendChild(badge);
+    } else {
+      top.appendChild(badge);
+    }
+  }
+
   container.appendChild(row);
 };
 


### PR DESCRIPTION
﻿## Summary

Fix the desktop player episode switcher so completed episodes show the same watched checkmark already shown on the series detail page. Watched state was already computed and sent into the HTML controls as `isWatched`; the switcher simply never rendered it.

## PR type

- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

On desktop, the series detail page shows a watched tick on completed episodes, but the in-player episode switcher did not. That is an incorrect visual state: completion data was already available to the player UI and was ignored when building each episode row.

## Desktop scope

Windows, macOS, and Linux desktop player HTML controls (`composeApp/src/desktopMain/resources/player-ui/`). Only the desktop player episode switcher is affected. No shared/common Kotlin UI changes.

## Issue or approval

No linked issue. This is a focused UI glitch fix restoring the already-intended watched indicator in the player episode list. I did not find an existing open issue for this.

## UI / behavior impact

- [ ] No UI change
- [x] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

Only two files changed:
- `composeApp/src/desktopMain/resources/player-ui/controls.js`
- `composeApp/src/desktopMain/resources/player-ui/controls.css`

No Kotlin/data-layer changes. Reuses the existing player `#icon-check` / `buildCheckIcon()`; does not introduce a new icon. Intentionally does not change Compose `PlayerEpisodesPanel` / mobile.

## Testing

- Confirmed detail page already shows watched ticks for completed episodes.
- Opened the desktop player episode switcher for a series with completed and uncompleted episodes.
- Verified completed episodes now show the watched check overlay; unwatched episodes do not.
- Verified the current episode still shows the Playing chip.
- Desktop OS: Windows 11.

## Screenshots / Video

### Before
Completed episodes in the player episode switcher had no watched tick.

![Before: player episode switcher without watched ticks](https://github.com/user-attachments/assets/b86cce3e-9cea-4e53-95f0-a14f654fadaa)


### After
Completed episodes show the watched checkmark on the episode thumbnail (same existing check icon used elsewhere in the player).

![After: player episode switcher with watched ticks](https://github.com/user-attachments/assets/1e8d4002-1ea8-475e-8f54-0b9de7ba47e2) 


## Breaking changes

None

## Linked issues

No linked issue. I did not file a bug nor locate one in the open issues; this restores an existing watched indicator that the detail page already displays.

