### PR TITLE
fix(player): dispose the native player off the event thread

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
@@ -348,8 +348,14 @@ internal class NativePlayerController(
         val current = handle
         handle = 0L
         lastSentControlsStructureKey = null
-        if (current != 0L) {
-            runCatching { NativePlayerBridge.dispose(current) }
+        if (current == 0L) return
+        // Native shutdown blocks: it SendMessage()s the player's own UI thread and then joins it.
+        // That UI thread owns child windows of the AWT host, so tearing them down needs the EDT to
+        // keep pumping messages. Disposing on the EDT is therefore a circular wait that deadlocks
+        // the whole app (black, completely unresponsive window). Tear down off the EDT instead.
+        Thread({ runCatching { NativePlayerBridge.dispose(current) } }, "nuvio-player-dispose").apply {
+            isDaemon = true
+            start()
         }
     }
 


### PR DESCRIPTION
## Summary

Dispose the native desktop player on a short-lived background thread instead of the AWT event dispatch thread, so exiting playback can no longer deadlock the UI.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Exiting a video intermittently left the whole window black and completely unresponsive, with no way to close it (#237).

It is not a rendering bug. `NativePlayerBridge.dispose` runs the native `shutdown()` synchronously on the calling thread, which was the event dispatch thread. `shutdown()` calls `sendUiTask`, which does a blocking `SendMessageW` to the player own UI thread and then joins it. The task it waits on tears down `containerHwnd`, a child window of the AWT host HWND owned by the event thread, so it needs that thread to keep pumping messages. The event thread waits for the player UI thread, the player UI thread needs the event thread: a circular wait that deadlocks the UI, so nothing paints and no input is processed.

## Desktop scope

Windows and macOS desktop. The change is in shared desktop Kotlin (`NativePlayerController`), and the blocking teardown it works around exists in both native bridges.

## Issue or approval

Fixes #237

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the dispose call is moved off the event thread. The native teardown itself is unchanged, as is player creation. No UI, no formatting, no refactors.

## Testing

Windows 11, built from source, 0.1.13-alpha.

Diagnosed with a JVM thread dump taken while the app was hung: the event thread was blocked in the native dispose path while background threads kept running. Verified by instrumenting the event thread, Swing timers scheduled immediately after dispose never fired at all before the change, and fire normally after it.

Manually exercised afterwards: entered and exited playback repeatedly, including from fullscreen, and switched sources and episodes back to back. The app returns to the previous screen and stays responsive.

Not tested on macOS or Linux.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #237