### PR TITLE
feat(player): add optional click to pause

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.android.kt
@@ -199,6 +199,10 @@ actual object PlayerSettingsStorage {
             ?.apply()
     }
 
+    actual fun loadVideoClickTogglesPlayback(): Boolean? = null
+
+    actual fun saveVideoClickTogglesPlayback(enabled: Boolean) = Unit
+
     actual fun loadResizeMode(): String? =
         preferences?.getString(ProfileScopedKey.of(resizeModeKey), null)
 

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -1025,6 +1025,8 @@
     <string name="settings_playback_show_loading_overlay_description">Show loading screen until first video frame appears.</string>
     <string name="settings_playback_parental_guide">Content Warnings</string>
     <string name="settings_playback_parental_guide_description">Show parental guidance overlay when playback starts.</string>
+    <string name="settings_playback_video_click_toggles_playback">Click video to play or pause</string>
+    <string name="settings_playback_video_click_toggles_playback_description">Pause or resume playback with a single click on the video surface.</string>
     <string name="settings_playback_subtitle_background_color">Background Color</string>
     <string name="settings_playback_subtitle_bold">Bold</string>
     <string name="settings_playback_subtitle_bold_description">Use a heavier subtitle font weight.</string>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerEngine.kt
@@ -64,6 +64,7 @@ data class PlayerControlsState(
     val resizeModeLabel: String = "Fit",
     val playbackSpeedLabel: String = "1x",
     val volumeLevel: Float? = null,
+    val videoClickTogglesPlayback: Boolean = false,
     val subtitlesLabel: String = "Subs",
     val audioLabel: String = "Audio",
     val sourcesLabel: String = "Sources",

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
@@ -179,6 +179,7 @@ internal fun PlayerScreenRuntime.RenderPlayerRuntimeUi() {
         pauseOverlayDescription = (pauseDescription ?: activeStreamSubtitle).orEmpty(),
         resizeModeLabel = stringResource(resizeMode.labelRes),
         playbackSpeedLabel = formatPlaybackSpeedLabel(playbackSnapshot.playbackSpeed),
+        videoClickTogglesPlayback = playerSettingsUiState.videoClickTogglesPlayback,
         subtitlesLabel = stringResource(Res.string.compose_player_subs),
         audioLabel = stringResource(Res.string.compose_player_audio),
         sourcesLabel = stringResource(Res.string.compose_player_sources),

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSettingsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSettingsRepository.kt
@@ -34,6 +34,7 @@ fun snapToAllowedTimeout(value: Int): Int {
 data class PlayerSettingsUiState(
     val showLoadingOverlay: Boolean = true,
     val showParentalGuide: Boolean = true,
+    val videoClickTogglesPlayback: Boolean = false,
     val resizeMode: PlayerResizeMode = PlayerResizeMode.Fit,
     val holdToSpeedEnabled: Boolean = true,
     val holdToSpeedValue: Float = 2f,
@@ -101,6 +102,7 @@ object PlayerSettingsRepository {
     private var hasLoaded = false
     private var showLoadingOverlay = true
     private var showParentalGuide = true
+    private var videoClickTogglesPlayback = false
     private var resizeMode = PlayerResizeMode.Fit
     private var holdToSpeedEnabled = true
     private var holdToSpeedValue = 2f
@@ -173,6 +175,7 @@ object PlayerSettingsRepository {
         hasLoaded = false
         showLoadingOverlay = true
         showParentalGuide = true
+        videoClickTogglesPlayback = false
         resizeMode = PlayerResizeMode.Fit
         holdToSpeedEnabled = true
         holdToSpeedValue = 2f
@@ -238,6 +241,7 @@ object PlayerSettingsRepository {
         hasLoaded = true
         showLoadingOverlay = PlayerSettingsStorage.loadShowLoadingOverlay() ?: true
         showParentalGuide = PlayerSettingsStorage.loadShowParentalGuide() ?: true
+        videoClickTogglesPlayback = PlayerSettingsStorage.loadVideoClickTogglesPlayback() ?: false
         resizeMode = PlayerSettingsStorage.loadResizeMode()
             ?.let { runCatching { PlayerResizeMode.valueOf(it) }.getOrNull() }
             ?: PlayerResizeMode.Fit
@@ -526,6 +530,14 @@ object PlayerSettingsRepository {
         PlayerSettingsStorage.saveSubtitleBottomOffset(normalized.bottomOffset)
         PlayerSettingsStorage.saveSubtitleUseForcedSubtitles(normalized.useForcedSubtitles)
         PlayerSettingsStorage.saveSubtitleShowOnlyPreferredLanguages(normalized.showOnlyPreferredLanguages)
+    }
+
+    fun setVideoClickTogglesPlayback(enabled: Boolean) {
+        ensureLoaded()
+        if (videoClickTogglesPlayback == enabled) return
+        videoClickTogglesPlayback = enabled
+        publish()
+        PlayerSettingsStorage.saveVideoClickTogglesPlayback(enabled)
     }
 
     fun setAddonSubtitleStartupMode(mode: AddonSubtitleStartupMode) {
@@ -939,6 +951,7 @@ object PlayerSettingsRepository {
         _uiState.value = PlayerSettingsUiState(
             showLoadingOverlay = showLoadingOverlay,
             showParentalGuide = showParentalGuide,
+            videoClickTogglesPlayback = videoClickTogglesPlayback,
             resizeMode = resizeMode,
             holdToSpeedEnabled = holdToSpeedEnabled,
             holdToSpeedValue = holdToSpeedValue,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.kt
@@ -7,6 +7,8 @@ internal expect object PlayerSettingsStorage {
     fun saveShowLoadingOverlay(enabled: Boolean)
     fun loadShowParentalGuide(): Boolean?
     fun saveShowParentalGuide(enabled: Boolean)
+    fun loadVideoClickTogglesPlayback(): Boolean?
+    fun saveVideoClickTogglesPlayback(enabled: Boolean)
     fun loadResizeMode(): String?
     fun saveResizeMode(mode: String)
     fun loadHoldToSpeedEnabled(): Boolean?

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/PlaybackSettingsPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/PlaybackSettingsPage.kt
@@ -349,6 +349,16 @@ private fun PlaybackSettingsSection(
                     isTablet = isTablet,
                     onCheckedChange = PlayerSettingsRepository::setShowParentalGuide,
                 )
+                if (isDesktop) {
+                    SettingsGroupDivider(isTablet = isTablet)
+                    SettingsSwitchRow(
+                        title = stringResource(Res.string.settings_playback_video_click_toggles_playback),
+                        description = stringResource(Res.string.settings_playback_video_click_toggles_playback_description),
+                        checked = autoPlayPlayerSettings.videoClickTogglesPlayback,
+                        isTablet = isTablet,
+                        onCheckedChange = PlayerSettingsRepository::setVideoClickTogglesPlayback,
+                    )
+                }
                 if (externalPlayerSupported) {
                     SettingsGroupDivider(isTablet = isTablet)
                     SettingsNavigationRow(

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.desktop.kt
@@ -12,6 +12,7 @@ import com.nuvio.app.core.sync.encodeSyncFloat
 import com.nuvio.app.core.sync.encodeSyncInt
 import com.nuvio.app.core.sync.encodeSyncString
 import com.nuvio.app.core.sync.encodeSyncStringSet
+import com.nuvio.app.features.player.desktop.DesktopVideoClickStorage
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -161,6 +162,10 @@ internal actual object PlayerSettingsStorage {
     actual fun saveShowLoadingOverlay(enabled: Boolean) = saveBoolean(showLoadingOverlayKey, enabled)
     actual fun loadShowParentalGuide(): Boolean? = loadBoolean(showParentalGuideKey)
     actual fun saveShowParentalGuide(enabled: Boolean) = saveBoolean(showParentalGuideKey, enabled)
+    actual fun loadVideoClickTogglesPlayback(): Boolean? =
+        DesktopVideoClickStorage.loadVideoClickTogglesPlayback()
+    actual fun saveVideoClickTogglesPlayback(enabled: Boolean) =
+        DesktopVideoClickStorage.saveVideoClickTogglesPlayback(enabled)
     actual fun loadResizeMode(): String? = loadString(resizeModeKey)
     actual fun saveResizeMode(mode: String) = saveString(resizeModeKey, mode)
     actual fun loadHoldToSpeedEnabled(): Boolean? = loadBoolean(holdToSpeedEnabledKey)

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopVideoClickStorage.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopVideoClickStorage.kt
@@ -1,0 +1,15 @@
+package com.nuvio.app.features.player.desktop
+
+import com.nuvio.app.core.storage.DesktopStorage
+
+internal object DesktopVideoClickStorage {
+    private const val VideoClickTogglesPlaybackKey = "video_click_toggles_playback"
+    private val store = DesktopStorage.store("nuvio_player_runtime")
+
+    fun loadVideoClickTogglesPlayback(): Boolean? =
+        store.getBoolean(VideoClickTogglesPlaybackKey)
+
+    fun saveVideoClickTogglesPlayback(enabled: Boolean) {
+        store.putBoolean(VideoClickTogglesPlaybackKey, enabled)
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
@@ -671,6 +671,8 @@ private fun PlayerControlsState.toControlsJson(isFullscreen: Boolean): String =
         append(',')
         appendJsonField("volumeLevel", volumeLevel)
         append(',')
+        appendJsonField("videoClickTogglesPlayback", videoClickTogglesPlayback)
+        append(',')
         appendJsonField("subtitlesLabel", subtitlesLabel)
         append(',')
         appendJsonField("audioLabel", audioLabel)

--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -168,6 +168,7 @@ let state = {
   playbackSpeedLabel: "1x",
   isFullscreen: false,
   volumeLevel: null,
+  videoClickTogglesPlayback: false,
   subtitlesLabel: "Subs",
   audioLabel: "Audio",
   sourcesLabel: "Sources",
@@ -2503,16 +2504,25 @@ window.playerControls = nextState => {
 
 root.addEventListener("click", event => {
   if (playbackErrorText()) return;
-  if (event.target.closest("button,input")) return;
+  if (isChromeInteractionTarget(event.target)) return;
   window.clearTimeout(tapTimer);
   tapTimer = window.setTimeout(() => {
-    toggleChrome();
+    if (state.isLocked) {
+      send("revealLockedOverlay", 0);
+      return;
+    }
+    noteChromeActivity(true);
+    if (state.videoClickTogglesPlayback) {
+      send("toggle", 0);
+    } else {
+      toggleChrome();
+    }
   }, 220);
 });
 
 root.addEventListener("dblclick", event => {
   if (playbackErrorText()) return;
-  if (event.target.closest("button,input")) return;
+  if (isChromeInteractionTarget(event.target)) return;
   event.preventDefault();
   window.clearTimeout(tapTimer);
   togglePlayerFullscreen();

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.ios.kt
@@ -204,6 +204,10 @@ actual object PlayerSettingsStorage {
         NSUserDefaults.standardUserDefaults.setBool(enabled, forKey = ProfileScopedKey.of(showParentalGuideKey))
     }
 
+    actual fun loadVideoClickTogglesPlayback(): Boolean? = null
+
+    actual fun saveVideoClickTogglesPlayback(enabled: Boolean) = Unit
+
     actual fun loadResizeMode(): String? {
         val defaults = NSUserDefaults.standardUserDefaults
         val key = ProfileScopedKey.of(resizeModeKey)


### PR DESCRIPTION
## Summary

Adds an optional direct click interaction for pausing and resuming Desktop playback.

- Adds a `Click video to play or pause` setting for the Windows and macOS player that defaults to off.
- When enabled, a single click on the unobstructed video surface toggles playback.
- Clicks on player buttons, sliders, menus, and other interactive controls are excluded.
- Double click fullscreen, locked controls, and keyboard shortcuts retain their existing behavior.
- When disabled, a single click continues to use the existing controls visibility behavior, so current users see no interaction change by default.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

This is a draft pending explicit maintainer approval in #230. The approved change box will be selected after approval.

## Why

Pausing currently requires the control button or keyboard. The requested option makes a direct click on the video surface available without changing the default interaction for existing users.

## Desktop scope

This affects the Windows and macOS Desktop player web controls only. The setting is stored as Desktop local runtime state.

## Issue or approval

Approval requested in #230. Related request: #126.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

Pending explicit approval in #230.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [ ] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [ ] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

The option defaults to off. Double click fullscreen, control interactions, locked controls, keyboard shortcuts, and the existing single click chrome behavior when disabled are preserved.

## Testing

- Windows 11 manual playback with the option enabled and disabled.
- Confirmed enabled single click toggles playback.
- Confirmed disabled single click keeps the existing controls visibility behavior.
- Confirmed buttons, inputs, double click fullscreen, and locked controls do not produce unintended playback toggles.
- `:composeApp:compileKotlinDesktop` passed with the verified upstream Desktop compatibility actuals applied during validation.
- `node --check composeApp/src/desktopMain/resources/player-ui/controls.js` passed.
- `git diff --check` passed.

## Screenshots / Video

![Click video setting](https://github.com/user-attachments/assets/d2c253f3-b9ff-4d2b-87c5-f292622284da)

## Breaking changes

None. The setting defaults to off.

## Linked issues

Closes #230.

Related: #126.