### PR TITLE
fix(player): stop the player leaving you on a blank screen with no way out

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
@@ -3017,8 +3017,18 @@ private fun MainAppContent(
                     )
                     val launch = remember(route.launchId) { PlayerLaunchStore.get(route.launchId) }
                     if (launch == null) {
+                        // The launch payload is already disposed, so this entry draws nothing but a
+                        // full-screen blank. The guarded pop cannot be trusted to get us out of it:
+                        // it no-ops once this route has popped before (popHandled is already spent),
+                        // and popBackStack also refuses when this is the only entry left. Either way
+                        // the user is stranded on an unrecoverable blank screen. Escape directly and
+                        // fall back to the tabs root if the stack itself cannot pop.
                         LaunchedEffect(route.launchId) {
-                            onBack()
+                            if (!navController.popBackStack(expectedRoute = route)) {
+                                navController.navigate(TabsRoute) {
+                                    popUpTo<PlayerRoute> { inclusive = true }
+                                }
+                            }
                         }
                         Box(modifier = Modifier.fillMaxSize())
                         return@entry


### PR DESCRIPTION
## Summary

Makes sure the player screen always sends you back somewhere usable, instead of occasionally leaving you stuck on a blank screen.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

The player screen needs its playback data (the "launch payload") to show anything. If that data has already been cleaned up by the time the screen is shown, the screen draws nothing at all, and it relies on automatically sending you back to get you out.

The problem is that the auto-back can quietly do nothing, for two reasons:

1. It only fires once. If this screen has already gone back before, the guard that prevents double-navigation has been used up, so the call does nothing.
2. It refuses to go back when the player is the only screen on the stack.

If either happens, nothing navigates and nothing is drawn, so you are left staring at a blank screen with no way out (#270).

The fix makes the exit unconditional: go back directly rather than through the used-up guard, and if the stack genuinely cannot go back, go to the main tabs screen instead. Either way you end up somewhere usable.

## Desktop scope

This is in shared code (`App.kt`) so it applies to all platforms, but it matters for desktop: it was found while investigating the desktop black-screen reports in #252. To a desktop user, a blank unrecoverable screen looks exactly like the freeze described there.

## Issue or approval

Fixes #270

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Eleven lines, in one place: the branch that runs when the playback data is missing.

The shared back-navigation helper is not touched, so every other screen keeps its current behaviour. The blank placeholder is left alone, since it is only on screen for the moment before the route exits.

## Testing

Windows 11, built from source, 0.1.13-alpha.

Being upfront: I found this by reading the code while investigating #252, not from a real occurrence, and I do not have steps to reproduce it. So I cannot claim to have watched this fix rescue a stuck screen in practice.

What I did verify is that normal use is unaffected: entering and exiting playback, switching sources and episodes, and backing out all behave exactly as before. That is expected, because the changed branch is only reached when the playback data is already gone.

If you would rather wait for a reproduction before taking this, that is completely reasonable.

Not tested on macOS or Linux.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #270. Found while investigating #252.