### PR TITLE
fix(player): bound the native player shutdown so it cannot strand its windows

### DIFF
--- a/composeApp/src/desktopMain/native/windows/player_bridge.cpp
+++ b/composeApp/src/desktopMain/native/windows/player_bridge.cpp
@@ -60,6 +60,12 @@ namespace {
 HMODULE gModule = nullptr;
 constexpr UINT WM_NUVIO_TASK = WM_APP + 0x4E50;
 constexpr UINT_PTR NUVIO_TIMER_ID = 0x4E50;
+
+// Caps on waiting for the player's own UI thread during teardown. Exceeding these means that
+// thread is wedged; shutdown gives up rather than blocking the caller forever.
+constexpr UINT kUiTaskTimeoutMs = 2000;
+constexpr UINT kShutdownJoinTimeoutMs = 3000;
+
 const wchar_t *kMessageWindowClass = L"NuvioPlayerBridgeMessageWindow";
 const wchar_t *kContainerWindowClass = L"NuvioPlayerBridgeContainerWindow";
 constexpr DWORD kDwmwaUseImmersiveDarkMode = 20;
@@ -811,9 +817,41 @@ public:
         }
     }
 
+    // Waits a bounded time for a thread to finish, then gives up and detaches it. Shutdown must
+    // always complete: a thread that never returns must not strand the player's windows alive.
+    static void joinOrDetach(std::thread &thread) {
+        if (!thread.joinable()) return;
+        auto finished = std::make_shared<std::atomic_bool>(false);
+        std::thread waiter([&thread, finished]() {
+            thread.join();
+            finished->store(true);
+        });
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(kShutdownJoinTimeoutMs);
+        while (!finished->load() && std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        if (finished->load()) {
+            waiter.join();
+        } else {
+            waiter.detach();
+        }
+    }
+
     void shutdown() {
         if (shuttingDown.exchange(true)) {
             return;
+        }
+
+        // Hide the player's window immediately, asynchronously, before anything below can block.
+        // If the UI thread has stopped pumping, the steps after this can stall and the window is
+        // then never destroyed, leaving a zombie child sitting over the AWT host that swallows
+        // every mouse and key event while video keeps playing. SWP_ASYNCWINDOWPOS posts rather
+        // than sends, so it cannot block on the stalled thread.
+        if (containerHwnd && IsWindow(containerHwnd)) {
+            SetWindowPos(
+                containerHwnd, nullptr, 0, 0, 0, 0,
+                SWP_HIDEWINDOW | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_ASYNCWINDOWPOS
+            );
         }
 
         sendUiTask([self = shared_from_this()]() {
@@ -828,9 +866,8 @@ public:
                 mpvApi().wakeup(mpv);
             }
         }
-        if (eventThread.joinable()) {
-            eventThread.join();
-        }
+        // Bounded: if a thread will not finish we detach rather than block dispose forever.
+        joinOrDetach(eventThread);
         {
             std::lock_guard<std::mutex> lock(mpvMutex);
             if (mpv) {
@@ -838,8 +875,8 @@ public:
                 mpv = nullptr;
             }
         }
-        if (uiThread.joinable() && GetCurrentThreadId() != uiThreadId) {
-            uiThread.join();
+        if (GetCurrentThreadId() != uiThreadId) {
+            joinOrDetach(uiThread);
         }
 
         if (eventSink) {
@@ -1283,10 +1320,18 @@ private:
                 doneCv->notify_one();
             });
         }
-        SendMessageW(messageHwnd, WM_NUVIO_TASK, 0, 0);
+        // Both of these were unbounded, so a UI thread that had stopped pumping (already quit, or
+        // stuck inside WebView2 teardown) blocked the caller forever. During shutdown that left the
+        // player's windows alive on top of the AWT host, swallowing all input while video kept
+        // playing. Bound both: a stalled UI thread now costs a short delay, not a permanent hang.
+        DWORD_PTR sendResult = 0;
+        SendMessageTimeoutW(
+            messageHwnd, WM_NUVIO_TASK, 0, 0,
+            SMTO_ABORTIFHUNG | SMTO_NORMAL, kUiTaskTimeoutMs, &sendResult
+        );
 
         std::unique_lock<std::mutex> waitLock(*doneMutex);
-        doneCv->wait(waitLock, [&]() { return *done; });
+        doneCv->wait_for(waitLock, std::chrono::milliseconds(kUiTaskTimeoutMs), [&]() { return *done; });
     }
 
     void startWebView(const std::string &controlsUrl) {


### PR DESCRIPTION
## Summary

Add timeouts to the native player shutdown path on Windows, and hide the player window asynchronously before anything that can block, so a wedged teardown can no longer leave a window alive over the app.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

The app stopped responding to all mouse and keyboard input while video kept playing and no controls appeared.

A thread dump showed two player dispose threads sitting in native `dispose` for over six minutes at zero CPU, while the event thread was idle. The teardown had no upper bound anywhere: `sendUiTask` used a blocking `SendMessageW` and then waited on a condition variable with no timeout, and `shutdown()` followed that with unbounded joins of the event and UI threads. If the player own UI thread stops pumping (already quit, or stuck inside WebView2 teardown) every one of those waits is infinite, so `cleanupUiResources` never runs and the container window is never destroyed. That window stays parented to the AWT host and swallows all input while mpv carries on rendering underneath.

This is the same class of problem as #237 and #252 (the native player blocking threads without bound), but a distinct failure and a distinct code path, so it is submitted separately.

## Desktop scope

Windows only. The change is entirely in `composeApp/src/desktopMain/native/windows/player_bridge.cpp`. The macOS bridge is untouched.

## Issue or approval

Same failure class as #237 and #252. No separate issue existed for this specific symptom, since it presents as the app ignoring input rather than as a visible freeze.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Three changes only, all in the shutdown path:

- Hide the container window first via `SWP_ASYNCWINDOWPOS`, which posts rather than sends and so cannot block on a stalled thread.
- `sendUiTask` uses `SendMessageTimeoutW` with `SMTO_ABORTIFHUNG` plus a bounded `wait_for` (2s).
- The thread joins are bounded and detach on timeout (3s), so shutdown always completes.

The teardown sequence itself is otherwise unchanged. Nothing outside shutdown is touched.

## Testing

Windows 11, built from source, 0.1.13-alpha.

Diagnosed from a JVM thread dump taken while input was dead, which showed the two stuck dispose threads at zero CPU and an idle event thread.

Manually exercised afterwards: repeated open, exit, source switch and episode switch cycles, plus fullscreen toggling. Input has remained responsive; no further stuck teardown threads observed in follow-up dumps.

Timeout values are conservative (2s and 3s) and only take effect on a thread that is already wedged, so normal teardown is unaffected.

Not tested on macOS or Linux; the change is Windows-only.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Related to #237 and #252 (same root cause class: the native player blocking without bound).