### PR TITLE
fix(subtitles): preserve authored ASS/SSA subtitle styling when useLibass is enabled

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerEngine.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerEngine.android.kt
@@ -839,7 +839,7 @@ private fun ExoPlayerSurface(
                     Log.d(TAG, "clearExternalSubtitleAndSelect: done, pending=$trackIndex position=$currentPosition")
                 }
 
-                override fun applySubtitleStyle(style: SubtitleStyleState) {
+                override fun applySubtitleStyle(style: SubtitleStyleState, useLibass: Boolean) {
                     currentSubtitleStyle = style
                     playerViewRef?.applySubtitleStyle(style, pipSubtitleScale)
                 }
@@ -1373,18 +1373,22 @@ private class NuvioLibmpvView(
                 selectSubtitleTrack(trackIndex)
             }
 
-            override fun applySubtitleStyle(style: SubtitleStyleState) {
-                mpv.setPropertyString("sub-ass-override", "no")
-                mpv.setPropertyString("sub-color", style.textColor.toMpvColor())
-                mpv.setPropertyString("sub-back-color", style.backgroundColor.toMpvColor())
-                mpv.setPropertyString("sub-outline-color", style.outlineColor.toMpvColor())
-                mpv.setPropertyString("sub-border-color", style.outlineColor.toMpvColor())
-                mpv.setPropertyString("sub-border-style", style.toMpvSubtitleBorderStyle())
-                mpv.setPropertyString("sub-bold", if (style.bold) "yes" else "no")
-                mpv.setPropertyInt("sub-font-size", style.toMpvSubtitleFontSize())
-                mpv.setPropertyInt("sub-outline-size", style.toMpvSubtitleOutlineSize())
-                mpv.setPropertyInt("sub-border-size", style.toMpvSubtitleOutlineSize())
-                mpv.setPropertyInt("sub-pos", (100 - style.bottomOffset / 10).coerceIn(0, 100))
+            override fun applySubtitleStyle(style: SubtitleStyleState, useLibass: Boolean) {
+                if (useLibass) {
+                    mpv.setPropertyString("sub-ass-override", "no")
+                } else {
+                    mpv.setPropertyString("sub-ass-override", "force")
+                    mpv.setPropertyString("sub-color", style.textColor.toMpvColor())
+                    mpv.setPropertyString("sub-back-color", style.backgroundColor.toMpvColor())
+                    mpv.setPropertyString("sub-outline-color", style.outlineColor.toMpvColor())
+                    mpv.setPropertyString("sub-border-color", style.outlineColor.toMpvColor())
+                    mpv.setPropertyString("sub-border-style", style.toMpvSubtitleBorderStyle())
+                    mpv.setPropertyString("sub-bold", if (style.bold) "yes" else "no")
+                    mpv.setPropertyInt("sub-font-size", style.toMpvSubtitleFontSize())
+                    mpv.setPropertyInt("sub-outline-size", style.toMpvSubtitleOutlineSize())
+                    mpv.setPropertyInt("sub-border-size", style.toMpvSubtitleOutlineSize())
+                    mpv.setPropertyInt("sub-pos", (100 - style.bottomOffset / 10).coerceIn(0, 100))
+                }
             }
 
             override fun setSubtitleDelayMs(delayMs: Int) {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerEngine.kt
@@ -18,7 +18,7 @@ interface PlayerEngineController {
     fun setSubtitleUri(url: String)
     fun clearExternalSubtitle()
     fun clearExternalSubtitleAndSelect(trackIndex: Int)
-    fun applySubtitleStyle(style: SubtitleStyleState) {}
+    fun applySubtitleStyle(style: SubtitleStyleState, useLibass: Boolean = false) {}
     fun setSubtitleDelayMs(delayMs: Int) {}
     fun configureIosVideoOutput(settings: PlayerSettingsUiState) {}
     fun updateNowPlayingMetadata(info: PlayerNowPlayingInfo) {}

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeEffects.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeEffects.kt
@@ -169,8 +169,8 @@ internal fun PlayerScreenRuntime.BindPlayerRuntimeEffects() {
         subtitleAutoSyncState = SubtitleAutoSyncUiState()
     }
 
-    LaunchedEffect(playerController, subtitleStyle) {
-        playerController?.applySubtitleStyle(subtitleStyle)
+    LaunchedEffect(playerController, subtitleStyle, playerSettingsUiState.useLibass) {
+        playerController?.applySubtitleStyle(subtitleStyle, playerSettingsUiState.useLibass)
     }
 
     LaunchedEffect(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeState.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeState.kt
@@ -63,7 +63,7 @@ internal class PlayerScreenRuntime(
     lateinit var scope: CoroutineScope
     lateinit var hapticFeedback: HapticFeedback
 
-    var playerSettingsUiState: PlayerSettingsUiState = PlayerSettingsUiState()
+    var playerSettingsUiState by mutableStateOf(PlayerSettingsUiState())
     var p2pSettingsUiState by mutableStateOf(P2pSettingsUiState())
     var p2pStreamingState by mutableStateOf<P2pStreamingState>(P2pStreamingState.Idle)
     var metaScreenSettingsUiState: MetaScreenSettingsUiState = MetaScreenSettingsUiState()

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerBridge.kt
@@ -89,6 +89,7 @@ internal object NativePlayerBridge {
         bold: Boolean,
         fontSize: Float,
         subPos: Int,
+        useLibass: Boolean,
     )
     external fun warmupWebView2(controlsPageUrl: String): Boolean
     external fun shutdownWebView2Warmup()

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
@@ -52,6 +52,7 @@ internal class NativePlayerController(
     private var controlsState = PlayerControlsState()
     private var pendingSubtitleDelayMs: Int? = null
     private var pendingSubtitleStyle: SubtitleStyleState? = null
+    private var pendingUseLibass: Boolean = false
     private var lastSentControlsStructureKey: NativeControlsStructureKey? = null
     private var onAction: (PlayerControlsAction) -> Boolean = { false }
     private var onEvent: (String, Double) -> Boolean = { _, _ -> false }
@@ -506,6 +507,7 @@ internal class NativePlayerController(
         }
         log.d { "selectSubtitleTrack index=$index trackId=$trackId count=${tracks.size} handle=$current" }
         NativePlayerBridge.selectSubtitleTrack(current, trackId)
+        applyPendingSubtitleSettings()
     }
 
     override fun setSubtitleUri(url: String) {
@@ -531,6 +533,7 @@ internal class NativePlayerController(
         }
         log.d { "clearExternalSubtitleAndSelect trackIndex=$trackIndex trackId=$trackId handle=$current" }
         NativePlayerBridge.clearExternalSubtitlesAndSelect(current, trackId)
+        applyPendingSubtitleSettings()
     }
 
     override fun setSubtitleDelayMs(delayMs: Int) {
@@ -541,10 +544,11 @@ internal class NativePlayerController(
         }
     }
 
-    override fun applySubtitleStyle(style: SubtitleStyleState) {
+    override fun applySubtitleStyle(style: SubtitleStyleState, useLibass: Boolean) {
         pendingSubtitleStyle = style
+        pendingUseLibass = useLibass
         handle.takeIf { it != 0L }?.let { current ->
-            applySubtitleStyle(current, style)
+            applySubtitleStyle(current, style, useLibass)
         }
     }
 
@@ -554,11 +558,11 @@ internal class NativePlayerController(
             NativePlayerBridge.setSubtitleDelayMs(current, delayMs)
         }
         pendingSubtitleStyle?.let { style ->
-            applySubtitleStyle(current, style)
+            applySubtitleStyle(current, style, pendingUseLibass)
         }
     }
 
-    private fun applySubtitleStyle(handle: Long, style: SubtitleStyleState) {
+    private fun applySubtitleStyle(handle: Long, style: SubtitleStyleState, useLibass: Boolean) {
         NativePlayerBridge.applySubtitleStyle(
             handle = handle,
             textColor = style.textColor.toMpvColorString(),
@@ -568,6 +572,7 @@ internal class NativePlayerController(
             bold = style.bold,
             fontSize = style.toMpvSubtitleFontSize(),
             subPos = style.toMpvSubtitlePosition(),
+            useLibass = useLibass,
         )
     }
 

--- a/composeApp/src/desktopMain/native/macos/player_bridge.mm
+++ b/composeApp/src/desktopMain/native/macos/player_bridge.mm
@@ -121,7 +121,8 @@
                              outlineSize:(double)outlineSize
                                     bold:(BOOL)bold
                                 fontSize:(double)fontSize
-                                  subPos:(int)subPos;
+                                  subPos:(int)subPos
+                               useLibass:(BOOL)useLibass;
 - (void)handleScriptMessage:(NSDictionary *)message;
 - (void)focusControlsWebViewIfNeeded;
 - (void)layoutNativeSubviews;
@@ -2018,24 +2019,29 @@ static void setMpvOptionString(mpv_handle *mpv, const char *name, const char *va
                              outlineSize:(double)outlineSize
                                     bold:(BOOL)bold
                                 fontSize:(double)fontSize
-                                  subPos:(int)subPos {
+                                  subPos:(int)subPos
+                               useLibass:(BOOL)useLibass {
     if (!_mpv) return;
-    [self setStringProperty:"sub-ass-override" value:@"force"];
-    [self setStringProperty:"sub-color" value:textColor ?: @"#FFFFFFFF"];
-    [self setStringProperty:"sub-back-color" value:backgroundColor ?: @"#00000000"];
-    [self setStringProperty:"sub-outline-color" value:outlineColor ?: @"#FF000000"];
-    [self setStringProperty:"sub-border-style"
-                      value:[(backgroundColor ?: @"") hasPrefix:@"#00"] ? @"outline-and-shadow" : @"opaque-box"];
-    [self setStringProperty:"sub-bold" value:bold ? @"yes" : @"no"];
+    if (useLibass) {
+        [self setStringProperty:"sub-ass-override" value:@"no"];
+    } else {
+        [self setStringProperty:"sub-ass-override" value:@"force"];
+        [self setStringProperty:"sub-color" value:textColor ?: @"#FFFFFFFF"];
+        [self setStringProperty:"sub-back-color" value:backgroundColor ?: @"#00000000"];
+        [self setStringProperty:"sub-outline-color" value:outlineColor ?: @"#FF000000"];
+        [self setStringProperty:"sub-border-style"
+                          value:[(backgroundColor ?: @"") hasPrefix:@"#00"] ? @"outline-and-shadow" : @"opaque-box"];
+        [self setStringProperty:"sub-bold" value:bold ? @"yes" : @"no"];
 
-    double outline = MAX(0.0, MIN(8.0, outlineSize));
-    mpv_set_property(_mpv, "sub-outline-size", MPV_FORMAT_DOUBLE, &outline);
+        double outline = MAX(0.0, MIN(8.0, outlineSize));
+        mpv_set_property(_mpv, "sub-outline-size", MPV_FORMAT_DOUBLE, &outline);
 
-    double size = MAX(18.0, MIN(96.0, fontSize));
-    mpv_set_property(_mpv, "sub-font-size", MPV_FORMAT_DOUBLE, &size);
+        double size = MAX(18.0, MIN(96.0, fontSize));
+        mpv_set_property(_mpv, "sub-font-size", MPV_FORMAT_DOUBLE, &size);
 
-    int64_t position = MAX(0, MIN(150, subPos));
-    mpv_set_property(_mpv, "sub-pos", MPV_FORMAT_INT64, &position);
+        int64_t position = MAX(0, MIN(150, subPos));
+        mpv_set_property(_mpv, "sub-pos", MPV_FORMAT_INT64, &position);
+    }
 }
 
 - (double)doubleProperty:(const char *)name fallback:(double)fallback {
@@ -2824,7 +2830,8 @@ Java_com_nuvio_app_features_player_desktop_NativePlayerBridge_applySubtitleStyle
     jfloat outlineSize,
     jboolean bold,
     jfloat fontSize,
-    jint subPos
+    jint subPos,
+    jboolean useLibass
 ) {
     if (handle == 0) return;
     std::string text = jstringToString(env, textColor);
@@ -2838,6 +2845,7 @@ Java_com_nuvio_app_features_player_desktop_NativePlayerBridge_applySubtitleStyle
                                      outlineSize:(double)outlineSize
                                             bold:bold == JNI_TRUE
                                         fontSize:(double)fontSize
-                                          subPos:(int)subPos];
+                                          subPos:(int)subPos
+                                       useLibass:useLibass == JNI_TRUE];
     });
 }

--- a/composeApp/src/desktopMain/native/windows/player_bridge.cpp
+++ b/composeApp/src/desktopMain/native/windows/player_bridge.cpp
@@ -1150,27 +1150,32 @@ public:
         double outlineSize,
         bool bold,
         double fontSize,
-        int subPos
+        int subPos,
+        bool useLibass
     ) {
-        setStringProperty("sub-ass-override", "force");
-        setStringProperty("sub-color", textColor.empty() ? "#FFFFFFFF" : textColor);
-        setStringProperty("sub-back-color", backgroundColor.empty() ? "#00000000" : backgroundColor);
-        setStringProperty("sub-outline-color", outlineColor.empty() ? "#FF000000" : outlineColor);
-        setStringProperty(
-            "sub-border-style",
-            backgroundColor.rfind("#00", 0) == 0 ? "outline-and-shadow" : "opaque-box"
-        );
-        setStringProperty("sub-bold", bold ? "yes" : "no");
+        if (useLibass) {
+            setStringProperty("sub-ass-override", "no");
+        } else {
+            setStringProperty("sub-ass-override", "force");
+            setStringProperty("sub-color", textColor.empty() ? "#FFFFFFFF" : textColor);
+            setStringProperty("sub-back-color", backgroundColor.empty() ? "#00000000" : backgroundColor);
+            setStringProperty("sub-outline-color", outlineColor.empty() ? "#FF000000" : outlineColor);
+            setStringProperty(
+                "sub-border-style",
+                backgroundColor.rfind("#00", 0) == 0 ? "outline-and-shadow" : "opaque-box"
+            );
+            setStringProperty("sub-bold", bold ? "yes" : "no");
 
-        {
-            std::lock_guard<std::mutex> lock(mpvMutex);
-            if (!mpv) return;
-            double outline = std::max(0.0, std::min(8.0, outlineSize));
-            double size = std::max(18.0, std::min(96.0, fontSize));
-            int64_t position = std::max(0, std::min(150, subPos));
-            mpvApi().setProperty(mpv, "sub-outline-size", MPV_FORMAT_DOUBLE, &outline);
-            mpvApi().setProperty(mpv, "sub-font-size", MPV_FORMAT_DOUBLE, &size);
-            mpvApi().setProperty(mpv, "sub-pos", MPV_FORMAT_INT64, &position);
+            {
+                std::lock_guard<std::mutex> lock(mpvMutex);
+                if (!mpv) return;
+                double outline = std::max(0.0, std::min(8.0, outlineSize));
+                double size = std::max(18.0, std::min(96.0, fontSize));
+                int64_t position = std::max(0, std::min(150, subPos));
+                mpvApi().setProperty(mpv, "sub-outline-size", MPV_FORMAT_DOUBLE, &outline);
+                mpvApi().setProperty(mpv, "sub-font-size", MPV_FORMAT_DOUBLE, &size);
+                mpvApi().setProperty(mpv, "sub-pos", MPV_FORMAT_INT64, &position);
+            }
         }
     }
 
@@ -2415,7 +2420,8 @@ Java_com_nuvio_app_features_player_desktop_NativePlayerBridge_applySubtitleStyle
     jfloat outlineSize,
     jboolean bold,
     jfloat fontSize,
-    jint subPos
+    jint subPos,
+    jboolean useLibass
 ) {
     auto player = playerFromHandle(handle);
     if (!player) return;
@@ -2426,6 +2432,7 @@ Java_com_nuvio_app_features_player_desktop_NativePlayerBridge_applySubtitleStyle
         outlineSize,
         bold == JNI_TRUE,
         fontSize,
-        subPos
+        subPos,
+        useLibass == JNI_TRUE
     );
 }


### PR DESCRIPTION
## Summary

`useLibass` is the existing player setting meant to control whether authored ASS/SSA subtitle styling is preserved. On Windows, macOS, and Android the native bridges ignored it and always forced the app's subtitle styling on top of whatever the subtitle author shipped.

This PR threads the existing setting into the subtitle-style apply path on every platform so it actually takes effect. When `useLibass` is on, the player sets `sub-ass-override=no` and libass renders the authored fonts, positioning, and effects. When it is off, the player sets `sub-ass-override=force` and the app's custom styling is applied as before.

Default behavior is unchanged.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

For anime and other releases that ship ASS/SSA subtitles, the app's flat size, color, outline, and bottom-center positioning is destructive: signs, typesetting, positioned captions, and karaoke all lose their authored appearance. The `useLibass` toggle already exists for this exact purpose but is not honored on any platform.

## Desktop scope

Desktop playback on Windows and macOS is where the bug reproduces most clearly, since both use the libmpv-backed bridge. Android is included because the shared `PlayerEngineController` in `commonMain` is the authoritative entry point; without the Android implementation the common-side overload would have no effect on that target.

## Issue or approval

Closes #240

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the `useLibass` toggle now takes effect on subtitle rendering. Subtitle delay, track selection, the rest of the subtitle styling controls, and default text-subtitle behavior are untouched. The native bridges each receive a single small change to honor the setting that was already declared in the shared interface.

## Testing

Built from source on Windows against current `Dev`. Confirmed that ASS/SSA subtitles retain their authored fonts, positioning, and effects when `useLibass` is on, and that plain SRT subtitles are unaffected either way. Confirmed that the existing app styling still applies when `useLibass` is off. Confirmed that the setting persists across restarts.

Android and macOS builds compile cleanly against the JNI and bridge changes but have not been runtime-tested.

## Screenshots / Video

| Setting OFF (Default App Style) | Setting ON (ASS/SSA Style) |
|:---:|:---:|
| ![Setting OFF](https://raw.githubusercontent.com/atharvkharbade/NuvioDesktop/pr-images/scratch/libass_off.png) | ![Setting ON](https://raw.githubusercontent.com/atharvkharbade/NuvioDesktop/pr-images/scratch/libass_on.png) |

## Breaking changes

None. `useLibass=false` still produces the existing behavior.

## Linked issues

Closes #240