### PR TITLE
fix(desktop): add a renderer setting to fix UI flicker on high refresh rate displays

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/Platform.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/Platform.android.kt
@@ -12,3 +12,7 @@ internal actual val isIos: Boolean = false
 internal actual val isDesktop: Boolean = false
 internal actual val isWindows: Boolean = false
 
+internal actual val isDesktopRenderBackendConfigurable: Boolean = false
+internal actual fun isDesktopOpenGlRendererEnabled(): Boolean = false
+internal actual fun setDesktopOpenGlRendererEnabled(enabled: Boolean) = Unit
+

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -1743,6 +1743,10 @@
     <string name="settings_playback_nvidia_rtx_video_section">NVIDIA RTX Video</string>
     <string name="settings_playback_nvidia_rtx_super_resolution">RTX Video Super Resolution</string>
     <string name="settings_playback_nvidia_rtx_super_resolution_desc">Upscale low-resolution video using NVIDIA RTX AI Super Resolution.</string>
+    <!-- Playback settings desktop display -->
+    <string name="settings_playback_desktop_display_section">Display</string>
+    <string name="settings_playback_desktop_opengl_renderer">Use OpenGL renderer</string>
+    <string name="settings_playback_desktop_opengl_renderer_desc">Draw the interface with OpenGL instead of Direct3D. Can reduce flicker or stutter on some high refresh rate displays. Restart the app to apply.</string>
     <!-- Playback settings iOS video output -->
     <string name="settings_playback_ios_video_output">iOS VIDEO OUTPUT</string>
     <string name="settings_playback_ios_hardware_decoder">Hardware decoder</string>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/Platform.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/Platform.kt
@@ -10,3 +10,12 @@ internal expect val isIos: Boolean
 internal expect val isDesktop: Boolean
 internal expect val isWindows: Boolean
 
+/** Whether the desktop UI render backend (Direct3D vs OpenGL) can be chosen at runtime. Windows only. */
+internal expect val isDesktopRenderBackendConfigurable: Boolean
+
+/** Reads the persisted "use OpenGL for the desktop UI" preference (default false = Direct3D). */
+internal expect fun isDesktopOpenGlRendererEnabled(): Boolean
+
+/** Persists the "use OpenGL for the desktop UI" preference. Takes effect after an app restart. */
+internal expect fun setDesktopOpenGlRendererEnabled(enabled: Boolean)
+

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/PlaybackSettingsPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/PlaybackSettingsPage.kt
@@ -87,8 +87,11 @@ import com.nuvio.app.features.plugins.PluginRepository
 import com.nuvio.app.features.streams.StreamAutoPlayMode
 import com.nuvio.app.features.streams.StreamAutoPlaySource
 import com.nuvio.app.isDesktop
+import com.nuvio.app.isDesktopOpenGlRendererEnabled
+import com.nuvio.app.isDesktopRenderBackendConfigurable
 import com.nuvio.app.isIos
 import com.nuvio.app.isWindows
+import com.nuvio.app.setDesktopOpenGlRendererEnabled
 import kotlinx.coroutines.launch
 import nuvio.composeapp.generated.resources.*
 import org.jetbrains.compose.resources.StringResource
