### PR TITLE
fix(player): remember the player volume between streams

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopPlayerVolumeStorage.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopPlayerVolumeStorage.kt
@@ -1,0 +1,15 @@
+package com.nuvio.app.features.player.desktop
+
+import com.nuvio.app.core.storage.DesktopStorage
+
+internal object DesktopPlayerVolumeStorage {
+    private const val VolumeLevelKey = "volume_level"
+    private val store = DesktopStorage.store("nuvio_player_runtime")
+
+    fun loadVolumeLevel(): Float? =
+        store.getFloat(VolumeLevelKey)?.coerceIn(0f, 1f)
+
+    fun saveVolumeLevel(level: Float) {
+        store.putFloat(VolumeLevelKey, level.coerceIn(0f, 1f))
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
@@ -39,7 +39,7 @@ internal class NativePlayerController(
         const val TEARDOWN_WAIT_MS = 5_000L
 
         @Volatile
-        var rememberedVolumeLevel: Float = 1f
+        var rememberedVolumeLevel: Float = DesktopPlayerVolumeStorage.loadVolumeLevel() ?: 1f
     }
 
     @Volatile
@@ -346,6 +346,7 @@ internal class NativePlayerController(
         if (current != 0L) {
             val nextLevel = level.coerceIn(0f, 1f)
             rememberedVolumeLevel = nextLevel
+            DesktopPlayerVolumeStorage.saveVolumeLevel(nextLevel)
             NativePlayerBridge.setVolume(current, nextLevel)
             controlsState = controlsState.copy(volumeLevel = nextLevel)
             updateControls(controlsState)


### PR DESCRIPTION
## Summary

The desktop player volume now persists, so it is remembered between streams and across restarts instead of resetting every time.

Previously submitted as #257, which I closed myself along with my other open PRs. Rebased onto current Dev and resubmitted.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Every time you start a stream the player volume returns to full, so if you keep the app quieter than your system volume you have to set it again on every single playback.

The volume was already tracked in memory for the lifetime of a player, it simply was never written anywhere, so it was lost as soon as the player was torn down.

## Desktop scope

Windows and macOS desktop. Desktop-only code: the remembered volume is stored through the existing desktop storage helper.

## Issue or approval

No linked issue. This is a small desktop-only behavior fix restoring an expectation users already have of a media player, previously submitted as #257. Happy to open an issue first if you would prefer one on record.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Two files. No new setting, no UI, and no change to how volume behaves while a stream is playing; only whether the level survives to the next one.

## Testing

Windows 11, built from source, on current Dev.

Set the volume mid-playback, exited, and started a different stream: the level carried over. Confirmed it also survives a full app restart, and that muting and restoring behaves as before within a single stream.

Not tested on macOS or Linux.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue. Resubmission of #257.