### PR TITLE
fix(player): persist volume between streams

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopPlayerVolumeStorage.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopPlayerVolumeStorage.kt
@@ -1,0 +1,15 @@
+package com.nuvio.app.features.player.desktop
+
+import com.nuvio.app.core.storage.DesktopStorage
+
+internal object DesktopPlayerVolumeStorage {
+    private const val VolumeLevelKey = "volume_level"
+    private val store = DesktopStorage.store("nuvio_player_runtime")
+
+    fun loadVolumeLevel(): Float? =
+        store.getFloat(VolumeLevelKey)?.coerceIn(0f, 1f)
+
+    fun saveVolumeLevel(level: Float) {
+        store.putFloat(VolumeLevelKey, level.coerceIn(0f, 1f))
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
@@ -36,7 +36,7 @@ internal class NativePlayerController(
         val log = Logger.withTag("NativePlayerControls")
 
         @Volatile
-        var rememberedVolumeLevel: Float = 1f
+        var rememberedVolumeLevel: Float = DesktopPlayerVolumeStorage.loadVolumeLevel() ?: 1f
     }
 
     @Volatile
@@ -290,6 +290,7 @@ internal class NativePlayerController(
         if (current != 0L) {
             val nextLevel = level.coerceIn(0f, 1f)
             rememberedVolumeLevel = nextLevel
+            DesktopPlayerVolumeStorage.saveVolumeLevel(nextLevel)
             NativePlayerBridge.setVolume(current, nextLevel)
             controlsState = controlsState.copy(volumeLevel = nextLevel)
             updateControls(controlsState)


### PR DESCRIPTION
## Summary

Fixes Desktop volume resetting whenever a new stream creates a fresh native player instance.

- Saves the user selected player volume as Desktop playback state.
- Restores that value when subsequent Windows or macOS player instances are created, including when switching streams.
- Requires no new setting and adds no UI.
- Leaves mute behavior, system volume, audio track selection, and the existing volume control unchanged.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Desktop kept volume only in process memory for the active controller. A new stream recreated the player at the default level, forcing users to readjust volume every time.

## Desktop scope

Windows and macOS use the shared Desktop native player controller. The persisted value is Desktop local runtime state and does not affect Android or iOS behavior.

## Issue or approval

Fixes #253

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the player volume value is persisted. This does not change mute behavior, system audio, track selection, or the volume control UI.

## Testing

- Windows 11 manual playback: changed volume, exited the stream, opened another stream, and confirmed the selected level was restored.
- `:composeApp:compileKotlinDesktop` passed when tested with the current upstream Desktop compatibility actuals.
- `git diff --check` passed.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #253