### PR TITLE
feat(player): add optional chapter markers

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.android.kt
@@ -199,6 +199,10 @@ actual object PlayerSettingsStorage {
             ?.apply()
     }
 
+    actual fun loadShowChapterMarkers(): Boolean? = null
+
+    actual fun saveShowChapterMarkers(enabled: Boolean) = Unit
+
     actual fun loadResizeMode(): String? =
         preferences?.getString(ProfileScopedKey.of(resizeModeKey), null)
 

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -1018,6 +1018,8 @@
     <string name="settings_playback_show_loading_overlay_description">Show loading screen until first video frame appears.</string>
     <string name="settings_playback_parental_guide">Content Warnings</string>
     <string name="settings_playback_parental_guide_description">Show parental guidance overlay when playback starts.</string>
+    <string name="settings_playback_show_chapter_markers">Show chapter markers</string>
+    <string name="settings_playback_show_chapter_markers_description">Display embedded chapter boundaries on the player timeline.</string>
     <string name="settings_playback_subtitle_background_color">Background Color</string>
     <string name="settings_playback_subtitle_bold">Bold</string>
     <string name="settings_playback_subtitle_bold_description">Use a heavier subtitle font weight.</string>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerEngine.kt
@@ -64,6 +64,7 @@ data class PlayerControlsState(
     val resizeModeLabel: String = "Fit",
     val playbackSpeedLabel: String = "1x",
     val volumeLevel: Float? = null,
+    val showChapterMarkers: Boolean = false,
     val subtitlesLabel: String = "Subs",
     val audioLabel: String = "Audio",
     val sourcesLabel: String = "Sources",

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
@@ -179,6 +179,7 @@ internal fun PlayerScreenRuntime.RenderPlayerRuntimeUi() {
         pauseOverlayDescription = (pauseDescription ?: activeStreamSubtitle).orEmpty(),
         resizeModeLabel = stringResource(resizeMode.labelRes),
         playbackSpeedLabel = formatPlaybackSpeedLabel(playbackSnapshot.playbackSpeed),
+        showChapterMarkers = playerSettingsUiState.showChapterMarkers,
         subtitlesLabel = stringResource(Res.string.compose_player_subs),
         audioLabel = stringResource(Res.string.compose_player_audio),
         sourcesLabel = stringResource(Res.string.compose_player_sources),

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSettingsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSettingsRepository.kt
@@ -34,6 +34,7 @@ fun snapToAllowedTimeout(value: Int): Int {
 data class PlayerSettingsUiState(
     val showLoadingOverlay: Boolean = true,
     val showParentalGuide: Boolean = true,
+    val showChapterMarkers: Boolean = false,
     val resizeMode: PlayerResizeMode = PlayerResizeMode.Fit,
     val holdToSpeedEnabled: Boolean = true,
     val holdToSpeedValue: Float = 2f,
@@ -101,6 +102,7 @@ object PlayerSettingsRepository {
     private var hasLoaded = false
     private var showLoadingOverlay = true
     private var showParentalGuide = true
+    private var showChapterMarkers = false
     private var resizeMode = PlayerResizeMode.Fit
     private var holdToSpeedEnabled = true
     private var holdToSpeedValue = 2f
@@ -173,6 +175,7 @@ object PlayerSettingsRepository {
         hasLoaded = false
         showLoadingOverlay = true
         showParentalGuide = true
+        showChapterMarkers = false
         resizeMode = PlayerResizeMode.Fit
         holdToSpeedEnabled = true
         holdToSpeedValue = 2f
@@ -238,6 +241,7 @@ object PlayerSettingsRepository {
         hasLoaded = true
         showLoadingOverlay = PlayerSettingsStorage.loadShowLoadingOverlay() ?: true
         showParentalGuide = PlayerSettingsStorage.loadShowParentalGuide() ?: true
+        showChapterMarkers = PlayerSettingsStorage.loadShowChapterMarkers() ?: false
         resizeMode = PlayerSettingsStorage.loadResizeMode()
             ?.let { runCatching { PlayerResizeMode.valueOf(it) }.getOrNull() }
             ?: PlayerResizeMode.Fit
@@ -526,6 +530,14 @@ object PlayerSettingsRepository {
         PlayerSettingsStorage.saveSubtitleBottomOffset(normalized.bottomOffset)
         PlayerSettingsStorage.saveSubtitleUseForcedSubtitles(normalized.useForcedSubtitles)
         PlayerSettingsStorage.saveSubtitleShowOnlyPreferredLanguages(normalized.showOnlyPreferredLanguages)
+    }
+
+    fun setShowChapterMarkers(enabled: Boolean) {
+        ensureLoaded()
+        if (showChapterMarkers == enabled) return
+        showChapterMarkers = enabled
+        publish()
+        PlayerSettingsStorage.saveShowChapterMarkers(enabled)
     }
 
     fun setAddonSubtitleStartupMode(mode: AddonSubtitleStartupMode) {
@@ -939,6 +951,7 @@ object PlayerSettingsRepository {
         _uiState.value = PlayerSettingsUiState(
             showLoadingOverlay = showLoadingOverlay,
             showParentalGuide = showParentalGuide,
+            showChapterMarkers = showChapterMarkers,
             resizeMode = resizeMode,
             holdToSpeedEnabled = holdToSpeedEnabled,
             holdToSpeedValue = holdToSpeedValue,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.kt
@@ -7,6 +7,8 @@ internal expect object PlayerSettingsStorage {
     fun saveShowLoadingOverlay(enabled: Boolean)
     fun loadShowParentalGuide(): Boolean?
     fun saveShowParentalGuide(enabled: Boolean)
+    fun loadShowChapterMarkers(): Boolean?
+    fun saveShowChapterMarkers(enabled: Boolean)
     fun loadResizeMode(): String?
     fun saveResizeMode(mode: String)
     fun loadHoldToSpeedEnabled(): Boolean?

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/PlaybackSettingsPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/PlaybackSettingsPage.kt
@@ -349,6 +349,16 @@ private fun PlaybackSettingsSection(
                     isTablet = isTablet,
                     onCheckedChange = PlayerSettingsRepository::setShowParentalGuide,
                 )
+                if (isDesktop) {
+                    SettingsGroupDivider(isTablet = isTablet)
+                    SettingsSwitchRow(
+                        title = stringResource(Res.string.settings_playback_show_chapter_markers),
+                        description = stringResource(Res.string.settings_playback_show_chapter_markers_description),
+                        checked = autoPlayPlayerSettings.showChapterMarkers,
+                        isTablet = isTablet,
+                        onCheckedChange = PlayerSettingsRepository::setShowChapterMarkers,
+                    )
+                }
                 if (externalPlayerSupported) {
                     SettingsGroupDivider(isTablet = isTablet)
                     SettingsNavigationRow(

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.desktop.kt
@@ -19,6 +19,7 @@ import kotlinx.serialization.json.put
 internal actual object PlayerSettingsStorage {
     private const val showLoadingOverlayKey = "show_loading_overlay"
     private const val showParentalGuideKey = "show_parental_guide"
+    private const val showChapterMarkersKey = "show_chapter_markers"
     private const val resizeModeKey = "resize_mode"
     private const val holdToSpeedEnabledKey = "hold_to_speed_enabled"
     private const val holdToSpeedValueKey = "hold_to_speed_value"
@@ -89,6 +90,7 @@ internal actual object PlayerSettingsStorage {
     private val syncKeys = listOf(
         showLoadingOverlayKey,
         showParentalGuideKey,
+        showChapterMarkersKey,
         resizeModeKey,
         holdToSpeedEnabledKey,
         holdToSpeedValueKey,
@@ -161,6 +163,8 @@ internal actual object PlayerSettingsStorage {
     actual fun saveShowLoadingOverlay(enabled: Boolean) = saveBoolean(showLoadingOverlayKey, enabled)
     actual fun loadShowParentalGuide(): Boolean? = loadBoolean(showParentalGuideKey)
     actual fun saveShowParentalGuide(enabled: Boolean) = saveBoolean(showParentalGuideKey, enabled)
+    actual fun loadShowChapterMarkers(): Boolean? = loadBoolean(showChapterMarkersKey)
+    actual fun saveShowChapterMarkers(enabled: Boolean) = saveBoolean(showChapterMarkersKey, enabled)
     actual fun loadResizeMode(): String? = loadString(resizeModeKey)
     actual fun saveResizeMode(mode: String) = saveString(resizeModeKey, mode)
     actual fun loadHoldToSpeedEnabled(): Boolean? = loadBoolean(holdToSpeedEnabledKey)
@@ -315,6 +319,7 @@ internal actual object PlayerSettingsStorage {
     actual fun exportToSyncPayload(): JsonObject = buildJsonObject {
         loadShowLoadingOverlay()?.let { put(showLoadingOverlayKey, encodeSyncBoolean(it)) }
         loadShowParentalGuide()?.let { put(showParentalGuideKey, encodeSyncBoolean(it)) }
+        loadShowChapterMarkers()?.let { put(showChapterMarkersKey, encodeSyncBoolean(it)) }
         loadResizeMode()?.let { put(resizeModeKey, encodeSyncString(it)) }
         loadHoldToSpeedEnabled()?.let { put(holdToSpeedEnabledKey, encodeSyncBoolean(it)) }
         loadHoldToSpeedValue()?.let { put(holdToSpeedValueKey, encodeSyncFloat(it)) }
@@ -388,6 +393,7 @@ internal actual object PlayerSettingsStorage {
         store.removeAll(syncKeys.map(::scoped))
         payload.decodeSyncBoolean(showLoadingOverlayKey)?.let(::saveShowLoadingOverlay)
         payload.decodeSyncBoolean(showParentalGuideKey)?.let(::saveShowParentalGuide)
+        payload.decodeSyncBoolean(showChapterMarkersKey)?.let(::saveShowChapterMarkers)
         payload.decodeSyncString(resizeModeKey)?.let(::saveResizeMode)
         payload.decodeSyncBoolean(holdToSpeedEnabledKey)?.let(::saveHoldToSpeedEnabled)
         payload.decodeSyncFloat(holdToSpeedValueKey)?.let(::saveHoldToSpeedValue)

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
@@ -671,6 +671,8 @@ private fun PlayerControlsState.toControlsJson(isFullscreen: Boolean): String =
         append(',')
         appendJsonField("volumeLevel", volumeLevel)
         append(',')
+        appendJsonField("showChapterMarkers", showChapterMarkers)
+        append(',')
         appendJsonField("subtitlesLabel", subtitlesLabel)
         append(',')
         appendJsonField("audioLabel", audioLabel)

--- a/composeApp/src/desktopMain/native/macos/player_bridge.mm
+++ b/composeApp/src/desktopMain/native/macos/player_bridge.mm
@@ -109,6 +109,7 @@
 - (BOOL)isEnded;
 - (NSString *)audioTracksJson;
 - (NSString *)subtitleTracksJson;
+- (NSString *)chaptersJson;
 - (void)selectAudioTrackId:(int)trackId;
 - (void)selectSubtitleTrackId:(int)trackId;
 - (void)addSubtitleUrl:(NSString *)url;
@@ -1504,6 +1505,7 @@ static void setMpvOptionString(mpv_handle *mpv, const char *name, const char *va
             double speed = [self rawSpeed];
             NSString *audioTracks = [self audioTracksJson] ?: @"[]";
             NSString *subtitleTracks = [self subtitleTracksJson] ?: @"[]";
+            NSString *chapters = [self chaptersJson] ?: @"[]";
             NSString *gamma = [[self stringProperty:"video-params/gamma" fallback:@""] lowercaseString];
             NSString *primaries = [[self stringProperty:"video-params/primaries" fallback:@""] lowercaseString];
             [self updateCachedDuration:duration
@@ -1521,13 +1523,14 @@ static void setMpvOptionString(mpv_handle *mpv, const char *name, const char *va
                 }
                 [self applyHdrForPolledGamma:gamma primaries:primaries reason:@"sync" force:NO];
                 NSString *script = [NSString stringWithFormat:
-                    @"window.playerUpdate({duration:%0.3f,position:%0.3f,paused:%@,loading:%@,audioTracks:%@,subtitleTracks:%@})",
+                    @"window.playerUpdate({duration:%0.3f,position:%0.3f,paused:%@,loading:%@,audioTracks:%@,subtitleTracks:%@,chapters:%@})",
                     duration,
                     position,
                     paused ? @"true" : @"false",
                     loading ? @"true" : @"false",
                     audioTracks,
-                    subtitleTracks];
+                    subtitleTracks,
+                    chapters];
                 [self->_webView evaluateJavaScript:script completionHandler:nil];
             });
         }
@@ -1966,6 +1969,22 @@ static void setMpvOptionString(mpv_handle *mpv, const char *name, const char *va
 
 - (NSString *)subtitleTracksJson {
     return [self tracksJsonForType:@"sub"];
+}
+
+- (NSString *)chaptersJson {
+    long long count = [self int64Property:"chapter-list/count" fallback:0];
+    NSMutableArray *chapters = [NSMutableArray arrayWithCapacity:(NSUInteger)MAX(0, count)];
+    for (long long index = 0; index < count; index++) {
+        NSString *prefix = [NSString stringWithFormat:@"chapter-list/%lld", index];
+        NSString *timeKey = [prefix stringByAppendingString:@"/time"];
+        double time = [self doubleProperty:timeKey.UTF8String fallback:-1.0];
+        if (!std::isfinite(time) || time < 0.0) continue;
+        NSString *titleKey = [prefix stringByAppendingString:@"/title"];
+        NSString *title = [self stringProperty:titleKey.UTF8String fallback:@""];
+        [chapters addObject:@{@"time": @(time), @"title": title ?: @""}];
+    }
+    NSData *data = [NSJSONSerialization dataWithJSONObject:chapters options:0 error:nil];
+    return data ? [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] : @"[]";
 }
 
 - (void)selectAudioTrackId:(int)trackId {

--- a/composeApp/src/desktopMain/native/windows/player_bridge.cpp
+++ b/composeApp/src/desktopMain/native/windows/player_bridge.cpp
@@ -1004,6 +1004,25 @@ public:
         return tracksJsonForType("sub");
     }
 
+    std::string chaptersJson() {
+        long long count = int64Property("chapter-list/count", 0);
+        std::ostringstream json;
+        json << "[";
+        bool first = true;
+        for (long long index = 0; index < count; index++) {
+            std::string prefix = "chapter-list/" + std::to_string(index);
+            double time = doubleProperty((prefix + "/time").c_str(), -1.0);
+            if (!std::isfinite(time) || time < 0.0) continue;
+            std::string title = stringProperty((prefix + "/title").c_str(), "");
+            if (!first) json << ",";
+            first = false;
+            json << "{\"time\":" << time
+                 << ",\"title\":\"" << jsonEscape(title) << "\"}";
+        }
+        json << "]";
+        return json.str();
+    }
+
     void selectAudioTrackId(int trackId) {
         std::lock_guard<std::mutex> lock(mpvMutex);
         if (!mpv) return;
@@ -1556,6 +1575,7 @@ private:
         bool loading = isLoading();
         std::string audioTracks = audioTracksJson();
         std::string subtitleTracks = subtitleTracksJson();
+        std::string chapters = chaptersJson();
 
         std::ostringstream script;
         script << "window.playerUpdate({duration:" << duration
@@ -1564,6 +1584,7 @@ private:
                << ",loading:" << (loading ? "true" : "false")
                << ",audioTracks:" << audioTracks
                << ",subtitleTracks:" << subtitleTracks
+               << ",chapters:" << chapters
                << "})";
         std::wstring wideScript = toWide(script.str());
         webView->ExecuteScript(wideScript.c_str(), nullptr);

--- a/composeApp/src/desktopMain/resources/player-ui/controls.css
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.css
@@ -138,6 +138,32 @@ button:disabled {
   cursor: default;
 }
 
+.timeline {
+  position: relative;
+  width: 100%;
+  height: 10px;
+}
+
+.chapter-markers {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
+  overflow: hidden;
+  border-radius: 999px;
+}
+
+.chapter-marker {
+  position: absolute;
+  top: 1px;
+  width: 2px;
+  height: 8px;
+  transform: translateX(-1px);
+  border-radius: 1px;
+  background: rgba(0, 0, 0, .72);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, .74);
+}
+
 .player {
   position: relative;
   width: 100%;

--- a/composeApp/src/desktopMain/resources/player-ui/controls.html
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.html
@@ -196,7 +196,10 @@
             <span class="provider" id="providerName"></span>
           </div>
         </section>
-        <input id="seek" class="scrub" type="range" min="0" max="1000" value="0" aria-label="Seek">
+        <div class="timeline">
+          <input id="seek" class="scrub" type="range" min="0" max="1000" value="0" aria-label="Seek">
+          <div class="chapter-markers" id="chapterMarkers" aria-hidden="true"></div>
+        </div>
         <div class="time-row">
           <span class="time-pill" id="position">00:00</span>
           <span class="time-pill" id="duration">00:00</span>

--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -1,5 +1,6 @@
 const root = document.getElementById("playerRoot");
 const seek = document.getElementById("seek");
+const chapterMarkers = document.getElementById("chapterMarkers");
 const positionLabel = document.getElementById("position");
 const durationLabel = document.getElementById("duration");
 const timeLabel = document.getElementById("timeLabel");
@@ -168,6 +169,8 @@ let state = {
   playbackSpeedLabel: "1x",
   isFullscreen: false,
   volumeLevel: null,
+  showChapterMarkers: false,
+  chapters: [],
   subtitlesLabel: "Subs",
   audioLabel: "Audio",
   sourcesLabel: "Sources",
@@ -657,12 +660,37 @@ const formatTime = milliseconds => {
     : `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
 };
 
+let lastChapterMarkerSignature = "";
+
+const renderChapterMarkers = durationMs => {
+  const chapters = Array.isArray(state.chapters) ? state.chapters : [];
+  const visibleChapters = state.showChapterMarkers && durationMs > 0
+    ? chapters.filter(chapter => {
+        const timeMs = Number(chapter.time) * 1000;
+        return Number.isFinite(timeMs) && timeMs > 0 && timeMs < durationMs;
+      })
+    : [];
+  const signature = visibleChapters
+    .map(chapter => `${Number(chapter.time).toFixed(3)}:${String(chapter.title || "")}`)
+    .join("|");
+  if (signature === lastChapterMarkerSignature) return;
+  lastChapterMarkerSignature = signature;
+  chapterMarkers.textContent = "";
+  visibleChapters.forEach(chapter => {
+    const marker = document.createElement("span");
+    marker.className = "chapter-marker";
+    marker.style.left = `${Math.max(0, Math.min(100, Number(chapter.time) * 100000 / durationMs))}%`;
+    chapterMarkers.appendChild(marker);
+  });
+};
+
 const setProgress = (positionMs, durationMs) => {
   const percent = durationMs > 0 ? Math.max(0, Math.min(100, positionMs / durationMs * 100)) : 0;
   seek.value = Math.round(percent * 10);
   seek.style.setProperty("--progress", `${percent}%`);
   positionLabel.textContent = formatTime(positionMs);
   durationLabel.textContent = formatTime(durationMs);
+  renderChapterMarkers(durationMs);
   if (timeLabel) {
     timeLabel.textContent = `${formatTime(positionMs)} / ${formatTime(durationMs)}`;
   }
@@ -2448,6 +2476,7 @@ window.playerUpdate = update => {
   const positionMs = Math.round((Number(update.position) || 0) * 1000);
   const audioTracks = normalizeTracks(update.audioTracks);
   const subtitleTracks = normalizeTracks(update.subtitleTracks);
+  const chapters = normalizeItems(update.chapters);
   const audioTracksChanged = trackListSignature(audioTracks) !== trackListSignature(state.audioTracks);
   const subtitleTracksChanged = trackListSignature(subtitleTracks) !== trackListSignature(state.subtitleTracks);
   state = {
@@ -2458,6 +2487,7 @@ window.playerUpdate = update => {
     isLoading: Boolean(update.loading || update.isLoading),
     audioTracks,
     subtitleTracks,
+    chapters,
   };
   renderChrome();
   if ((audioTracksChanged && activeModal === "audio") ||

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.ios.kt
@@ -204,6 +204,10 @@ actual object PlayerSettingsStorage {
         NSUserDefaults.standardUserDefaults.setBool(enabled, forKey = ProfileScopedKey.of(showParentalGuideKey))
     }
 
+    actual fun loadShowChapterMarkers(): Boolean? = null
+
+    actual fun saveShowChapterMarkers(enabled: Boolean) = Unit
+
     actual fun loadResizeMode(): String? {
         val defaults = NSUserDefaults.standardUserDefaults
         val key = ProfileScopedKey.of(resizeModeKey)


### PR DESCRIPTION
## Summary

Adds optional chapter boundaries to the existing Desktop player timeline using chapter metadata already exposed by the native players.

- Adds a `Show chapter markers` setting that defaults to off.
- Reads embedded chapter lists through the Windows and macOS native player bridges.
- Renders valid interior chapter boundaries over the seek bar and refreshes them when the active media changes.
- Leaves the timeline unchanged for streams without chapter metadata or while the setting is disabled.
- Does not change seeking, chapter navigation, control timing, or playback behavior.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

This is a draft pending explicit maintainer approval in #255. The approved change box will be selected after approval.

## Why

The native player already has access to embedded chapter metadata, but Desktop users cannot see chapter boundaries while seeking.

## Desktop scope

The setting is shown only on Desktop. Chapter extraction is implemented for Windows and macOS, with shared controls state used to feed the Desktop player UI.

## Issue or approval

Approval requested in #255.

## UI / behavior impact

- [ ] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

Pending explicit UI approval in #255.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [ ] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [ ] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Markers are off by default. Seeking, chapter navigation, controls timing, and streams without chapters are unchanged.

## Testing

- Windows 11 manual playback with chaptered and non chaptered media.
- Confirmed markers appear only when enabled and only for valid interior chapter boundaries.
- Confirmed streams without chapters retain the existing timeline.
- `:composeApp:compileKotlinDesktop` passed with the verified upstream Desktop compatibility actuals applied during validation.
- `:composeApp:buildWindowsPlayerBridge` passed.
- `node --check composeApp/src/desktopMain/resources/player-ui/controls.js` passed.
- `git diff --check` passed.
- macOS native source was reviewed but could not be built on Windows.

## Screenshots / Video

![Show chapter markers setting](https://github.com/user-attachments/assets/48c835ac-d391-4d50-b951-2dd7d8d83954)

## Breaking changes

None. The setting defaults to off.

## Linked issues

Closes #255.