### PR TITLE
feat(player): automatic skipping and long title handling, matching NuvioTV

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.android.kt
@@ -60,6 +60,7 @@ actual object PlayerSettingsStorage {
     private const val streamAutoPlayRegexKey = "stream_auto_play_regex"
     private const val streamAutoPlayTimeoutSecondsKey = "stream_auto_play_timeout_seconds"
     private const val skipIntroEnabledKey = "skip_intro_enabled"
+    private const val autoSkipSegmentTypesKey = "auto_skip_segment_types"
     private const val animeSkipEnabledKey = "animeskip_enabled"
     private const val animeSkipClientIdKey = "animeskip_client_id"
     private const val introDbApiKeyKey = "introdb_api_key"
@@ -132,6 +133,7 @@ actual object PlayerSettingsStorage {
         streamAutoPlayRegexKey,
         streamAutoPlayTimeoutSecondsKey,
         skipIntroEnabledKey,
+        autoSkipSegmentTypesKey,
         animeSkipEnabledKey,
         animeSkipClientIdKey,
         streamAutoPlayNextEpisodeEnabledKey,
@@ -778,6 +780,23 @@ actual object PlayerSettingsStorage {
             ?.apply()
     }
 
+    actual fun loadAutoSkipSegmentTypes(): Set<String>? =
+        preferences?.let { sharedPreferences ->
+            val key = ProfileScopedKey.of(autoSkipSegmentTypesKey)
+            if (sharedPreferences.contains(key)) {
+                sharedPreferences.getStringSet(key, emptySet()) ?: emptySet()
+            } else {
+                null
+            }
+        }
+
+    actual fun saveAutoSkipSegmentTypes(segmentTypes: Set<String>) {
+        preferences
+            ?.edit()
+            ?.putStringSet(ProfileScopedKey.of(autoSkipSegmentTypesKey), segmentTypes)
+            ?.apply()
+    }
+
     actual fun loadAnimeSkipEnabled(): Boolean? =
         preferences?.let { sharedPreferences ->
             val key = ProfileScopedKey.of(animeSkipEnabledKey)
@@ -1137,6 +1156,7 @@ actual object PlayerSettingsStorage {
         loadStreamAutoPlayRegex()?.let { put(streamAutoPlayRegexKey, encodeSyncString(it)) }
         loadStreamAutoPlayTimeoutSeconds()?.let { put(streamAutoPlayTimeoutSecondsKey, encodeSyncInt(it)) }
         loadSkipIntroEnabled()?.let { put(skipIntroEnabledKey, encodeSyncBoolean(it)) }
+        loadAutoSkipSegmentTypes()?.let { put(autoSkipSegmentTypesKey, encodeSyncStringSet(it)) }
         loadAnimeSkipEnabled()?.let { put(animeSkipEnabledKey, encodeSyncBoolean(it)) }
         loadAnimeSkipClientId()?.let { put(animeSkipClientIdKey, encodeSyncString(it)) }
         loadStreamAutoPlayNextEpisodeEnabled()?.let { put(streamAutoPlayNextEpisodeEnabledKey, encodeSyncBoolean(it)) }
@@ -1212,6 +1232,7 @@ actual object PlayerSettingsStorage {
         payload.decodeSyncString(streamAutoPlayRegexKey)?.let(::saveStreamAutoPlayRegex)
         payload.decodeSyncInt(streamAutoPlayTimeoutSecondsKey)?.let(::saveStreamAutoPlayTimeoutSeconds)
         payload.decodeSyncBoolean(skipIntroEnabledKey)?.let(::saveSkipIntroEnabled)
+        payload.decodeSyncStringSet(autoSkipSegmentTypesKey)?.let(::saveAutoSkipSegmentTypes)
         payload.decodeSyncBoolean(animeSkipEnabledKey)?.let(::saveAnimeSkipEnabled)
         payload.decodeSyncString(animeSkipClientIdKey)?.let(::saveAnimeSkipClientId)
         payload.decodeSyncString(introDbApiKeyKey)?.let(::saveIntroDbApiKey)

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -1041,6 +1041,14 @@
     <string name="settings_playback_subtitle_vertical_offset">Vertical Offset</string>
     <string name="settings_playback_skip_intro_outro_recap">Skip Intro</string>
     <string name="settings_playback_skip_intro_outro_recap_description">Use introdb.app to detect intros and recaps.</string>
+    <string name="settings_playback_auto_skip_segments">Automatic Skipping</string>
+    <string name="settings_playback_auto_skip_none">Off</string>
+    <string name="settings_playback_auto_skip_intro">Intro / Opening</string>
+    <string name="settings_playback_auto_skip_intro_description">Skip intros and anime openings automatically.</string>
+    <string name="settings_playback_auto_skip_recap">Recap</string>
+    <string name="settings_playback_auto_skip_recap_description">Skip recap segments automatically.</string>
+    <string name="settings_playback_auto_skip_outro">Outro / Ending</string>
+    <string name="settings_playback_auto_skip_outro_description">Skip outros and anime endings automatically.</string>
     <string name="settings_playback_source_scope">Auto-play Source Scope</string>
     <string name="settings_playback_source_scope_all_addons">All installed addons</string>
     <string name="settings_playback_source_scope_all_addons_description">Auto-play only considers streams coming from your installed addons.</string>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/ShelfComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/ShelfComponents.kt
@@ -5,10 +5,12 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -227,6 +229,7 @@ internal fun Modifier.nuvioDesktopDragScroll(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun NuvioPosterCard(
     title: String,
@@ -252,10 +255,21 @@ fun NuvioPosterCard(
         shape = shape,
     )
     val shouldShowTitleBelow = showTitleBelow && !posterCardStyle.hideLabelsEnabled
+    val cardInteractionSource = remember { MutableInteractionSource() }
+    val isHovered by cardInteractionSource.collectIsHoveredAsState()
+    val isFocused by cardInteractionSource.collectIsFocusedAsState()
+    val marqueeModifier = if (isDesktop && (isHovered || isFocused)) {
+        Modifier.basicMarquee(
+            iterations = Int.MAX_VALUE,
+            velocity = 45.dp,
+        )
+    } else {
+        Modifier
+    }
 
     Column(
         modifier = Modifier
-            .desktopPosterHoverScale()
+            .desktopPosterHoverScale(interactionSource = cardInteractionSource)
             .then(modifier)
             .width(cardWidth),
         verticalArrangement = Arrangement.spacedBy(NuvioTokens.Space.s6),
@@ -276,6 +290,7 @@ fun NuvioPosterCard(
                     zoomImageUrl = imageUrl,
                     zoomCornerRadius = posterCardStyle.cornerRadiusDp.dp,
                     hoverScaleEnabled = false,
+                    interactionSource = cardInteractionSource,
                 ),
             contentAlignment = Alignment.Center,
         ) {
@@ -320,7 +335,9 @@ fun NuvioPosterCard(
                             color = tokens.colors.textPrimary,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier.widthIn(max = catalogLogoOverlaySize.textMaxWidth),
+                            modifier = Modifier
+                                .widthIn(max = catalogLogoOverlaySize.textMaxWidth)
+                                .then(marqueeModifier),
                         )
                     }
                 }
@@ -331,6 +348,7 @@ fun NuvioPosterCard(
         if (shouldShowTitleBelow) {
             Text(
                 text = title,
+                modifier = marqueeModifier,
                 style = MaterialTheme.typography.bodyMedium,
                 color = tokens.colors.textPrimary,
                 maxLines = 1,
@@ -339,6 +357,7 @@ fun NuvioPosterCard(
             if (!detailLine.isNullOrBlank()) {
                 Text(
                     text = detailLine,
+                    modifier = marqueeModifier,
                     style = MaterialTheme.typography.labelSmall,
                     color = tokens.colors.textMuted,
                     maxLines = 1,
@@ -573,10 +592,10 @@ internal fun Modifier.posterCardClickable(
     zoomImageUrl: String? = null,
     zoomCornerRadius: Dp = NuvioTokens.Radius.poster,
     hoverScaleEnabled: Boolean = true,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ): Modifier {
     if (onClick == null && onLongClick == null) return this
     val bounds = remember { mutableStateOf<Rect?>(null) }
-    val interactionSource = remember { MutableInteractionSource() }
     val handleLongClick = onLongClick?.let { longClick ->
         {
             bounds.value?.takeIf { zoomImageUrl != null }?.let { cardBounds ->

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/ShelfComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/ShelfComponents.kt
@@ -24,8 +24,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.gestures.awaitEachGesture
-import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
@@ -47,8 +48,6 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.input.pointer.PointerEventPass
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -64,7 +63,6 @@ import nuvio.composeapp.generated.resources.Res
 import nuvio.composeapp.generated.resources.home_view_all
 import nuvio.composeapp.generated.resources.poster_logo_content_description
 import org.jetbrains.compose.resources.stringResource
-import kotlin.math.abs
 import kotlin.math.roundToInt
 
 enum class NuvioPosterShape {
@@ -93,6 +91,7 @@ fun <T> NuvioShelfSection(
     key: ((T) -> Any)? = null,
     animatePlacement: Boolean = false,
     state: LazyListState = rememberLazyListState(),
+    onUserScrollStarted: () -> Unit = {},
     itemContent: @Composable (T) -> Unit,
 ) {
     val tokens = MaterialTheme.nuvio
@@ -115,7 +114,10 @@ fun <T> NuvioShelfSection(
         }
         LazyRow(
             state = state,
-            modifier = rowModifier.nuvioDesktopDragScroll(state),
+            modifier = rowModifier.nuvioDesktopDragScroll(
+                state = state,
+                onDragStarted = onUserScrollStarted,
+            ),
             contentPadding = rowContentPadding,
             horizontalArrangement = Arrangement.spacedBy(itemSpacing),
         ) {
@@ -147,86 +149,34 @@ fun <T> NuvioShelfSection(
     }
 }
 
+@Composable
 internal fun Modifier.nuvioDesktopDragScroll(
     state: LazyListState,
+    onDragStarted: () -> Unit = {},
 ): Modifier {
     if (!isDesktop) return this
 
-    return pointerInput(state) {
-        awaitEachGesture {
-            val down = awaitFirstDown(pass = PointerEventPass.Initial)
-            var totalDx = 0f
-            var totalDy = 0f
-            var dragging = false
-
-            while (true) {
-                val event = awaitPointerEvent(pass = PointerEventPass.Initial)
-                val change = event.changes.firstOrNull { it.id == down.id } ?: break
-                if (!change.pressed) break
-
-                val delta = change.position - change.previousPosition
-                totalDx += delta.x
-                totalDy += delta.y
-
-                if (!dragging) {
-                    val horizontalDrag =
-                        abs(totalDx) > viewConfiguration.touchSlop && abs(totalDx) > abs(totalDy)
-                    val verticalDrag =
-                        abs(totalDy) > viewConfiguration.touchSlop && abs(totalDy) > abs(totalDx)
-
-                    when {
-                        verticalDrag -> break
-                        horizontalDrag -> dragging = true
-                        else -> continue
-                    }
-                }
-
-                state.dispatchRawDelta(-delta.x)
-                change.consume()
-            }
-        }
-    }
+    val dragState = rememberDraggableState { delta -> state.dispatchRawDelta(-delta) }
+    return draggable(
+        state = dragState,
+        orientation = Orientation.Horizontal,
+        onDragStarted = { onDragStarted() },
+    )
 }
 
+@Composable
 internal fun Modifier.nuvioDesktopDragScroll(
     state: ScrollState,
+    onDragStarted: () -> Unit = {},
 ): Modifier {
     if (!isDesktop) return this
 
-    return pointerInput(state) {
-        awaitEachGesture {
-            val down = awaitFirstDown(pass = PointerEventPass.Initial)
-            var totalDx = 0f
-            var totalDy = 0f
-            var dragging = false
-
-            while (true) {
-                val event = awaitPointerEvent(pass = PointerEventPass.Initial)
-                val change = event.changes.firstOrNull { it.id == down.id } ?: break
-                if (!change.pressed) break
-
-                val delta = change.position - change.previousPosition
-                totalDx += delta.x
-                totalDy += delta.y
-
-                if (!dragging) {
-                    val horizontalDrag =
-                        abs(totalDx) > viewConfiguration.touchSlop && abs(totalDx) > abs(totalDy)
-                    val verticalDrag =
-                        abs(totalDy) > viewConfiguration.touchSlop && abs(totalDy) > abs(totalDx)
-
-                    when {
-                        verticalDrag -> break
-                        horizontalDrag -> dragging = true
-                        else -> continue
-                    }
-                }
-
-                state.dispatchRawDelta(-delta.x)
-                change.consume()
-            }
-        }
-    }
+    val dragState = rememberDraggableState { delta -> state.dispatchRawDelta(-delta) }
+    return draggable(
+        state = dragState,
+        orientation = Orientation.Horizontal,
+        onDragStarted = { onDragStarted() },
+    )
 }
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -284,7 +234,7 @@ fun NuvioPosterCard(
                     shape = cardShape,
                     surface = NuvioCardDepthSurface.Posters,
                 )
-                .posterCardClickable(
+                .posterCardClickableWithInteractionSource(
                     onClick = onClick,
                     onLongClick = onLongClick,
                     zoomImageUrl = imageUrl,
@@ -592,7 +542,28 @@ internal fun Modifier.posterCardClickable(
     zoomImageUrl: String? = null,
     zoomCornerRadius: Dp = NuvioTokens.Radius.poster,
     hoverScaleEnabled: Boolean = true,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+): Modifier {
+    if (onClick == null && onLongClick == null) return this
+    val interactionSource = remember { MutableInteractionSource() }
+    return posterCardClickableWithInteractionSource(
+        onClick = onClick,
+        onLongClick = onLongClick,
+        zoomImageUrl = zoomImageUrl,
+        zoomCornerRadius = zoomCornerRadius,
+        hoverScaleEnabled = hoverScaleEnabled,
+        interactionSource = interactionSource,
+    )
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun Modifier.posterCardClickableWithInteractionSource(
+    onClick: (() -> Unit)?,
+    onLongClick: (() -> Unit)?,
+    zoomImageUrl: String? = null,
+    zoomCornerRadius: Dp = NuvioTokens.Radius.poster,
+    hoverScaleEnabled: Boolean = true,
+    interactionSource: MutableInteractionSource,
 ): Modifier {
     if (onClick == null && onLongClick == null) return this
     val bounds = remember { mutableStateOf<Rect?>(null) }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeScreen.kt
@@ -934,6 +934,7 @@ fun HomeScreen(
                         layout = continueWatchingLayout,
                         continueWatchingListState = continueWatchingListState,
                         upcomingListState = upcomingListState,
+                        onUserScrollStarted = { hasUserScrolledContinueWatching = true },
                         onItemClick = onContinueWatchingClick,
                         onItemLongPress = onContinueWatchingLongPress,
                     )
@@ -955,6 +956,7 @@ fun HomeScreen(
                         layout = continueWatchingLayout,
                         continueWatchingListState = continueWatchingListState,
                         upcomingListState = upcomingListState,
+                        onUserScrollStarted = { hasUserScrolledContinueWatching = true },
                         onItemClick = onContinueWatchingClick,
                         onItemLongPress = onContinueWatchingLongPress,
                     )
@@ -999,6 +1001,7 @@ fun HomeScreen(
                         layout = continueWatchingLayout,
                         continueWatchingListState = continueWatchingListState,
                         upcomingListState = upcomingListState,
+                        onUserScrollStarted = { hasUserScrolledContinueWatching = true },
                         onItemClick = onContinueWatchingClick,
                         onItemLongPress = onContinueWatchingLongPress,
                     )
@@ -1055,6 +1058,7 @@ private fun LazyListScope.homeContinueWatchingSections(
     layout: ContinueWatchingLayout,
     continueWatchingListState: LazyListState,
     upcomingListState: LazyListState,
+    onUserScrollStarted: () -> Unit = {},
     onItemClick: ((ContinueWatchingItem) -> Unit)?,
     onItemLongPress: ((ContinueWatchingItem) -> Unit)?,
 ) {
@@ -1071,6 +1075,7 @@ private fun LazyListScope.homeContinueWatchingSections(
                 sectionPadding = sectionPadding,
                 layout = layout,
                 listState = continueWatchingListState,
+                onUserScrollStarted = onUserScrollStarted,
                 onItemClick = onItemClick,
                 onItemLongPress = onItemLongPress,
             )

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/components/HomeContinueWatchingSection.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/components/HomeContinueWatchingSection.kt
@@ -1,7 +1,12 @@
 package com.nuvio.app.features.home.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.border
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -66,6 +71,7 @@ import com.nuvio.app.features.watchprogress.ContinueWatchingItem
 import com.nuvio.app.features.watchprogress.ContinueWatchingSectionStyle
 import com.nuvio.app.features.watchprogress.CurrentDateProvider
 import com.nuvio.app.features.watchprogress.computeAirDateBadgeText
+import com.nuvio.app.isDesktop
 import kotlin.math.roundToInt
 import nuvio.composeapp.generated.resources.*
 import org.jetbrains.compose.resources.stringResource
@@ -74,6 +80,31 @@ private val ContinueWatchingStatusBadgeShape = RoundedCornerShape(4.dp)
 private val ContinueWatchingNewEpisodeBadgeColor = Color(0xFF1D4ED8)
 private val ContinueWatchingNewSeasonBadgeColor = Color(0xFFB45309)
 private const val ContinueWatchingLandscapeCardScale = 1.2f
+
+private data class ContinueWatchingTitleMarquee(
+    val isHovered: Boolean,
+    val hoverModifier: Modifier,
+    val textModifier: Modifier,
+)
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun rememberContinueWatchingTitleMarquee(): ContinueWatchingTitleMarquee {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isHovered by interactionSource.collectIsHoveredAsState()
+    return ContinueWatchingTitleMarquee(
+        isHovered = isDesktop && isHovered,
+        hoverModifier = if (isDesktop) Modifier.hoverable(interactionSource) else Modifier,
+        textModifier = if (isDesktop && isHovered) {
+            Modifier.basicMarquee(
+                iterations = Int.MAX_VALUE,
+                velocity = 45.dp,
+            )
+        } else {
+            Modifier
+        },
+    )
+}
 
 internal fun continueWatchingLandscapeCardWidth(basePosterWidthDp: Int): Dp =
     (landscapePosterWidth(basePosterWidthDp).value * ContinueWatchingLandscapeCardScale).dp
@@ -198,6 +229,7 @@ internal fun HomeContinueWatchingSection(
     sectionPadding: Dp? = null,
     layout: ContinueWatchingLayout? = null,
     listState: LazyListState = rememberLazyListState(),
+    onUserScrollStarted: () -> Unit = {},
     onItemClick: ((ContinueWatchingItem) -> Unit)? = null,
     onItemLongPress: ((ContinueWatchingItem) -> Unit)? = null,
 ) {
@@ -214,6 +246,7 @@ internal fun HomeContinueWatchingSection(
             sectionPadding = sectionPadding,
             layout = layout,
             listState = listState,
+            onUserScrollStarted = onUserScrollStarted,
             onItemClick = onItemClick,
             onItemLongPress = onItemLongPress,
         )
@@ -229,6 +262,7 @@ internal fun HomeContinueWatchingSection(
                 sectionPadding = homeSectionHorizontalPaddingForWidth(maxWidth.value),
                 layout = rememberContinueWatchingLayout(maxWidth.value),
                 listState = listState,
+                onUserScrollStarted = onUserScrollStarted,
                 onItemClick = onItemClick,
                 onItemLongPress = onItemLongPress,
             )
@@ -247,6 +281,7 @@ private fun HomeContinueWatchingSectionContent(
     sectionPadding: Dp,
     layout: ContinueWatchingLayout,
     listState: LazyListState,
+    onUserScrollStarted: () -> Unit,
     onItemClick: ((ContinueWatchingItem) -> Unit)?,
     onItemLongPress: ((ContinueWatchingItem) -> Unit)?,
 ) {
@@ -269,6 +304,7 @@ private fun HomeContinueWatchingSectionContent(
         key = { entry -> entry.videoId },
         animatePlacement = true,
         state = listState,
+        onUserScrollStarted = onUserScrollStarted,
     ) { entry ->
         val item = entry.item
         val onClick = if (entry.exiting) null else onItemClick?.let { { it(item) } }
@@ -635,6 +671,7 @@ private fun ContinueWatchingCard(
     onClick: (() -> Unit)?,
     onLongClick: (() -> Unit)?,
 ) {
+    val titleMarquee = rememberContinueWatchingTitleMarquee()
     val posterCardStyle = rememberPosterCardStyleUiState()
     val cardMetrics = remember(posterCardStyle.widthDp, posterCardStyle.cornerRadiusDp) {
         val basePosterWidthDp = desktopCatalogShelfPosterBaseWidthDp(posterCardStyle.widthDp)
@@ -679,6 +716,7 @@ private fun ContinueWatchingCard(
                 shape = RoundedCornerShape(cardMetrics.cornerRadius),
                 surface = NuvioCardDepthSurface.ContinueWatching,
             )
+            .then(titleMarquee.hoverModifier)
             .posterCardClickable(
                 onClick = onClick,
                 onLongClick = onLongClick,
@@ -736,6 +774,9 @@ private fun ContinueWatchingCard(
             }
             Text(
                 text = item.title,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .then(titleMarquee.textModifier),
                 style = MaterialTheme.typography.titleSmall.copy(
                     fontSize = cardMetrics.titleTextSize,
                     fontWeight = FontWeight.SemiBold,
@@ -847,8 +888,10 @@ private fun ContinueWatchingWideCard(
     onClick: (() -> Unit)?,
     onLongClick: (() -> Unit)?,
 ) {
+    val titleMarquee = rememberContinueWatchingTitleMarquee()
     Row(
         modifier = Modifier
+            .then(titleMarquee.hoverModifier)
             .posterCardClickable(onClick = onClick, onLongClick = onLongClick)
             .width(layout.wideCardWidth)
             .height(layout.wideCardHeight)
@@ -887,7 +930,9 @@ private fun ContinueWatchingWideCard(
                 ) {
                     Text(
                         text = item.title,
-                        modifier = Modifier.weight(1f),
+                        modifier = Modifier
+                            .weight(1f)
+                            .then(titleMarquee.textModifier),
                         style = MaterialTheme.typography.titleMedium.copy(
                             fontSize = layout.wideTitleSize,
                             fontWeight = FontWeight.Bold,
@@ -969,9 +1014,11 @@ private fun ContinueWatchingPosterCard(
     onClick: (() -> Unit)?,
     onLongClick: (() -> Unit)?,
 ) {
+    val titleMarquee = rememberContinueWatchingTitleMarquee()
     val imageUrl = item.continueWatchingPosterArtworkUrl(useEpisodeThumbnails)
     Column(
         modifier = Modifier
+            .then(titleMarquee.hoverModifier)
             .desktopPosterHoverScale()
             .width(layout.posterCardWidth),
         verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -1061,14 +1108,16 @@ private fun ContinueWatchingPosterCard(
             ) {
                 Text(
                     text = item.title,
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .then(titleMarquee.textModifier),
                     style = MaterialTheme.typography.bodyMedium.copy(
                         fontSize = layout.posterTitleSize,
                         fontWeight = FontWeight.SemiBold,
                         lineHeight = 18.sp,
                     ),
                     color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = 2,
+                    maxLines = if (titleMarquee.isHovered) 1 else 2,
                     overflow = TextOverflow.Ellipsis,
                 )
             }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeEffects.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeEffects.kt
@@ -9,8 +9,12 @@ import com.nuvio.app.features.p2p.P2pStreamRequest
 import com.nuvio.app.features.p2p.P2pStreamingEngine
 import com.nuvio.app.features.p2p.P2pStreamingState
 import com.nuvio.app.features.player.skip.NextEpisodeInfo
+import com.nuvio.app.features.player.skip.AutoSkipSegmentType
 import com.nuvio.app.features.player.skip.PlayerNextEpisodeRules
 import com.nuvio.app.features.player.skip.SkipIntroRepository
+import com.nuvio.app.features.player.skip.SkipIntervalLookup
+import com.nuvio.app.features.player.skip.autoSkipKey
+import com.nuvio.app.features.player.skip.resolveSkipIntervalLookup
 import com.nuvio.app.features.streams.BingeGroupCacheRepository
 import com.nuvio.app.features.streams.StreamLinkCacheRepository
 import com.nuvio.app.features.streams.StreamItem
@@ -389,42 +393,80 @@ private fun PlayerScreenRuntime.BindPlayerMetadataAndSkipEffects() {
         }
     }
 
-    LaunchedEffect(activeVideoId, activeSeasonNumber, activeEpisodeNumber) {
+    LaunchedEffect(
+        activeVideoId,
+        activeSeasonNumber,
+        activeEpisodeNumber,
+        playerSettingsUiState.skipIntroEnabled,
+    ) {
         skipIntervals = emptyList()
         activeSkipInterval = null
         skipIntervalDismissed = false
+        autoSkippedIntervalKeys.clear()
         showNextEpisodeCard = false
         nextEpisodeAutoPlayJob?.cancel()
         nextEpisodeAutoPlaySearching = false
 
-        val season = activeSeasonNumber
-        val episode = activeEpisodeNumber
-        val vid = activeVideoId
-        if (season == null || episode == null || vid == null) return@LaunchedEffect
+        if (!playerSettingsUiState.skipIntroEnabled) return@LaunchedEffect
+
+        val lookup = resolveSkipIntervalLookup(
+            videoId = activeVideoId,
+            season = activeSeasonNumber,
+            episode = activeEpisodeNumber,
+        ) ?: return@LaunchedEffect
 
         launch {
-            val imdbId = vid.split(":").firstOrNull()?.takeIf { it.startsWith("tt") }
-            val intervals = SkipIntroRepository.getSkipIntervals(
-                imdbId = imdbId,
-                season = season,
-                episode = episode,
-            )
+            val intervals = when (lookup) {
+                is SkipIntervalLookup.Imdb -> SkipIntroRepository.getSkipIntervals(
+                    imdbId = lookup.imdbId,
+                    season = lookup.season,
+                    episode = lookup.episode,
+                )
+                is SkipIntervalLookup.Mal -> SkipIntroRepository.getSkipIntervalsForMal(
+                    malId = lookup.malId,
+                    episode = lookup.episode,
+                )
+                is SkipIntervalLookup.Kitsu -> SkipIntroRepository.getSkipIntervalsForKitsu(
+                    kitsuId = lookup.kitsuId,
+                    episode = lookup.episode,
+                )
+            }
             skipIntervals = intervals
         }
     }
 
-    LaunchedEffect(playbackSnapshot.positionMs, skipIntervals) {
+    LaunchedEffect(
+        playbackSnapshot.positionMs,
+        skipIntervals,
+        playerSettingsUiState.autoSkipSegmentTypes,
+    ) {
         if (skipIntervals.isEmpty()) {
             activeSkipInterval = null
             return@LaunchedEffect
         }
         val positionSec = playbackSnapshot.positionMs / 1000.0
         val current = skipIntervals.firstOrNull { interval ->
-            positionSec >= interval.startTime && positionSec < interval.endTime
+            positionSec >= interval.startTime && positionSec < (interval.endTime - 0.5)
         }
         if (current != activeSkipInterval) {
             activeSkipInterval = current
             if (current != null) skipIntervalDismissed = false
+        }
+        if (current != null) {
+            val segmentType = AutoSkipSegmentType.fromSkipIntervalType(current.type)
+            val intervalKey = current.autoSkipKey()
+            val controller = playerController
+            if (
+                controller != null &&
+                segmentType != null &&
+                segmentType in playerSettingsUiState.autoSkipSegmentTypes &&
+                intervalKey !in autoSkippedIntervalKeys
+            ) {
+                autoSkippedIntervalKeys.add(intervalKey)
+                controller.seekTo((current.endTime * 1000).toLong())
+                scheduleProgressSyncAfterSeek()
+                skipIntervalDismissed = true
+            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeState.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeState.kt
@@ -172,6 +172,7 @@ internal class PlayerScreenRuntime(
     var skipIntervals by mutableStateOf<List<SkipInterval>>(emptyList())
     var activeSkipInterval by mutableStateOf<SkipInterval?>(null)
     var skipIntervalDismissed by mutableStateOf(false)
+    val autoSkippedIntervalKeys = mutableSetOf<String>()
     var parentalWarnings by mutableStateOf<List<ParentalWarning>>(emptyList())
     var showParentalGuide by mutableStateOf(false)
     var parentalGuideHasShown by mutableStateOf(false)

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSettingsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSettingsRepository.kt
@@ -2,6 +2,7 @@ package com.nuvio.app.features.player
 
 import com.nuvio.app.core.build.AppFeaturePolicy
 import com.nuvio.app.features.player.skip.NextEpisodeThresholdMode
+import com.nuvio.app.features.player.skip.AutoSkipSegmentType
 import com.nuvio.app.features.streams.StreamAutoPlayMode
 import com.nuvio.app.features.streams.StreamAutoPlaySource
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -64,6 +65,7 @@ data class PlayerSettingsUiState(
     val streamAutoPlayRegex: String = "",
     val streamAutoPlayTimeoutSeconds: Int = 3,
     val skipIntroEnabled: Boolean = true,
+    val autoSkipSegmentTypes: Set<AutoSkipSegmentType> = emptySet(),
     val animeSkipEnabled: Boolean = false,
     val animeSkipClientId: String = "",
     val introDbApiKey: String = "",
@@ -131,6 +133,7 @@ object PlayerSettingsRepository {
     private var streamAutoPlayRegex = ""
     private var streamAutoPlayTimeoutSeconds = 3
     private var skipIntroEnabled = true
+    private var autoSkipSegmentTypes: Set<AutoSkipSegmentType> = emptySet()
     private var animeSkipEnabled = false
     private var animeSkipClientId = ""
     private var introDbApiKey = ""
@@ -203,6 +206,7 @@ object PlayerSettingsRepository {
         streamAutoPlayRegex = ""
         streamAutoPlayTimeoutSeconds = 3
         skipIntroEnabled = true
+        autoSkipSegmentTypes = emptySet()
         animeSkipEnabled = false
         animeSkipClientId = ""
         introDbApiKey = ""
@@ -335,6 +339,10 @@ object PlayerSettingsRepository {
             PlayerSettingsStorage.saveStreamAutoPlayTimeoutSeconds(streamAutoPlayTimeoutSeconds)
         }
         skipIntroEnabled = PlayerSettingsStorage.loadSkipIntroEnabled() ?: true
+        autoSkipSegmentTypes = PlayerSettingsStorage.loadAutoSkipSegmentTypes()
+            ?.mapNotNull(AutoSkipSegmentType::fromStoredValue)
+            ?.toSet()
+            ?: emptySet()
         animeSkipEnabled = PlayerSettingsStorage.loadAnimeSkipEnabled() ?: false
         animeSkipClientId = PlayerSettingsStorage.loadAnimeSkipClientId() ?: ""
         introDbApiKey = PlayerSettingsStorage.loadIntroDbApiKey() ?: ""
@@ -666,6 +674,15 @@ object PlayerSettingsRepository {
         PlayerSettingsStorage.saveSkipIntroEnabled(enabled)
     }
 
+    fun setAutoSkipSegmentTypeEnabled(segmentType: AutoSkipSegmentType, enabled: Boolean) {
+        ensureLoaded()
+        val updated = if (enabled) autoSkipSegmentTypes + segmentType else autoSkipSegmentTypes - segmentType
+        if (autoSkipSegmentTypes == updated) return
+        autoSkipSegmentTypes = updated
+        publish()
+        PlayerSettingsStorage.saveAutoSkipSegmentTypes(updated.mapTo(linkedSetOf()) { it.storedValue })
+    }
+
     fun setAnimeSkipEnabled(enabled: Boolean) {
         ensureLoaded()
         if (animeSkipEnabled == enabled) return
@@ -969,6 +986,7 @@ object PlayerSettingsRepository {
             streamAutoPlayRegex = streamAutoPlayRegex,
             streamAutoPlayTimeoutSeconds = streamAutoPlayTimeoutSeconds,
             skipIntroEnabled = skipIntroEnabled,
+            autoSkipSegmentTypes = autoSkipSegmentTypes,
             animeSkipEnabled = animeSkipEnabled,
             animeSkipClientId = animeSkipClientId,
             introDbApiKey = introDbApiKey,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.kt
@@ -85,6 +85,8 @@ internal expect object PlayerSettingsStorage {
     fun saveStreamAutoPlayTimeoutSeconds(seconds: Int)
     fun loadSkipIntroEnabled(): Boolean?
     fun saveSkipIntroEnabled(enabled: Boolean)
+    fun loadAutoSkipSegmentTypes(): Set<String>?
+    fun saveAutoSkipSegmentTypes(segmentTypes: Set<String>)
     fun loadAnimeSkipEnabled(): Boolean?
     fun saveAnimeSkipEnabled(enabled: Boolean)
     fun loadAnimeSkipClientId(): String?

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/AutoSkipSegmentType.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/AutoSkipSegmentType.kt
@@ -1,0 +1,22 @@
+package com.nuvio.app.features.player.skip
+
+enum class AutoSkipSegmentType(val storedValue: String) {
+    INTRO("intro"),
+    RECAP("recap"),
+    OUTRO("outro");
+
+    companion object {
+        fun fromStoredValue(value: String): AutoSkipSegmentType? =
+            entries.firstOrNull { it.storedValue == value }
+
+        fun fromSkipIntervalType(type: String): AutoSkipSegmentType? = when (type.trim().lowercase()) {
+            "op", "opening", "mixed-op", "intro" -> INTRO
+            "recap" -> RECAP
+            "ed", "ending", "mixed-ed", "outro", "credits" -> OUTRO
+            else -> null
+        }
+    }
+}
+
+internal fun SkipInterval.autoSkipKey(): String =
+    "$provider:$type:$startTime:$endTime"

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/SkipIntervalLookup.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/SkipIntervalLookup.kt
@@ -1,0 +1,44 @@
+package com.nuvio.app.features.player.skip
+
+internal sealed interface SkipIntervalLookup {
+    data class Imdb(val imdbId: String, val season: Int, val episode: Int) : SkipIntervalLookup
+    data class Mal(val malId: String, val episode: Int) : SkipIntervalLookup
+    data class Kitsu(val kitsuId: String, val episode: Int) : SkipIntervalLookup
+}
+
+internal fun resolveSkipIntervalLookup(
+    videoId: String?,
+    season: Int?,
+    episode: Int?,
+): SkipIntervalLookup? {
+    val normalizedId = videoId?.trim()?.takeIf(String::isNotEmpty) ?: return null
+    val parts = normalizedId.split(':')
+
+    return when {
+        normalizedId.startsWith("mal:", ignoreCase = true) -> {
+            val malId = parts.getOrNull(1)?.takeIf(String::isNotBlank) ?: return null
+            val embeddedEpisode = parts.takeIf { it.size >= 3 }?.lastOrNull()?.toIntOrNull()
+            val resolvedEpisode = episode ?: embeddedEpisode ?: return null
+            SkipIntervalLookup.Mal(malId = malId, episode = resolvedEpisode)
+        }
+
+        normalizedId.startsWith("kitsu:", ignoreCase = true) -> {
+            val kitsuId = parts.getOrNull(1)?.takeIf(String::isNotBlank) ?: return null
+            val embeddedEpisode = parts.takeIf { it.size >= 3 }?.lastOrNull()?.toIntOrNull()
+            val resolvedEpisode = episode ?: embeddedEpisode ?: return null
+            SkipIntervalLookup.Kitsu(kitsuId = kitsuId, episode = resolvedEpisode)
+        }
+
+        parts.firstOrNull()?.startsWith("tt", ignoreCase = true) == true -> {
+            val resolvedSeason = season ?: parts.getOrNull(1)?.toIntOrNull() ?: return null
+            val resolvedEpisode = episode ?: parts.getOrNull(2)?.toIntOrNull() ?: return null
+            SkipIntervalLookup.Imdb(
+                imdbId = parts.first(),
+                season = resolvedSeason,
+                episode = resolvedEpisode,
+            )
+        }
+
+        else -> null
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/PlaybackSettingsPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/PlaybackSettingsPage.kt
@@ -67,6 +67,7 @@ import com.nuvio.app.features.player.localizedLabel
 import com.nuvio.app.features.player.IosTargetPrimaries
 import com.nuvio.app.features.player.IosTargetTransfer
 import com.nuvio.app.features.player.PlayerSettingsRepository
+import com.nuvio.app.features.player.skip.AutoSkipSegmentType
 import com.nuvio.app.features.player.STREAM_AUTO_PLAY_TIMEOUT_VALUES
 import com.nuvio.app.features.player.SubtitleBackgroundColorSwatches
 import com.nuvio.app.features.player.SubtitleColorSwatches
@@ -330,6 +331,7 @@ private fun PlaybackSettingsSection(
     var showAutoPlayAddonSelectionDialog by remember { mutableStateOf(false) }
     var showAutoPlayPluginSelectionDialog by remember { mutableStateOf(false) }
     var showAutoPlayRegexDialog by remember { mutableStateOf(false) }
+    var showAutoSkipSegmentDialog by remember { mutableStateOf(false) }
     var showP2pConsentDialog by remember { mutableStateOf(false) }
     var showP2pProfileDialog by remember { mutableStateOf(false) }
     var showP2pCacheSizeDialog by remember { mutableStateOf(false) }
@@ -1060,6 +1062,14 @@ private fun PlaybackSettingsSection(
                     onCheckedChange = PlayerSettingsRepository::setSkipIntroEnabled,
                 )
                 SettingsGroupDivider(isTablet = isTablet)
+                SettingsNavigationRow(
+                    title = stringResource(Res.string.settings_playback_auto_skip_segments),
+                    description = autoSkipSelectionSummary(autoPlayPlayerSettings.autoSkipSegmentTypes),
+                    enabled = autoPlayPlayerSettings.skipIntroEnabled,
+                    isTablet = isTablet,
+                    onClick = { showAutoSkipSegmentDialog = true },
+                )
+                SettingsGroupDivider(isTablet = isTablet)
                 SettingsSwitchRow(
                     title = stringResource(Res.string.settings_playback_anime_skip),
                     description = stringResource(Res.string.settings_playback_anime_skip_description),
@@ -1487,6 +1497,14 @@ private fun PlaybackSettingsSection(
                 showP2pConsentDialog = false
             },
             onDismiss = { showP2pConsentDialog = false },
+        )
+    }
+
+    if (showAutoSkipSegmentDialog) {
+        AutoSkipSegmentSelectionDialog(
+            selectedTypes = autoPlayPlayerSettings.autoSkipSegmentTypes,
+            onTypeToggled = PlayerSettingsRepository::setAutoSkipSegmentTypeEnabled,
+            onDismiss = { showAutoSkipSegmentDialog = false },
         )
     }
 
@@ -2109,6 +2127,124 @@ private fun ReuseCacheDurationDialog(
             }
         }
     }
+}
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+private fun AutoSkipSegmentSelectionDialog(
+    selectedTypes: Set<AutoSkipSegmentType>,
+    onTypeToggled: (AutoSkipSegmentType, Boolean) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    BasicAlertDialog(onDismissRequest = onDismiss) {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(20.dp),
+            color = MaterialTheme.colorScheme.surface,
+        ) {
+            Column(
+                modifier = Modifier.padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Text(
+                    text = stringResource(Res.string.settings_playback_auto_skip_segments),
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.SemiBold,
+                )
+
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    AutoSkipSegmentType.entries.forEach { segmentType ->
+                        val isSelected = segmentType in selectedTypes
+                        val containerColor = if (isSelected) {
+                            MaterialTheme.colorScheme.primary.copy(alpha = 0.14f)
+                        } else {
+                            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f)
+                        }
+                        Surface(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onTypeToggled(segmentType, !isSelected) },
+                            shape = RoundedCornerShape(12.dp),
+                            color = containerColor,
+                        ) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 14.dp, vertical = 12.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Column(
+                                    modifier = Modifier.weight(1f),
+                                    verticalArrangement = Arrangement.spacedBy(3.dp),
+                                ) {
+                                    Text(
+                                        text = autoSkipTypeLabel(segmentType),
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        color = MaterialTheme.colorScheme.onSurface,
+                                    )
+                                    Text(
+                                        text = autoSkipTypeDescription(segmentType),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                                Box(
+                                    modifier = Modifier.size(24.dp),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    if (isSelected) {
+                                        Icon(
+                                            imageVector = Icons.Rounded.Check,
+                                            contentDescription = null,
+                                            tint = MaterialTheme.colorScheme.primary,
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = stringResource(Res.string.settings_playback_dialog_close),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun autoSkipSelectionSummary(selectedTypes: Set<AutoSkipSegmentType>): String {
+    if (selectedTypes.isEmpty()) return stringResource(Res.string.settings_playback_auto_skip_none)
+    val introLabel = stringResource(Res.string.settings_playback_auto_skip_intro)
+    val recapLabel = stringResource(Res.string.settings_playback_auto_skip_recap)
+    val outroLabel = stringResource(Res.string.settings_playback_auto_skip_outro)
+    return buildList {
+        if (AutoSkipSegmentType.INTRO in selectedTypes) add(introLabel)
+        if (AutoSkipSegmentType.RECAP in selectedTypes) add(recapLabel)
+        if (AutoSkipSegmentType.OUTRO in selectedTypes) add(outroLabel)
+    }.joinToString(", ")
+}
+
+@Composable
+private fun autoSkipTypeLabel(segmentType: AutoSkipSegmentType): String = when (segmentType) {
+    AutoSkipSegmentType.INTRO -> stringResource(Res.string.settings_playback_auto_skip_intro)
+    AutoSkipSegmentType.RECAP -> stringResource(Res.string.settings_playback_auto_skip_recap)
+    AutoSkipSegmentType.OUTRO -> stringResource(Res.string.settings_playback_auto_skip_outro)
+}
+
+@Composable
+private fun autoSkipTypeDescription(segmentType: AutoSkipSegmentType): String = when (segmentType) {
+    AutoSkipSegmentType.INTRO -> stringResource(Res.string.settings_playback_auto_skip_intro_description)
+    AutoSkipSegmentType.RECAP -> stringResource(Res.string.settings_playback_auto_skip_recap_description)
+    AutoSkipSegmentType.OUTRO -> stringResource(Res.string.settings_playback_auto_skip_outro_description)
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watchprogress/AirDateUtils.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watchprogress/AirDateUtils.kt
@@ -66,16 +66,16 @@ fun calculateReleaseAlertState(
     seedSeasonNumber: Int?,
     nextSeasonNumber: Int?,
     releasedIso: String?,
+    nowEpochMs: Long = WatchProgressClock.nowEpochMs(),
 ): ReleaseAlertState {
     if (releasedIso.isNullOrBlank()) return NoReleaseAlertState
 
     val releaseEpoch = parseReleaseDateToEpochMs(releasedIso)
         ?: return NoReleaseAlertState
 
-    val nowMs = WatchProgressClock.nowEpochMs()
-    if (nowMs < releaseEpoch) return NoReleaseAlertState
+    if (nowEpochMs < releaseEpoch) return NoReleaseAlertState
     if (releaseEpoch <= seedLastUpdatedEpochMs) return NoReleaseAlertState
-    if (nowMs - releaseEpoch >= ReleaseAlertWindowMs) return NoReleaseAlertState
+    if (nowEpochMs - releaseEpoch >= ReleaseAlertWindowMs) return NoReleaseAlertState
 
     val isNewSeasonRelease =
         seedSeasonNumber != null &&

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/skip/AutoSkipSegmentTypeTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/skip/AutoSkipSegmentTypeTest.kt
@@ -1,0 +1,29 @@
+package com.nuvio.app.features.player.skip
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AutoSkipSegmentTypeTest {
+    @Test
+    fun mapsSupportedIntervalAliases() {
+        assertEquals(AutoSkipSegmentType.INTRO, AutoSkipSegmentType.fromSkipIntervalType("opening"))
+        assertEquals(AutoSkipSegmentType.INTRO, AutoSkipSegmentType.fromSkipIntervalType("mixed-op"))
+        assertEquals(AutoSkipSegmentType.RECAP, AutoSkipSegmentType.fromSkipIntervalType("recap"))
+        assertEquals(AutoSkipSegmentType.OUTRO, AutoSkipSegmentType.fromSkipIntervalType("ending"))
+        assertEquals(AutoSkipSegmentType.OUTRO, AutoSkipSegmentType.fromSkipIntervalType("credits"))
+        assertNull(AutoSkipSegmentType.fromSkipIntervalType("preview"))
+    }
+
+    @Test
+    fun intervalKeyDistinguishesProviderTypeAndBounds() {
+        val interval = SkipInterval(
+            startTime = 12.5,
+            endTime = 96.0,
+            type = "intro",
+            provider = "introdb",
+        )
+
+        assertEquals("introdb:intro:12.5:96.0", interval.autoSkipKey())
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/skip/SkipIntervalLookupTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/skip/SkipIntervalLookupTest.kt
@@ -1,0 +1,45 @@
+package com.nuvio.app.features.player.skip
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SkipIntervalLookupTest {
+    @Test
+    fun resolvesImdbEpisodeFromPlayerMetadata() {
+        assertEquals(
+            SkipIntervalLookup.Imdb("tt1234567", season = 2, episode = 4),
+            resolveSkipIntervalLookup("tt1234567:2:4", season = 2, episode = 4),
+        )
+    }
+
+    @Test
+    fun resolvesMalEpisodeEmbeddedInVideoId() {
+        assertEquals(
+            SkipIntervalLookup.Mal("62322", episode = 4),
+            resolveSkipIntervalLookup("mal:62322:4", season = 1, episode = null),
+        )
+    }
+
+    @Test
+    fun usesActiveEpisodeForSeasonQualifiedMalId() {
+        assertEquals(
+            SkipIntervalLookup.Mal("63375", episode = 5),
+            resolveSkipIntervalLookup("mal:63375:1:5", season = 1, episode = 5),
+        )
+    }
+
+    @Test
+    fun resolvesKitsuEpisodeEmbeddedInVideoId() {
+        assertEquals(
+            SkipIntervalLookup.Kitsu("12345", episode = 8),
+            resolveSkipIntervalLookup("kitsu:12345:8", season = null, episode = null),
+        )
+    }
+
+    @Test
+    fun rejectsUnsupportedOrIncompleteIds() {
+        assertNull(resolveSkipIntervalLookup("tmdb:123", season = 1, episode = 2))
+        assertNull(resolveSkipIntervalLookup("mal:62322", season = 1, episode = null))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/watchprogress/AirDateUtilsTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/watchprogress/AirDateUtilsTest.kt
@@ -1,0 +1,38 @@
+package com.nuvio.app.features.watchprogress
+
+import com.nuvio.app.core.time.parseEpisodeReleaseEpochMs
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AirDateUtilsTest {
+    @Test
+    fun futureEpisodeCannotShowNewEpisodeAlert() {
+        val nowEpochMs = requireNotNull(parseEpisodeReleaseEpochMs("2026-07-19T00:40:00Z"))
+
+        val alert = calculateReleaseAlertState(
+            seedLastUpdatedEpochMs = requireNotNull(parseEpisodeReleaseEpochMs("2026-07-12T00:40:00Z")),
+            seedSeasonNumber = 1,
+            nextSeasonNumber = 1,
+            releasedIso = "2026-07-19T13:00:00Z",
+            nowEpochMs = nowEpochMs,
+        )
+
+        assertFalse(alert.isReleaseAlert)
+    }
+
+    @Test
+    fun newlyAiredEpisodeStillShowsNewEpisodeAlert() {
+        val releaseEpochMs = requireNotNull(parseEpisodeReleaseEpochMs("2026-07-18T23:40:00Z"))
+
+        val alert = calculateReleaseAlertState(
+            seedLastUpdatedEpochMs = releaseEpochMs - 24 * 60 * 60 * 1000,
+            seedSeasonNumber = 1,
+            nextSeasonNumber = 1,
+            releasedIso = "2026-07-18T23:40:00Z",
+            nowEpochMs = requireNotNull(parseEpisodeReleaseEpochMs("2026-07-19T00:40:00Z")),
+        )
+
+        assertTrue(alert.isReleaseAlert)
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.desktop.kt
@@ -58,6 +58,7 @@ internal actual object PlayerSettingsStorage {
     private const val streamAutoPlayRegexKey = "stream_auto_play_regex"
     private const val streamAutoPlayTimeoutSecondsKey = "stream_auto_play_timeout_seconds"
     private const val skipIntroEnabledKey = "skip_intro_enabled"
+    private const val autoSkipSegmentTypesKey = "auto_skip_segment_types"
     private const val animeSkipEnabledKey = "animeskip_enabled"
     private const val animeSkipClientIdKey = "animeskip_client_id"
     private const val introDbApiKeyKey = "introdb_api_key"
@@ -129,6 +130,7 @@ internal actual object PlayerSettingsStorage {
         streamAutoPlayRegexKey,
         streamAutoPlayTimeoutSecondsKey,
         skipIntroEnabledKey,
+        autoSkipSegmentTypesKey,
         animeSkipEnabledKey,
         animeSkipClientIdKey,
         streamAutoPlayNextEpisodeEnabledKey,
@@ -241,6 +243,8 @@ internal actual object PlayerSettingsStorage {
     actual fun saveStreamAutoPlayTimeoutSeconds(seconds: Int) = saveInt(streamAutoPlayTimeoutSecondsKey, seconds)
     actual fun loadSkipIntroEnabled(): Boolean? = loadBoolean(skipIntroEnabledKey)
     actual fun saveSkipIntroEnabled(enabled: Boolean) = saveBoolean(skipIntroEnabledKey, enabled)
+    actual fun loadAutoSkipSegmentTypes(): Set<String>? = loadStringSet(autoSkipSegmentTypesKey)
+    actual fun saveAutoSkipSegmentTypes(segmentTypes: Set<String>) = saveStringSet(autoSkipSegmentTypesKey, segmentTypes)
     actual fun loadAnimeSkipEnabled(): Boolean? = loadBoolean(animeSkipEnabledKey)
     actual fun saveAnimeSkipEnabled(enabled: Boolean) = saveBoolean(animeSkipEnabledKey, enabled)
     actual fun loadAnimeSkipClientId(): String? = loadString(animeSkipClientIdKey)
@@ -356,6 +360,7 @@ internal actual object PlayerSettingsStorage {
         loadStreamAutoPlayRegex()?.let { put(streamAutoPlayRegexKey, encodeSyncString(it)) }
         loadStreamAutoPlayTimeoutSeconds()?.let { put(streamAutoPlayTimeoutSecondsKey, encodeSyncInt(it)) }
         loadSkipIntroEnabled()?.let { put(skipIntroEnabledKey, encodeSyncBoolean(it)) }
+        loadAutoSkipSegmentTypes()?.let { put(autoSkipSegmentTypesKey, encodeSyncStringSet(it)) }
         loadAnimeSkipEnabled()?.let { put(animeSkipEnabledKey, encodeSyncBoolean(it)) }
         loadAnimeSkipClientId()?.let { put(animeSkipClientIdKey, encodeSyncString(it)) }
         loadStreamAutoPlayNextEpisodeEnabled()?.let { put(streamAutoPlayNextEpisodeEnabledKey, encodeSyncBoolean(it)) }
@@ -428,6 +433,7 @@ internal actual object PlayerSettingsStorage {
         payload.decodeSyncString(streamAutoPlayRegexKey)?.let(::saveStreamAutoPlayRegex)
         payload.decodeSyncInt(streamAutoPlayTimeoutSecondsKey)?.let(::saveStreamAutoPlayTimeoutSeconds)
         payload.decodeSyncBoolean(skipIntroEnabledKey)?.let(::saveSkipIntroEnabled)
+        payload.decodeSyncStringSet(autoSkipSegmentTypesKey)?.let(::saveAutoSkipSegmentTypes)
         payload.decodeSyncBoolean(animeSkipEnabledKey)?.let(::saveAnimeSkipEnabled)
         payload.decodeSyncString(animeSkipClientIdKey)?.let(::saveAnimeSkipClientId)
         payload.decodeSyncString(introDbApiKeyKey)?.let(::saveIntroDbApiKey)

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.ios.kt
@@ -58,6 +58,7 @@ actual object PlayerSettingsStorage {
     private const val streamAutoPlayRegexKey = "stream_auto_play_regex"
     private const val streamAutoPlayTimeoutSecondsKey = "stream_auto_play_timeout_seconds"
     private const val skipIntroEnabledKey = "skip_intro_enabled"
+    private const val autoSkipSegmentTypesKey = "auto_skip_segment_types"
     private const val animeSkipEnabledKey = "animeskip_enabled"
     private const val animeSkipClientIdKey = "animeskip_client_id"
     private const val introDbApiKeyKey = "introdb_api_key"
@@ -129,6 +130,7 @@ actual object PlayerSettingsStorage {
         streamAutoPlayRegexKey,
         streamAutoPlayTimeoutSecondsKey,
         skipIntroEnabledKey,
+        autoSkipSegmentTypesKey,
         animeSkipEnabledKey,
         animeSkipClientIdKey,
         streamAutoPlayNextEpisodeEnabledKey,
@@ -658,6 +660,18 @@ actual object PlayerSettingsStorage {
         NSUserDefaults.standardUserDefaults.setBool(enabled, forKey = ProfileScopedKey.of(skipIntroEnabledKey))
     }
 
+    @Suppress("UNCHECKED_CAST")
+    actual fun loadAutoSkipSegmentTypes(): Set<String>? {
+        val defaults = NSUserDefaults.standardUserDefaults
+        val key = ProfileScopedKey.of(autoSkipSegmentTypesKey)
+        val array = defaults.arrayForKey(key) as? List<String> ?: return null
+        return array.toSet()
+    }
+
+    actual fun saveAutoSkipSegmentTypes(segmentTypes: Set<String>) {
+        NSUserDefaults.standardUserDefaults.setObject(segmentTypes.toList(), forKey = ProfileScopedKey.of(autoSkipSegmentTypesKey))
+    }
+
     actual fun loadAnimeSkipEnabled(): Boolean? {
         val defaults = NSUserDefaults.standardUserDefaults
         val key = ProfileScopedKey.of(animeSkipEnabledKey)
@@ -952,6 +966,7 @@ actual object PlayerSettingsStorage {
         loadStreamAutoPlayRegex()?.let { put(streamAutoPlayRegexKey, encodeSyncString(it)) }
         loadStreamAutoPlayTimeoutSeconds()?.let { put(streamAutoPlayTimeoutSecondsKey, encodeSyncInt(it)) }
         loadSkipIntroEnabled()?.let { put(skipIntroEnabledKey, encodeSyncBoolean(it)) }
+        loadAutoSkipSegmentTypes()?.let { put(autoSkipSegmentTypesKey, encodeSyncStringSet(it)) }
         loadAnimeSkipEnabled()?.let { put(animeSkipEnabledKey, encodeSyncBoolean(it)) }
         loadAnimeSkipClientId()?.let { put(animeSkipClientIdKey, encodeSyncString(it)) }
         loadStreamAutoPlayNextEpisodeEnabled()?.let { put(streamAutoPlayNextEpisodeEnabledKey, encodeSyncBoolean(it)) }
@@ -1026,6 +1041,7 @@ actual object PlayerSettingsStorage {
         payload.decodeSyncString(streamAutoPlayRegexKey)?.let(::saveStreamAutoPlayRegex)
         payload.decodeSyncInt(streamAutoPlayTimeoutSecondsKey)?.let(::saveStreamAutoPlayTimeoutSeconds)
         payload.decodeSyncBoolean(skipIntroEnabledKey)?.let(::saveSkipIntroEnabled)
+        payload.decodeSyncStringSet(autoSkipSegmentTypesKey)?.let(::saveAutoSkipSegmentTypes)
         payload.decodeSyncBoolean(animeSkipEnabledKey)?.let(::saveAnimeSkipEnabled)
         payload.decodeSyncString(animeSkipClientIdKey)?.let(::saveAnimeSkipClientId)
         payload.decodeSyncString(introDbApiKeyKey)?.let(::saveIntroDbApiKey)


### PR DESCRIPTION
## Summary

Brings three established NuvioTV behaviours to Desktop: skip lookup for anime identifiers, opt-in automatic skipping per segment type, and scrolling for long focused shelf titles.

Opened as a draft pending approval in #280. Previously submitted as #259, which was a draft pending #256; that approval request was closed automatically by the unlabeled-issue bot rather than declined, so #280 re-raises it with a label as the bot asked.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

Left unchecked deliberately: this is a draft pending approval in #280. The approved box will be checked if and when that is granted.

## Why

Desktop uses an older, desktop-specific version of these shared player behaviours:

- Skip intervals are resolved from IMDb metadata only, so anime identified by MAL or Kitsu frequently finds no skip data.
- There is no automatic skipping, so every intro, recap and ending is skipped by hand even when the data exists.
- Long focused shelf titles are static, while NuvioTV scrolls them so they can be read.

Automatic skipping is off by default, so existing users keep the current manual behaviour unless they opt in.

## Desktop scope

Desktop UI and playback. The runtime and shelf behaviour is shared code required by the Desktop UI; settings persistence includes platform actuals so the shared setting stays valid for every target this repo compiles.

## Issue or approval

Approval requested in #280. Supersedes #259 and its approval request #256.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

Left unchecked pending #280, since this adds a setting and new playback behaviour rather than fixing a documented bug.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Automatic skipping is off by default. Manual skip controls remain for every segment type not selected. Stream selection, next-episode behaviour, playback engines, provider credentials and external player handling are all untouched.

The three parts are grouped because they are the same parity effort and were reviewed together as #259; happy to split them into separate PRs if you would rather take them one at a time.

## Testing

Windows 11, built from source, rebased onto current Dev and verified building there.

Exercised skip lookup against IMDb, MAL and Kitsu identified episodes, confirmed automatic skipping seeks past each selected segment once and leaves unselected types to the manual control, and confirmed the setting persists and stays off by default. Checked long shelf titles scroll on focus while short ones stay static.

Not tested on macOS or Linux.

## Screenshots / Video

Automatic skipping:

![Automatic skipping panel](https://github.com/user-attachments/assets/96ffdfe1-fe8a-44b4-a5c8-e0f73bb11f34)

https://github.com/user-attachments/assets/a96b4b5d-f5bc-4020-9391-1daf7645de28

## Related NuvioTV pull requests

- NuvioMedia/NuvioTV#2641
- NuvioMedia/NuvioTV#2457
- NuvioMedia/NuvioTV#2359

## Breaking changes

None. Automatic skipping is disabled by default.

## Linked issues

Approval requested in #280. Supersedes #259 (approval request #256, closed by the unlabeled-issue bot).