### PR TITLE
Enable RPM packaging for Linux

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1278,7 +1278,7 @@ compose.desktop {
         )
 
         nativeDistributions {
-            targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
+            targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb, TargetFormat.Rpm)
             packageName = "Nuvio"
             packageVersion = desktopReleasePackageVersion
             vendor = "Nuvio Media"


### PR DESCRIPTION
## Summary

Enable native RPM packaging for Linux by adding `TargetFormat.Rpm` to the Compose Desktop packaging configuration.

## PR type

- [x] Small maintenance only, with no UI or behavior change

## Why

Compose Desktop already supports RPM packaging, but the project configuration only enabled DMG, MSI and DEB targets. This change enables building native RPM packages for Linux distributions that use the RPM package format.

## Desktop scope

Linux desktop packaging only.

## Issue or approval

No linked issue. This is a small packaging improvement that enables an existing Compose Desktop packaging target.

## UI / behavior impact

- [x] No UI change
- [x] No behavior change

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only enables the existing RPM packaging target. No application logic, UI, or other packaging formats were modified.

## Testing

Tested on Fedora 44.

- Verified that the `packageRpm` Gradle task is generated.
- Successfully executed `./gradlew :composeApp:packageRpm`.
- Successfully built an RPM package.
- Installed the generated RPM using `dnf`.
- Verified that the application launches successfully from the installed RPM package.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue.