### PR TITLE
fix(desktop): restore window placement, size, and position across restarts

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
@@ -46,6 +46,7 @@ fun main(args: Array<String>) {
             )
             ?.takeIf { it.isNotBlank() }
         val wasFullscreenOnLastExit = remember { DesktopWindowModeStorage.loadWasFullscreen() }
+        val wasMaximizedOnLastExit = remember { DesktopWindowModeStorage.loadWasMaximized() }
         val savedGeometry = remember { DesktopWindowModeStorage.loadWindowedGeometry() }
         val windowState = rememberWindowState(
             width = savedGeometry?.width?.dp ?: 1280.dp,
@@ -54,10 +55,16 @@ fun main(args: Array<String>) {
                 ?: WindowPosition.PlatformDefault,
             // Windows fullscreen is emulated natively (see DesktopAppFullscreenController)
             // rather than driven by WindowPlacement, so it's restored separately below.
-            placement = if (wasFullscreenOnLastExit && DesktopHostOs.current != DesktopHostOs.WINDOWS) {
-                WindowPlacement.Fullscreen
-            } else {
-                WindowPlacement.Floating
+            placement = when {
+                wasFullscreenOnLastExit && DesktopHostOs.current != DesktopHostOs.WINDOWS -> {
+                    WindowPlacement.Fullscreen
+                }
+                wasMaximizedOnLastExit == false && savedGeometry != null -> {
+                    WindowPlacement.Floating
+                }
+                else -> {
+                    WindowPlacement.Maximized
+                }
             },
         )
         val fullscreenController = remember { DesktopAppFullscreenController() }
@@ -98,8 +105,11 @@ fun main(args: Array<String>) {
                 // coordinates aren't a meaningful "windowed position" to restore later.
                 snapshotFlow { Triple(windowState.placement, windowState.position, windowState.size) }
                     .collect { (placement, position, size) ->
-                        val isWindowed = placement == WindowPlacement.Floating &&
-                            !fullscreenController.isFullscreen(window, windowState)
+                        val isFullscreen = fullscreenController.isFullscreen(window, windowState)
+                        if (!isFullscreen) {
+                            DesktopWindowModeStorage.saveWasMaximized(placement == WindowPlacement.Maximized)
+                        }
+                        val isWindowed = placement == WindowPlacement.Floating && !isFullscreen
                         if (isWindowed && position.isSpecified) {
                             DesktopWindowModeStorage.saveWindowedGeometry(
                                 DesktopWindowGeometry(

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopWindowModeStorage.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopWindowModeStorage.kt
@@ -19,6 +19,7 @@ internal data class DesktopWindowGeometry(
 
 internal object DesktopWindowModeStorage {
     private const val WasFullscreenKey = "was_fullscreen"
+    private const val WasMaximizedKey = "was_maximized"
     private const val WindowXKey = "window_x"
     private const val WindowYKey = "window_y"
     private const val WindowWidthKey = "window_width"
@@ -30,6 +31,13 @@ internal object DesktopWindowModeStorage {
 
     fun saveWasFullscreen(fullscreen: Boolean) {
         store.putBoolean(WasFullscreenKey, fullscreen)
+    }
+
+    fun loadWasMaximized(): Boolean? =
+        store.getBoolean(WasMaximizedKey)
+
+    fun saveWasMaximized(maximized: Boolean) {
+        store.putBoolean(WasMaximizedKey, maximized)
     }
 
     fun loadWindowedGeometry(): DesktopWindowGeometry? {


### PR DESCRIPTION
## Summary

This PR fixes desktop window state restoration across restarts by persisting the maximized placement state and improving initial launch window placement logic:

- **Maximized State Persistence**: Added `was_maximized` loading/saving to `DesktopWindowModeStorage.kt` so closing the app while maximized is remembered and restored on relaunch.
- **Smart Window Placement**: Updated `Main.kt` placement evaluation:
  - Restores **Fullscreen** if closed in fullscreen mode.
  - Restores **Floating mode** at exact saved coordinates (`x, y, width, height`) if un-maximized/resized.
  - Restores **Maximized mode** if closed while maximized, or defaults to maximized on first launch (fresh install).

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

PR #194 introduced `DesktopWindowModeStorage` to persist fullscreen and floating window geometry (`x, y, width, height`), but omitted persisting the maximized window placement state (`WindowPlacement.Maximized`). 

Because `was_maximized` was not tracked, closing Nuvio Desktop while maximized caused `Main.kt` to fall through on relaunch to `WindowPlacement.Floating` (a `1280x820` floating window on the right side of the monitor), leaving behind an unhandled state-loss gap originally reported in #148.

## Desktop scope

Affects desktop windowing logic across Windows, macOS, and Linux:
- `composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt`
- `composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopWindowModeStorage.kt`

## Issue or approval

Fixes #148, Fixes #308 

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Intentionally limited to desktop window placement evaluation and window state persistence. Does not alter core UI components, themes, player controls, or common code.

## Testing

- Compiled using `./gradlew compileKotlinDesktop` (verified clean build).
- Tested via `./gradlew run` on Windows 11:
  1. Cold launch without saved state opens maximized.
  2. Un-maximizing, resizing, and repositioning window saves geometry and restores exact floating position/dimensions on next launch.
  3. Re-maximizing and closing restores maximized state on next launch.
  4. F11 borderless fullscreen exit state restoration functions smoothly.

## Screenshots / Video

Not a UI change

## Breaking changes

None

## Linked issues

Fixes #148, Fixes #308
