### PR TITLE
fix(subtitles): show languages in track labels

### DIFF
--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -920,6 +920,24 @@ const appendEmptyTrackState = (container, label) => {
   container.appendChild(empty);
 };
 
+const displayLanguageName = language => {
+  const code = String(language || "").trim().replace(/_/g, "-");
+  if (!code) return "";
+  try {
+    const displayNames = new Intl.DisplayNames([navigator.language || "en"], { type: "language" });
+    return displayNames.of(code) || code;
+  } catch (_) {
+    return code;
+  }
+};
+
+const trackDisplayLabel = (track, fallback) => {
+  const base = String(track.label || track.language || fallback).trim();
+  const language = displayLanguageName(track.language);
+  if (!language || base.toLocaleLowerCase().includes(language.toLocaleLowerCase())) return base;
+  return `${language} • ${base}`;
+};
+
 const renderAudioTrackList = () => {
   audioTrackList.textContent = "";
   const tracks = normalizeTracks(state.audioTracks);
@@ -930,7 +948,7 @@ const renderAudioTrackList = () => {
   tracks.forEach(track => {
     appendTrackRow(
       audioTrackList,
-      track.label || track.language || `Track ${Number(track.index || 0) + 1}`,
+      trackDisplayLabel(track, `Track ${Number(track.index || 0) + 1}`),
       Boolean(track.selected),
       () => send("selectAudioTrack", trackIdValue(track)),
     );
@@ -951,7 +969,7 @@ const renderSubtitleTrackList = () => {
   tracks.forEach(track => {
     appendTrackRow(
       subtitleTrackList,
-      track.label || track.language || `Subtitle ${Number(track.index || 0) + 1}`,
+      trackDisplayLabel(track, `Subtitle ${Number(track.index || 0) + 1}`),
       Boolean(track.selected),
       () => send("selectBuiltInSubtitleTrack", Number(track.index) || 0),
       false,


### PR DESCRIPTION
## Summary

Makes built in audio and subtitle tracks distinguishable when several tracks share the same provider, title, or codec label.

- Reads the language already supplied by the native Windows or macOS track metadata.
- Appends that language to the existing label, preserving provider, title, and codec information such as `CR (SSA)`.
- Avoids repeating the language when it is already present in the original label.
- Keeps the existing fallback label when language metadata is unavailable.
- Does not change track ordering, selection, or playback behavior.

## PR type

- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Multi language streams can contain several tracks whose existing labels are identical, such as repeated `CR (SSA)` entries. The language was available but omitted from the panel, making the tracks impossible to distinguish reliably.

## Desktop scope

This changes only the Desktop player web controls used on Windows and macOS.

## Issue or approval

Fixes #254

## UI / behavior impact

- [ ] No UI change
- [x] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Track selection and ordering are unchanged. The patch only formats labels from metadata already supplied by the native player.

## Testing

- Windows 11 manual playback with a stream containing multiple ASS/SSA tracks.
- Confirmed language names appear without duplicating a language already present in the original label.
- `node --check composeApp/src/desktopMain/resources/player-ui/controls.js` passed.
- `git diff --check` passed.

## Screenshots / Video

Before:

![Tracks without languages](https://github.com/user-attachments/assets/bb2522cb-d893-4435-a633-d2fb9e1229cd)

After:

![Tracks with languages](https://github.com/user-attachments/assets/4bb36fba-9728-412a-b583-de51733fae6d)

## Breaking changes

None.

## Linked issues

Fixes #254