### PR TITLE
feat(subtitles): allow authored ASS and SSA styling

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.android.kt
@@ -531,6 +531,10 @@ actual object PlayerSettingsStorage {
             ?.apply()
     }
 
+    actual fun loadSubtitleOverrideEmbeddedStyles(): Boolean? = null
+
+    actual fun saveSubtitleOverrideEmbeddedStyles(enabled: Boolean) = Unit
+
     actual fun loadAddonSubtitleStartupMode(): String? =
         preferences?.getString(ProfileScopedKey.of(addonSubtitleStartupModeKey), null)
 

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -1025,6 +1025,8 @@
     <string name="settings_playback_show_loading_overlay_description">Show loading screen until first video frame appears.</string>
     <string name="settings_playback_parental_guide">Content Warnings</string>
     <string name="settings_playback_parental_guide_description">Show parental guidance overlay when playback starts.</string>
+    <string name="settings_playback_subtitle_custom_style">Use custom subtitle styling</string>
+    <string name="settings_playback_subtitle_custom_style_description">Override subtitle size, colors, outline, weight, and position. Turn off to preserve embedded ASS/SSA styling.</string>
     <string name="settings_playback_subtitle_background_color">Background Color</string>
     <string name="settings_playback_subtitle_bold">Bold</string>
     <string name="settings_playback_subtitle_bold_description">Use a heavier subtitle font weight.</string>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerEngine.kt