@@ -982,6 +985,27 @@ private fun PlaybackSettingsSection(
                         checked = autoPlayPlayerSettings.nvidiaRtxSuperResolutionEnabled,
                         isTablet = isTablet,
                         onCheckedChange = PlayerSettingsRepository::setNvidiaRtxSuperResolutionEnabled,
+                    )
+                }
+            }
+        }
+
+        if (isDesktopRenderBackendConfigurable) {
+            var useOpenGlRenderer by remember { mutableStateOf(isDesktopOpenGlRendererEnabled()) }
+            SettingsSection(
+                title = stringResource(Res.string.settings_playback_desktop_display_section),
+                isTablet = isTablet,
+            ) {
+                SettingsGroup(isTablet = isTablet) {
+                    SettingsSwitchRow(
+                        title = stringResource(Res.string.settings_playback_desktop_opengl_renderer),
+                        description = stringResource(Res.string.settings_playback_desktop_opengl_renderer_desc),
+                        checked = useOpenGlRenderer,
+                        isTablet = isTablet,
+                        onCheckedChange = { enabled ->
+                            useOpenGlRenderer = enabled
+                            setDesktopOpenGlRendererEnabled(enabled)
+                        },
                     )
                 }
             }

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.unit.dp
 import com.nuvio.app.core.deeplink.handleAppUrl
 import com.nuvio.app.features.p2p.P2pStreamingEngine
 import com.nuvio.app.features.player.PlatformPlayerSurface
+import com.nuvio.app.features.player.desktop.DesktopRenderSettings
 import com.nuvio.app.features.player.desktop.DesktopAppFullscreenController
 import com.nuvio.app.features.player.desktop.DesktopHostOs
 import com.nuvio.app.features.player.desktop.DesktopWindowGeometry
@@ -34,6 +35,17 @@ private const val NuvioDesktopIconPath = "icons/nuvio-app-icon.png"
 private const val MacosDarkAquaAppearance = "NSAppearanceNameDarkAqua"
 
 fun main(args: Array<String>) {
+    // Skiko defaults to Direct3D on Windows, which can misalign its present on high-refresh
+    // displays and show as UI flicker / a low frame-pace feel (video is unaffected). OpenGL
+    // avoids it but is opt-in: keep Direct3D by default and only switch when the user has
+    // enabled it in Settings and hasn't pinned a backend via property/env.
+    if (DesktopHostOs.current == DesktopHostOs.WINDOWS &&
+        System.getProperty("skiko.renderApi") == null &&
+        System.getenv("SKIKO_RENDER_API") == null &&
+        runCatching { DesktopRenderSettings.isOpenGlEnabled() }.getOrDefault(false)
+    ) {
+        System.setProperty("skiko.renderApi", "OPENGL")
+    }
     configureDesktopChrome()
     installDesktopOpenUriHandler()
     handleDesktopLaunchArgs(args)

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/Platform.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/Platform.desktop.kt
@@ -10,3 +10,9 @@ internal actual val isIos: Boolean = false
 internal actual val isDesktop: Boolean = true
 internal actual val isWindows: Boolean = System.getProperty("os.name").orEmpty().lowercase().contains("win")
 
+internal actual val isDesktopRenderBackendConfigurable: Boolean = isWindows
+internal actual fun isDesktopOpenGlRendererEnabled(): Boolean =
+    com.nuvio.app.features.player.desktop.DesktopRenderSettings.isOpenGlEnabled()
+internal actual fun setDesktopOpenGlRendererEnabled(enabled: Boolean) =
+    com.nuvio.app.features.player.desktop.DesktopRenderSettings.setOpenGlEnabled(enabled)
+

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopRenderSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopRenderSettings.kt
@@ -1,0 +1,17 @@
+package com.nuvio.app.features.player.desktop
+
+import com.nuvio.app.core.storage.DesktopStorage
+
+/**
+ * Per-machine UI render-backend preference (Direct3D vs OpenGL). Kept separate from the synced
+ * player settings so it never travels between devices. Read once at startup in `main()` before
+ * Compose initializes, so it must not depend on any Compose state.
+ */
+internal object DesktopRenderSettings {
+    private const val useOpenGlKey = "use_opengl_renderer"
+    private val store by lazy { DesktopStorage.store("nuvio_desktop_render") }
+
+    fun isOpenGlEnabled(): Boolean = store.getBoolean(useOpenGlKey) ?: false
+
+    fun setOpenGlEnabled(enabled: Boolean) = store.putBoolean(useOpenGlKey, enabled)
+}

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/Platform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/Platform.ios.kt
@@ -12,3 +12,7 @@ internal actual val isIos: Boolean = true
 internal actual val isDesktop: Boolean = false
 internal actual val isWindows: Boolean = false
 
+internal actual val isDesktopRenderBackendConfigurable: Boolean = false
+internal actual fun isDesktopOpenGlRendererEnabled(): Boolean = false
+internal actual fun setDesktopOpenGlRendererEnabled(enabled: Boolean) = Unit
+


### PR DESCRIPTION
## Summary

Adds an off-by-default Windows setting that switches the interface from Direct3D to OpenGL, which fixes flicker and choppiness on high refresh rate monitors. Nothing changes unless you turn it on.

## PR type

- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

On a high refresh rate monitor the interface flickers and feels like it is running at roughly 30fps, no matter how fast the display actually is. Scrolling and screen transitions are the most obvious. Video playback is fine, because video is rendered by mpv, not by the interface renderer (#269, and #16 which was closed but still reproduces).

The cause is the renderer. Compose draws the interface through Skiko, which uses Direct3D by default on Windows, and its frame presentation does not line up properly on these displays. Switching Skiko to OpenGL removes the flicker completely on the same machine, with no other changes.

Since this depends on the specific monitor and GPU, OpenGL is not a safe default for everyone. So instead of changing the default, this exposes it as a setting that affected users can turn on.

## Desktop scope

Windows desktop. The setting only appears on Windows.

Most of the changed files are the standard plumbing for showing a desktop-only setting in the shared settings screen: the desktop implementation plus `Platform` expect/actual, with the Android and iOS versions being no-ops.

## Issue or approval

Fixes #269. Related to #16, which was closed but still reproduces on high refresh rate monitors.

Flagging for maintainer judgement: this does add a visible setting. If that counts as a directional change rather than a bug fix, say so and I will close it. It is written to be completely inert unless enabled.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Three deliberate choices:

- **Direct3D stays the default.** Anyone who does not enable the setting sees no change whatsoever.
- **The preference is stored per machine**, in its own store, so it never syncs between devices. The right renderer depends on the monitor you are sitting in front of, so syncing it would be actively wrong.
- **An existing `skiko.renderApi` property or environment variable still wins**, so anyone already pinning a renderer is unaffected.

No renderer is forced, no other setting is touched, and it requires a restart to apply (stated in the setting description).

## Testing

Windows 11, 2560x1440 at 360Hz, built from source, 0.1.13-alpha.

- Setting off (the default): runs on Direct3D exactly as before.
- Setting on, after restart: the flicker and choppiness are gone on the same hardware.
- The preference persists across restarts and is read before the interface starts.
- Video playback and NVIDIA RTX Super Resolution are unaffected either way, since mpv renders through its own D3D11 pipeline independently of the interface renderer.

Not tested on macOS or Linux; the setting is Windows-only.

## Screenshots / Video

A screenshot cannot show this. The bug is frame timing, so it does not survive a still image, and a photo of a settings toggle would not evidence anything. #269 has the full description and hardware details. I can record a video against a high refresh rate display if that would help.
<img width="1265" height="181" alt="image" src="https://github.com/user-attachments/assets/be0ce607-5153-4c38-993c-3eb5857ffb5a" />


## Breaking changes

None. Default behaviour is unchanged.

## Linked issues

Fixes #269. Related to #16.