@@ -108,6 +108,7 @@ data class PlayerControlsState(
     val subtitleBuiltInTabLabel: String = "Built-in",
     val subtitleAddonsTabLabel: String = "Addons",
     val subtitleStyleTabLabel: String = "Style",
+    val customSubtitleStyleLabel: String = "Use custom styling",
     val noneLabel: String = "None",
     val fetchSubtitlesLabel: String = "Tap to fetch subtitles",
     val subtitleDelayLabel: String = "Subtitle Delay",

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
@@ -223,6 +223,7 @@ internal fun PlayerScreenRuntime.RenderPlayerRuntimeUi() {
         subtitleBuiltInTabLabel = stringResource(Res.string.compose_player_built_in),
         subtitleAddonsTabLabel = stringResource(Res.string.addon_title),
         subtitleStyleTabLabel = stringResource(Res.string.compose_player_style),
+        customSubtitleStyleLabel = stringResource(Res.string.settings_playback_subtitle_custom_style),
         noneLabel = stringResource(Res.string.compose_player_none),
         fetchSubtitlesLabel = stringResource(Res.string.compose_player_fetch_subtitles),
         subtitleDelayLabel = stringResource(Res.string.compose_player_subtitle_delay),
@@ -773,6 +774,9 @@ private fun PlayerScreenRuntime.handlePlayerControlsEvent(type: String, value: D
         "subtitleAutoSyncCue" -> {
             val cue = playerControlsNearestSubtitleCues().getOrNull(value.toInt()) ?: return true
             applySubtitleAutoSyncCue(cue)
+        }
+        "subtitleStyleOverrideToggle" -> {
+            PlayerSettingsRepository.setSubtitleOverrideEmbeddedStyles(!subtitleStyle.overrideEmbeddedStyles)
         }
         "subtitleFontSizeDelta" -> {
             PlayerSettingsRepository.setSubtitleStyle(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSettingsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSettingsRepository.kt
@@ -268,6 +268,8 @@ object PlayerSettingsRepository {
         secondaryPreferredSubtitleLanguage =
             normalizeLanguageCode(PlayerSettingsStorage.loadSecondaryPreferredSubtitleLanguage())
         subtitleStyle = SubtitleStyleState(
+            overrideEmbeddedStyles = PlayerSettingsStorage.loadSubtitleOverrideEmbeddedStyles()
+                ?: SubtitleStyleState.DEFAULT.overrideEmbeddedStyles,
             textColor = subtitleColorFromStorage(PlayerSettingsStorage.loadSubtitleTextColor())
                 ?: SubtitleStyleState.DEFAULT.textColor,
             backgroundColor = subtitleColorFromStorage(PlayerSettingsStorage.loadSubtitleBackgroundColor())
@@ -526,6 +528,15 @@ object PlayerSettingsRepository {
         PlayerSettingsStorage.saveSubtitleBottomOffset(normalized.bottomOffset)
         PlayerSettingsStorage.saveSubtitleUseForcedSubtitles(normalized.useForcedSubtitles)
         PlayerSettingsStorage.saveSubtitleShowOnlyPreferredLanguages(normalized.showOnlyPreferredLanguages)
+        PlayerSettingsStorage.saveSubtitleOverrideEmbeddedStyles(normalized.overrideEmbeddedStyles)
+    }
+
+    fun setSubtitleOverrideEmbeddedStyles(enabled: Boolean) {
+        ensureLoaded()
+        if (subtitleStyle.overrideEmbeddedStyles == enabled) return
+        subtitleStyle = subtitleStyle.copy(overrideEmbeddedStyles = enabled)
+        publish()
+        PlayerSettingsStorage.saveSubtitleOverrideEmbeddedStyles(enabled)
     }
 
     fun setAddonSubtitleStartupMode(mode: AddonSubtitleStartupMode) {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.kt
@@ -51,6 +51,8 @@ internal expect object PlayerSettingsStorage {
     fun saveSubtitleUseForcedSubtitles(enabled: Boolean)
     fun loadSubtitleShowOnlyPreferredLanguages(): Boolean?
     fun saveSubtitleShowOnlyPreferredLanguages(enabled: Boolean)
+    fun loadSubtitleOverrideEmbeddedStyles(): Boolean?
+    fun saveSubtitleOverrideEmbeddedStyles(enabled: Boolean)
     fun loadAddonSubtitleStartupMode(): String?
     fun saveAddonSubtitleStartupMode(mode: String)
     fun loadStreamReuseLastLinkEnabled(): Boolean?

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/SubtitleAudioModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/SubtitleAudioModels.kt
@@ -55,6 +55,7 @@ internal val subtitleFontSizeRangeSp: IntRange
     get() = if (isDesktop) 6..40 else 12..40
 
 data class SubtitleStyleState(
+    val overrideEmbeddedStyles: Boolean = true,
     val textColor: Color = Color.White,
     val backgroundColor: Color = Color.Transparent,
     val outlineColor: Color = Color.Black,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/PlaybackSettingsPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/PlaybackSettingsPage.kt
@@ -529,6 +529,19 @@ private fun PlaybackSettingsSection(
             val subtitleRenderingEnabled = !autoPlayPlayerSettings.externalPlayerEnabled
             SettingsGroup(isTablet = isTablet) {
                 val subtitleStyle = autoPlayPlayerSettings.subtitleStyle
+                if (isDesktop) {
+                    SettingsSwitchRow(
+                        title = stringResource(Res.string.settings_playback_subtitle_custom_style),
+                        description = stringResource(Res.string.settings_playback_subtitle_custom_style_description),
+                        checked = subtitleStyle.overrideEmbeddedStyles,
+                        enabled = subtitleRenderingEnabled,
+                        isTablet = isTablet,
+                        onCheckedChange = PlayerSettingsRepository::setSubtitleOverrideEmbeddedStyles,
+                    )
+                    SettingsGroupDivider(isTablet = isTablet)
+                }
+                val customSubtitleRenderingEnabled = subtitleRenderingEnabled &&
+                    (!isDesktop || subtitleStyle.overrideEmbeddedStyles)
                 SettingsSliderRow(
                     title = stringResource(Res.string.settings_playback_subtitle_size),
                     value = subtitleStyle.fontSizeSp,
@@ -536,7 +549,7 @@ private fun PlaybackSettingsSection(
                     valueRange = subtitleFontSizeRangeSp,
                     step = 2,
                     isTablet = isTablet,
-                    enabled = subtitleRenderingEnabled,
+                    enabled = customSubtitleRenderingEnabled,
                     onValueChange = { value ->
                         PlayerSettingsRepository.setSubtitleStyle(subtitleStyle.copy(fontSizeSp = value))
                     },
@@ -549,7 +562,7 @@ private fun PlaybackSettingsSection(
                     valueRange = 0..200,
                     step = 5,
                     isTablet = isTablet,
-                    enabled = subtitleRenderingEnabled,
+                    enabled = customSubtitleRenderingEnabled,
                     onValueChange = { value ->
                         PlayerSettingsRepository.setSubtitleStyle(subtitleStyle.copy(bottomOffset = value))
                     },
@@ -559,7 +572,7 @@ private fun PlaybackSettingsSection(
                     title = stringResource(Res.string.settings_playback_subtitle_bold),
                     description = stringResource(Res.string.settings_playback_subtitle_bold_description),
                     checked = subtitleStyle.bold,
-                    enabled = subtitleRenderingEnabled,
+                    enabled = customSubtitleRenderingEnabled,
                     isTablet = isTablet,
                     onCheckedChange = { enabled ->
                         PlayerSettingsRepository.setSubtitleStyle(subtitleStyle.copy(bold = enabled))
@@ -569,7 +582,7 @@ private fun PlaybackSettingsSection(
                 SettingsNavigationRow(
                     title = stringResource(Res.string.settings_playback_subtitle_text_color),
                     description = subtitleColorLabel(subtitleStyle.textColor),
-                    enabled = subtitleRenderingEnabled,
+                    enabled = customSubtitleRenderingEnabled,
                     isTablet = isTablet,
                     onClick = { showSubtitleTextColorDialog = true },
                 )
@@ -597,7 +610,7 @@ private fun PlaybackSettingsSection(
                     SettingsNavigationRow(
                         title = stringResource(Res.string.settings_playback_subtitle_outline_color),
                         description = subtitleColorLabel(subtitleStyle.outlineColor),
-                        enabled = subtitleRenderingEnabled,
+                        enabled = customSubtitleRenderingEnabled,
                         isTablet = isTablet,
                         onClick = { showSubtitleOutlineColorDialog = true },
                     )

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.desktop.kt
@@ -41,6 +41,7 @@ internal actual object PlayerSettingsStorage {
     private const val subtitleBottomOffsetKey = "subtitle_bottom_offset"
     private const val subtitleUseForcedSubtitlesKey = "subtitle_use_forced_subtitles"
     private const val subtitleShowOnlyPreferredLanguagesKey = "subtitle_show_only_preferred_languages"
+    private const val subtitleOverrideEmbeddedStylesKey = "subtitle_override_embedded_styles"
     private const val addonSubtitleStartupModeKey = "addon_subtitle_startup_mode"
     private const val streamReuseLastLinkEnabledKey = "stream_reuse_last_link_enabled"
     private const val streamReuseLastLinkCacheHoursKey = "stream_reuse_last_link_cache_hours"
@@ -112,6 +113,7 @@ internal actual object PlayerSettingsStorage {
         subtitleBottomOffsetKey,
         subtitleUseForcedSubtitlesKey,
         subtitleShowOnlyPreferredLanguagesKey,
+        subtitleOverrideEmbeddedStylesKey,
         addonSubtitleStartupModeKey,
         streamReuseLastLinkEnabledKey,
         streamReuseLastLinkCacheHoursKey,
@@ -206,6 +208,8 @@ internal actual object PlayerSettingsStorage {
     actual fun saveSubtitleUseForcedSubtitles(enabled: Boolean) = saveBoolean(subtitleUseForcedSubtitlesKey, enabled)
     actual fun loadSubtitleShowOnlyPreferredLanguages(): Boolean? = loadBoolean(subtitleShowOnlyPreferredLanguagesKey)
     actual fun saveSubtitleShowOnlyPreferredLanguages(enabled: Boolean) = saveBoolean(subtitleShowOnlyPreferredLanguagesKey, enabled)
+    actual fun loadSubtitleOverrideEmbeddedStyles(): Boolean? = loadBoolean(subtitleOverrideEmbeddedStylesKey)
+    actual fun saveSubtitleOverrideEmbeddedStyles(enabled: Boolean) = saveBoolean(subtitleOverrideEmbeddedStylesKey, enabled)
     actual fun loadAddonSubtitleStartupMode(): String? = loadString(addonSubtitleStartupModeKey)
     actual fun saveAddonSubtitleStartupMode(mode: String) = saveString(addonSubtitleStartupModeKey, mode)
     actual fun loadStreamReuseLastLinkEnabled(): Boolean? = loadBoolean(streamReuseLastLinkEnabledKey)
@@ -337,6 +341,7 @@ internal actual object PlayerSettingsStorage {
         loadSubtitleBottomOffset()?.let { put(subtitleBottomOffsetKey, encodeSyncInt(it)) }
         loadSubtitleUseForcedSubtitles()?.let { put(subtitleUseForcedSubtitlesKey, encodeSyncBoolean(it)) }
         loadSubtitleShowOnlyPreferredLanguages()?.let { put(subtitleShowOnlyPreferredLanguagesKey, encodeSyncBoolean(it)) }
+        loadSubtitleOverrideEmbeddedStyles()?.let { put(subtitleOverrideEmbeddedStylesKey, encodeSyncBoolean(it)) }
         loadAddonSubtitleStartupMode()?.let { put(addonSubtitleStartupModeKey, encodeSyncString(it)) }
         loadStreamReuseLastLinkEnabled()?.let { put(streamReuseLastLinkEnabledKey, encodeSyncBoolean(it)) }
         loadStreamReuseLastLinkCacheHours()?.let { put(streamReuseLastLinkCacheHoursKey, encodeSyncInt(it)) }
@@ -410,6 +415,7 @@ internal actual object PlayerSettingsStorage {
         payload.decodeSyncInt(subtitleBottomOffsetKey)?.let(::saveSubtitleBottomOffset)
         payload.decodeSyncBoolean(subtitleUseForcedSubtitlesKey)?.let(::saveSubtitleUseForcedSubtitles)
         payload.decodeSyncBoolean(subtitleShowOnlyPreferredLanguagesKey)?.let(::saveSubtitleShowOnlyPreferredLanguages)
+        payload.decodeSyncBoolean(subtitleOverrideEmbeddedStylesKey)?.let(::saveSubtitleOverrideEmbeddedStyles)
         payload.decodeSyncString(addonSubtitleStartupModeKey)?.let(::saveAddonSubtitleStartupMode)
         payload.decodeSyncBoolean(streamReuseLastLinkEnabledKey)?.let(::saveStreamReuseLastLinkEnabled)
         payload.decodeSyncInt(streamReuseLastLinkCacheHoursKey)?.let(::saveStreamReuseLastLinkCacheHours)

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerBridge.kt
@@ -80,8 +80,15 @@ internal object NativePlayerBridge {
     )
 
     external fun setSubtitleDelayMs(handle: Long, delayMs: Int)
+    external fun applySubtitleStyleMode(
+        handle: Long,
+        overrideEmbeddedStyles: Boolean,
+        fontSize: Float,
+        subPos: Int,
+    )
     external fun applySubtitleStyle(
         handle: Long,
+        overrideEmbeddedStyles: Boolean,
         textColor: String,
         backgroundColor: String,
         outlineColor: String,

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
@@ -45,6 +45,7 @@ internal class NativePlayerController(
     private var controlsState = PlayerControlsState()
     private var pendingSubtitleDelayMs: Int? = null
     private var pendingSubtitleStyle: SubtitleStyleState? = null
+    private var appliedSubtitleStyle: SubtitleStyleState? = null
     private var lastSentControlsStructureKey: NativeControlsStructureKey? = null
     private var onAction: (PlayerControlsAction) -> Boolean = { false }
     private var onEvent: (String, Double) -> Boolean = { _, _ -> false }
@@ -114,6 +115,7 @@ internal class NativePlayerController(
                     eventSink = eventSink,
                 )
                 if (handle == 0L) error("Native player did not return a handle.")
+                appliedSubtitleStyle = null
                 log.d {
                     "attach created handle=$handle source=${resolvedSource.toPlaybackLogKey()} " +
                         "initialPositionMs=${pending.initialPositionMs}"
@@ -481,7 +483,13 @@ internal class NativePlayerController(
     override fun applySubtitleStyle(style: SubtitleStyleState) {
         pendingSubtitleStyle = style
         handle.takeIf { it != 0L }?.let { current ->
-            applySubtitleStyle(current, style)
+            val previous = appliedSubtitleStyle
+            if (previous != null && previous.copy(overrideEmbeddedStyles = style.overrideEmbeddedStyles) == style) {
+                applySubtitleStyleMode(current, style)
+            } else {
+                applySubtitleStyle(current, style)
+            }
+            appliedSubtitleStyle = style
         }
     }
 
@@ -492,12 +500,23 @@ internal class NativePlayerController(
         }
         pendingSubtitleStyle?.let { style ->
             applySubtitleStyle(current, style)
+            appliedSubtitleStyle = style
         }
+    }
+
+    private fun applySubtitleStyleMode(handle: Long, style: SubtitleStyleState) {
+        NativePlayerBridge.applySubtitleStyleMode(
+            handle = handle,
+            overrideEmbeddedStyles = style.overrideEmbeddedStyles,
+            fontSize = style.toMpvSubtitleFontSize(),
+            subPos = style.toMpvSubtitlePosition(),
+        )
     }
 
     private fun applySubtitleStyle(handle: Long, style: SubtitleStyleState) {
         NativePlayerBridge.applySubtitleStyle(
             handle = handle,
+            overrideEmbeddedStyles = style.overrideEmbeddedStyles,
             textColor = style.textColor.toMpvColorString(),
             backgroundColor = style.backgroundColor.toMpvColorString(),
             outlineColor = style.outlineColor.toMpvColorString(),
@@ -758,6 +777,8 @@ private fun PlayerControlsState.toControlsJson(isFullscreen: Boolean): String =
         appendJsonField("subtitleAddonsTabLabel", subtitleAddonsTabLabel)
         append(',')
         appendJsonField("subtitleStyleTabLabel", subtitleStyleTabLabel)
+        append(',')
+        appendJsonField("customSubtitleStyleLabel", customSubtitleStyleLabel)
         append(',')
         appendJsonField("noneLabel", noneLabel)
         append(',')
@@ -1103,6 +1124,8 @@ private fun StringBuilder.appendParentalWarningJson(item: ParentalWarning) {
 
 private fun StringBuilder.appendSubtitleStyleJson(style: SubtitleStyleState) {
     append('{')
+    appendJsonField("overrideEmbeddedStyles", style.overrideEmbeddedStyles)
+    append(',')
     appendJsonField("textColor", style.textColor.toStorageHexString())
     append(',')
     appendJsonField("outlineColor", style.outlineColor.toStorageHexString())

--- a/composeApp/src/desktopMain/native/macos/player_bridge.mm
+++ b/composeApp/src/desktopMain/native/macos/player_bridge.mm
@@ -115,7 +115,11 @@
 - (void)removeExternalSubtitles;
 - (void)removeExternalSubtitlesAndSelect:(int)trackId;
 - (void)setSubtitleDelayMs:(int)delayMs;
-- (void)applySubtitleStyleWithTextColor:(NSString *)textColor
+- (void)applySubtitleStyleModeWithOverrideEmbeddedStyles:(BOOL)overrideEmbeddedStyles
+                                fontSize:(double)fontSize
+                                  subPos:(int)subPos;
+- (void)applySubtitleStyleWithOverrideEmbeddedStyles:(BOOL)overrideEmbeddedStyles
+                                   textColor:(NSString *)textColor
                         backgroundColor:(NSString *)backgroundColor
                             outlineColor:(NSString *)outlineColor
                              outlineSize:(double)outlineSize
@@ -2012,7 +2016,22 @@ static void setMpvOptionString(mpv_handle *mpv, const char *name, const char *va
     mpv_set_property(_mpv, "sub-delay", MPV_FORMAT_DOUBLE, &delaySeconds);
 }
 
-- (void)applySubtitleStyleWithTextColor:(NSString *)textColor
+- (void)applySubtitleStyleModeWithOverrideEmbeddedStyles:(BOOL)overrideEmbeddedStyles
+                                fontSize:(double)fontSize
+                                  subPos:(int)subPos {
+    if (!_mpv) return;
+    [self setStringProperty:"sub-ass-override" value:overrideEmbeddedStyles ? @"force" : @"scale"];
+
+    double size = MAX(18.0, MIN(96.0, fontSize));
+    double scale = overrideEmbeddedStyles ? 1.0 : size / 54.0;
+    mpv_set_property(_mpv, "sub-scale", MPV_FORMAT_DOUBLE, &scale);
+    mpv_set_property(_mpv, "sub-font-size", MPV_FORMAT_DOUBLE, &size);
+    int64_t position = MAX(0, MIN(150, subPos));
+    mpv_set_property(_mpv, "sub-pos", MPV_FORMAT_INT64, &position);
+}
+
+- (void)applySubtitleStyleWithOverrideEmbeddedStyles:(BOOL)overrideEmbeddedStyles
+                                   textColor:(NSString *)textColor
                         backgroundColor:(NSString *)backgroundColor
                             outlineColor:(NSString *)outlineColor
                              outlineSize:(double)outlineSize
@@ -2020,7 +2039,10 @@ static void setMpvOptionString(mpv_handle *mpv, const char *name, const char *va
                                 fontSize:(double)fontSize
                                   subPos:(int)subPos {
     if (!_mpv) return;
-    [self setStringProperty:"sub-ass-override" value:@"force"];
+    [self applySubtitleStyleModeWithOverrideEmbeddedStyles:overrideEmbeddedStyles
+                                                  fontSize:fontSize
+                                                    subPos:subPos];
+    if (!overrideEmbeddedStyles) return;
     [self setStringProperty:"sub-color" value:textColor ?: @"#FFFFFFFF"];
     [self setStringProperty:"sub-back-color" value:backgroundColor ?: @"#00000000"];
     [self setStringProperty:"sub-outline-color" value:outlineColor ?: @"#FF000000"];
@@ -2031,11 +2053,6 @@ static void setMpvOptionString(mpv_handle *mpv, const char *name, const char *va
     double outline = MAX(0.0, MIN(8.0, outlineSize));
     mpv_set_property(_mpv, "sub-outline-size", MPV_FORMAT_DOUBLE, &outline);
 
-    double size = MAX(18.0, MIN(96.0, fontSize));
-    mpv_set_property(_mpv, "sub-font-size", MPV_FORMAT_DOUBLE, &size);
-
-    int64_t position = MAX(0, MIN(150, subPos));
-    mpv_set_property(_mpv, "sub-pos", MPV_FORMAT_INT64, &position);
 }
 
 - (double)doubleProperty:(const char *)name fallback:(double)fallback {
@@ -2814,10 +2831,29 @@ Java_com_nuvio_app_features_player_desktop_NativePlayerBridge_setSubtitleDelayMs
 }
 
 extern "C" JNIEXPORT void JNICALL
+Java_com_nuvio_app_features_player_desktop_NativePlayerBridge_applySubtitleStyleMode(
+    JNIEnv * /* env */,
+    jobject /* bridge */,
+    jlong handle,
+    jboolean overrideEmbeddedStyles,
+    jfloat fontSize,
+    jint subPos
+) {
+    if (handle == 0) return;
+    MpvWebPlayer *player = (__bridge MpvWebPlayer *)(void *)(intptr_t)handle;
+    runOnMainAsync(^{
+        [player applySubtitleStyleModeWithOverrideEmbeddedStyles:overrideEmbeddedStyles == JNI_TRUE
+                                                      fontSize:(double)fontSize
+                                                        subPos:(int)subPos];
+    });
+}
+
+extern "C" JNIEXPORT void JNICALL
 Java_com_nuvio_app_features_player_desktop_NativePlayerBridge_applySubtitleStyle(
     JNIEnv *env,
     jobject /* bridge */,
     jlong handle,
+    jboolean overrideEmbeddedStyles,
     jstring textColor,
     jstring backgroundColor,
     jstring outlineColor,
@@ -2832,7 +2868,8 @@ Java_com_nuvio_app_features_player_desktop_NativePlayerBridge_applySubtitleStyle
     std::string outline = jstringToString(env, outlineColor);
     MpvWebPlayer *player = (__bridge MpvWebPlayer *)(void *)(intptr_t)handle;
     runOnMainAsync(^{
-        [player applySubtitleStyleWithTextColor:[NSString stringWithUTF8String:text.c_str()]
+        [player applySubtitleStyleWithOverrideEmbeddedStyles:overrideEmbeddedStyles == JNI_TRUE
+                                                   textColor:[NSString stringWithUTF8String:text.c_str()]
                                 backgroundColor:[NSString stringWithUTF8String:background.c_str()]
                                     outlineColor:[NSString stringWithUTF8String:outline.c_str()]
                                      outlineSize:(double)outlineSize

--- a/composeApp/src/desktopMain/native/windows/player_bridge.cpp
+++ b/composeApp/src/desktopMain/native/windows/player_bridge.cpp
@@ -1049,7 +1049,25 @@ public:
         mpvApi().setProperty(mpv, "sub-delay", MPV_FORMAT_DOUBLE, &delaySeconds);
     }
 
+    void applySubtitleStyleMode(
+        bool overrideEmbeddedStyles,
+        double fontSize,
+        int subPos
+    ) {
+        setStringProperty("sub-ass-override", overrideEmbeddedStyles ? "force" : "scale");
+
+        std::lock_guard<std::mutex> lock(mpvMutex);
+        if (!mpv) return;
+        double size = std::max(18.0, std::min(96.0, fontSize));
+        double scale = overrideEmbeddedStyles ? 1.0 : size / 54.0;
+        int64_t position = std::max(0, std::min(150, subPos));
+        mpvApi().setProperty(mpv, "sub-scale", MPV_FORMAT_DOUBLE, &scale);
+        mpvApi().setProperty(mpv, "sub-font-size", MPV_FORMAT_DOUBLE, &size);
+        mpvApi().setProperty(mpv, "sub-pos", MPV_FORMAT_INT64, &position);
+    }
+
     void applySubtitleStyle(
+        bool overrideEmbeddedStyles,
         const std::string &textColor,
         const std::string &backgroundColor,
         const std::string &outlineColor,
@@ -1058,7 +1076,8 @@ public:
         double fontSize,
         int subPos
     ) {
-        setStringProperty("sub-ass-override", "force");
+        applySubtitleStyleMode(overrideEmbeddedStyles, fontSize, subPos);
+        if (!overrideEmbeddedStyles) return;
         setStringProperty("sub-color", textColor.empty() ? "#FFFFFFFF" : textColor);
         setStringProperty("sub-back-color", backgroundColor.empty() ? "#00000000" : backgroundColor);
         setStringProperty("sub-outline-color", outlineColor.empty() ? "#FF000000" : outlineColor);
@@ -1072,11 +1091,7 @@ public:
             std::lock_guard<std::mutex> lock(mpvMutex);
             if (!mpv) return;
             double outline = std::max(0.0, std::min(8.0, outlineSize));
-            double size = std::max(18.0, std::min(96.0, fontSize));
-            int64_t position = std::max(0, std::min(150, subPos));
             mpvApi().setProperty(mpv, "sub-outline-size", MPV_FORMAT_DOUBLE, &outline);
-            mpvApi().setProperty(mpv, "sub-font-size", MPV_FORMAT_DOUBLE, &size);
-            mpvApi().setProperty(mpv, "sub-pos", MPV_FORMAT_INT64, &position);
         }
     }
 
@@ -2295,10 +2310,29 @@ Java_com_nuvio_app_features_player_desktop_NativePlayerBridge_setSubtitleDelayMs
 }
 
 extern "C" JNIEXPORT void JNICALL
+Java_com_nuvio_app_features_player_desktop_NativePlayerBridge_applySubtitleStyleMode(
+    JNIEnv *,
+    jobject,
+    jlong handle,
+    jboolean overrideEmbeddedStyles,
+    jfloat fontSize,
+    jint subPos
+) {
+    auto player = playerFromHandle(handle);
+    if (!player) return;
+    player->applySubtitleStyleMode(
+        overrideEmbeddedStyles == JNI_TRUE,
+        fontSize,
+        subPos
+    );
+}
+
+extern "C" JNIEXPORT void JNICALL
 Java_com_nuvio_app_features_player_desktop_NativePlayerBridge_applySubtitleStyle(
     JNIEnv *env,
     jobject,
     jlong handle,
+    jboolean overrideEmbeddedStyles,
     jstring textColor,
     jstring backgroundColor,
     jstring outlineColor,
@@ -2310,6 +2344,7 @@ Java_com_nuvio_app_features_player_desktop_NativePlayerBridge_applySubtitleStyle
     auto player = playerFromHandle(handle);
     if (!player) return;
     player->applySubtitleStyle(
+        overrideEmbeddedStyles == JNI_TRUE,
         jstringToUtf8(env, textColor),
         jstringToUtf8(env, backgroundColor),
         jstringToUtf8(env, outlineColor),

--- a/composeApp/src/desktopMain/resources/player-ui/controls.css
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.css
@@ -1384,6 +1384,15 @@ button:disabled {
   cursor: pointer;
 }
 
+.custom-subtitle-style-controls {
+  display: contents;
+}
+
+.custom-subtitle-style-controls.disabled > * {
+  opacity: .42;
+  pointer-events: none;
+}
+
 .scrub::-webkit-slider-runnable-track {
   height: 10px;
   border-radius: 999px;

--- a/composeApp/src/desktopMain/resources/player-ui/controls.html
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.html
@@ -273,6 +273,10 @@
                 <div id="autoSyncCueList"></div>
               </div>
               <div class="style-row">
+                <span class="style-label" id="customSubtitleStyleLabel">Use custom styling</span>
+                <button class="panel-button" id="customSubtitleStyleToggle" type="button">On</button>
+              </div>
+              <div class="style-row">
                 <span class="style-label" id="fontSizeLabel">Font Size</span>
                 <div class="stepper">
                   <button class="round-step" id="fontSizeMinus" type="button">-</button>
@@ -281,20 +285,21 @@
                 </div>
               </div>
               <div class="style-row">
-                <span class="style-label" id="outlineLabel">Outline</span>
-                <button class="panel-button" id="outlineToggle" type="button">On</button>
-              </div>
-              <div class="style-row">
-                <span class="style-label" id="boldLabel">Bold</span>
-                <button class="panel-button" id="boldToggle" type="button">Off</button>
-              </div>
-              <div class="style-row">
                 <span class="style-label" id="bottomOffsetLabel">Bottom Offset</span>
                 <div class="stepper">
                   <button class="round-step" id="bottomOffsetMinus" type="button">-</button>
                   <span class="stepper-value" id="bottomOffsetValue">20</span>
                   <button class="round-step" id="bottomOffsetPlus" type="button">+</button>
                 </div>
+              </div>
+              <div class="custom-subtitle-style-controls" id="customSubtitleStyleControls">
+              <div class="style-row">
+                <span class="style-label" id="outlineLabel">Outline</span>
+                <button class="panel-button" id="outlineToggle" type="button">On</button>
+              </div>
+              <div class="style-row">
+                <span class="style-label" id="boldLabel">Bold</span>
+                <button class="panel-button" id="boldToggle" type="button">Off</button>
               </div>
               <div class="swatch-section">
                 <span class="style-label" id="subtitleColorLabel">Color</span>
@@ -315,6 +320,7 @@
               <div class="style-row">
                 <span></span>
                 <button class="panel-button" id="subtitleStyleReset" type="button">Reset Defaults</button>
+              </div>
               </div>
             </div>
           </div>

--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -79,6 +79,9 @@ const subtitleAddonsTab = document.getElementById("subtitleAddonsTab");
 const subtitleStyleTab = document.getElementById("subtitleStyleTab");
 const addonSubtitleList = document.getElementById("addonSubtitleList");
 const subtitleStylePanel = document.getElementById("subtitleStylePanel");
+const customSubtitleStyleLabel = document.getElementById("customSubtitleStyleLabel");
+const customSubtitleStyleToggle = document.getElementById("customSubtitleStyleToggle");
+const customSubtitleStyleControls = document.getElementById("customSubtitleStyleControls");
 const subtitleDelayLabel = document.getElementById("subtitleDelayLabel");
 const subtitleDelayMinus = document.getElementById("subtitleDelayMinus");
 const subtitleDelayValue = document.getElementById("subtitleDelayValue");
@@ -212,6 +215,7 @@ let state = {
   subtitleBuiltInTabLabel: "Built-in",
   subtitleAddonsTabLabel: "Addons",
   subtitleStyleTabLabel: "Style",
+  customSubtitleStyleLabel: "Use custom styling",
   noneLabel: "None",
   fetchSubtitlesLabel: "Tap to fetch subtitles",
   subtitleDelayLabel: "Subtitle Delay",
@@ -305,6 +309,7 @@ let state = {
   subtitleAutoSyncIsLoading: false,
   subtitleAutoSyncErrorMessage: "",
   subtitleStyle: {
+    overrideEmbeddedStyles: true,
     textColor: "#FFFFFFFF",
     outlineColor: "#FF000000",
     outlineEnabled: true,
@@ -315,6 +320,8 @@ let state = {
   subtitleColorSwatches: [],
   closeModalsToken: 0,
 };
+let pendingSubtitleStyleOverride = null;
+let pendingSubtitleStyleOverrideTimer = 0;
 let isScrubbing = false;
 let scrubPositionMs = 0;
 let tapTimer = 0;
@@ -1084,12 +1091,25 @@ const renderAutoSyncCues = () => {
 
 const renderSubtitleStylePanel = () => {
   const style = state.subtitleStyle || {};
+  const storedOverrideEmbeddedStyles = style.overrideEmbeddedStyles !== false;
+  if (pendingSubtitleStyleOverride !== null && pendingSubtitleStyleOverride === storedOverrideEmbeddedStyles) {
+    pendingSubtitleStyleOverride = null;
+    window.clearTimeout(pendingSubtitleStyleOverrideTimer);
+    pendingSubtitleStyleOverrideTimer = 0;
+  }
+  const overrideEmbeddedStyles = pendingSubtitleStyleOverride ?? storedOverrideEmbeddedStyles;
   subtitleDelayLabel.textContent = state.subtitleDelayLabel || "Subtitle Delay";
   subtitleDelayValue.textContent = formatDelay(state.subtitleDelayMs);
   subtitleDelayReset.textContent = state.resetLabel || "Reset";
   autoSyncLabel.textContent = state.autoSyncLabel || "Auto Sync";
   autoSyncReload.textContent = state.reloadSmallLabel || "Reload";
   autoSyncCapture.textContent = state.captureLineLabel || "Capture";
+  customSubtitleStyleLabel.textContent = state.customSubtitleStyleLabel || "Use custom styling";
+  customSubtitleStyleToggle.textContent = overrideEmbeddedStyles
+    ? (state.onLabel || "On")
+    : (state.offLabel || "Off");
+  customSubtitleStyleToggle.classList.toggle("primary", overrideEmbeddedStyles);
+  customSubtitleStyleControls.classList.toggle("disabled", !overrideEmbeddedStyles);
   fontSizeLabel.textContent = state.fontSizeLabel || "Font Size";
   fontSizeValue.textContent = `${Number(style.fontSizeSp) || 18}sp`;
   outlineLabel.textContent = state.outlineLabel || "Outline";
@@ -2242,6 +2262,20 @@ autoSyncReload.addEventListener("click", event => {
 autoSyncCapture.addEventListener("click", event => {
   event.stopPropagation();
   send("subtitleAutoSyncCapture", 0);
+});
+customSubtitleStyleToggle.addEventListener("click", event => {
+  event.stopPropagation();
+  if (pendingSubtitleStyleOverride !== null) return;
+  const current = (state.subtitleStyle || {}).overrideEmbeddedStyles !== false;
+  pendingSubtitleStyleOverride = !current;
+  renderSubtitleStylePanel();
+  send("subtitleStyleOverrideToggle", 0);
+  window.clearTimeout(pendingSubtitleStyleOverrideTimer);
+  pendingSubtitleStyleOverrideTimer = window.setTimeout(() => {
+    pendingSubtitleStyleOverride = null;
+    pendingSubtitleStyleOverrideTimer = 0;
+    renderSubtitleStylePanel();
+  }, 1500);
 });
 fontSizeMinus.addEventListener("click", event => {
   event.stopPropagation();

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.ios.kt
@@ -454,6 +454,10 @@ actual object PlayerSettingsStorage {
         saveBoolean(subtitleShowOnlyPreferredLanguagesKey, enabled)
     }
 
+    actual fun loadSubtitleOverrideEmbeddedStyles(): Boolean? = null
+
+    actual fun saveSubtitleOverrideEmbeddedStyles(enabled: Boolean) = Unit
+
     actual fun loadAddonSubtitleStartupMode(): String? {
         val defaults = NSUserDefaults.standardUserDefaults
         val key = ProfileScopedKey.of(addonSubtitleStartupModeKey)


### PR DESCRIPTION
## Summary

Adds a choice between Nuvio's custom subtitle presentation and the styling authored inside embedded ASS or SSA tracks.

- Exposes `Use custom subtitle styling` in both Playback settings and the in player subtitle Style panel.
- Keeps the existing Nuvio subtitle appearance enabled by default.
- When disabled, preserves authored ASS or SSA colors, fonts, weight, outline, alignment, and placement instead of overriding them with application styling.
- Keeps subtitle size and vertical offset controls available in either mode.
- Applies the change live through the Windows and macOS native bridges without recreating the player, reloading the stream, or causing a playback buffer cycle.

Track selection, subtitle rendering engines, horizontal positioning, and offset ranges are unchanged.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

This is a draft pending explicit maintainer approval in #240. The approved change box will be selected after approval.

## Why

Desktop currently forces application colors, outline, weight, and placement over embedded ASS and SSA presentation. This removes styling authored for the stream and can make the same subtitle track render differently from other libass based players.

## Desktop scope

The toggle is exposed only for Desktop playback. Shared settings types and no op non Desktop actuals are required so the multiplatform project continues to compile. Native behavior is implemented for Windows and macOS.

## Issue or approval

Approval requested in #240.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

Pending explicit approval in #240.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [ ] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [ ] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

This does not add horizontal positioning, negative offsets, subtitle renderer changes, or track selection changes. Size and vertical offset remain adjustable in both modes.

## Testing

- Windows 11 manual playback with embedded ASS/SSA subtitles.
- Confirmed custom styling on preserves the existing Nuvio appearance.
- Confirmed custom styling off preserves authored ASS/SSA colors, outline, weight, and placement.
- Confirmed toggling does not restart or rebuffer playback.
- Confirmed font size and vertical offset remain adjustable with authored styling enabled.
- `:composeApp:compileKotlinDesktop` passed with the verified upstream Desktop compatibility actuals applied during validation.
- `:composeApp:buildWindowsPlayerBridge` passed.
- `node --check composeApp/src/desktopMain/resources/player-ui/controls.js` passed.
- `git diff --check` passed.

## Screenshots / Video

Before, forced application styling:

![Forced subtitle styling](https://github.com/user-attachments/assets/79f1a225-9750-427d-b666-919ad2b36c76)

After, authored ASS/SSA styling:

![Authored subtitle styling](https://github.com/user-attachments/assets/8a6bab28-2430-4d39-95b6-25829e90f8c1)

Setting:

![Custom subtitle style setting](https://github.com/user-attachments/assets/a489cc50-46ea-484b-ac11-7b4cc5997a42)

## Breaking changes

None. Existing custom styling remains enabled by default.

## Linked issues

Closes #240.