### PR TITLE
feat(desktop): add Skia GIF animation decoding for collection cards

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/home/components/CollectionCardRemoteImage.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/home/components/CollectionCardRemoteImage.desktop.kt
@@ -1,12 +1,73 @@
 package com.nuvio.app.features.home.components
 
+import androidx.compose.foundation.Image
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asComposeImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import com.nuvio.app.core.ui.NuvioAsyncImage as AsyncImage
 import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.get
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import org.jetbrains.skia.Bitmap
+import org.jetbrains.skia.Codec
+import org.jetbrains.skia.Data
+import org.jetbrains.skia.ImageInfo
+
+private data class SkiaGifAnimation(
+    val frames: List<ImageBitmap>,
+    val delaysMs: List<Long>,
+)
+
+private val desktopGifHttpClient by lazy { HttpClient(CIO) }
+private val desktopGifCache = mutableMapOf<String, SkiaGifAnimation?>()
+
+private suspend fun loadDesktopGifAnimation(url: String): SkiaGifAnimation? {
+    if (desktopGifCache.containsKey(url)) {
+        return desktopGifCache[url]
+    }
+    val anim = withContext(Dispatchers.IO) {
+        try {
+            val bytes = desktopGifHttpClient.get(url).body<ByteArray>()
+            val codec = Codec.makeFromData(Data.makeFromBytes(bytes))
+            val count = codec.frameCount
+            if (count <= 1) return@withContext null
+            val width = codec.width
+            val height = codec.height
+            if (width <= 0 || height <= 0) return@withContext null
+
+            val frames = mutableListOf<ImageBitmap>()
+            val delays = mutableListOf<Long>()
+
+            for (i in 0 until count) {
+                val bitmap = Bitmap().apply {
+                    allocPixels(ImageInfo.makeN32Premul(width, height))
+                }
+                codec.readPixels(bitmap, i)
+                frames.add(bitmap.asComposeImageBitmap())
+                val duration = codec.getFrameInfo(i).duration
+                delays.add(if (duration > 0) duration.toLong() else 100L)
+            }
+            SkiaGifAnimation(frames, delays)
+        } catch (_: Exception) {
+            null
+        }
+    }
+    desktopGifCache[url] = anim
+    return anim
+}
 
 @Composable
 internal actual fun CollectionCardRemoteImage(
@@ -16,6 +77,41 @@ internal actual fun CollectionCardRemoteImage(
     contentScale: ContentScale,
     animateIfPossible: Boolean,
 ) {
+    val isGifUrl = remember(imageUrl) {
+        imageUrl.contains(".gif", ignoreCase = true)
+    }
+
+    if (animateIfPossible && isGifUrl) {
+        var animation by remember(imageUrl) { mutableStateOf(desktopGifCache[imageUrl]) }
+
+        LaunchedEffect(imageUrl) {
+            if (animation == null && !desktopGifCache.containsKey(imageUrl)) {
+                animation = loadDesktopGifAnimation(imageUrl)
+            }
+        }
+
+        val currentAnimation = animation
+        if (currentAnimation != null && currentAnimation.frames.isNotEmpty()) {
+            var frameIndex by remember(imageUrl) { mutableStateOf(0) }
+
+            LaunchedEffect(imageUrl, currentAnimation) {
+                while (true) {
+                    val delayMs = currentAnimation.delaysMs.getOrElse(frameIndex) { 100L }
+                    delay(delayMs)
+                    frameIndex = (frameIndex + 1) % currentAnimation.frames.size
+                }
+            }
+
+            Image(
+                bitmap = currentAnimation.frames[frameIndex],
+                contentDescription = contentDescription,
+                modifier = modifier,
+                contentScale = contentScale,
+            )
+            return
+        }
+    }
+
     val context = LocalPlatformContext.current
     val request = remember(context, imageUrl) {
         ImageRequest.Builder(context)


### PR DESCRIPTION
## Summary

This PR adds native Skia GIF animation decoding for collection cards on Desktop, bringing desktop collection card rendering into parity with mobile behavior:

- **Desktop GIF Decoder**: Implements Skia `Codec` frame decoding in `CollectionCardRemoteImage.desktop.kt` to extract frame bitmaps and frame delays for `.gif` image sources.
- **Animated Playback Loop**: Runs a smooth coroutine animation loop respecting each frame's exact timing delay.
- **Parity with Mobile**: Ensures collection card GIFs (such as animated streaming service logos) render and animate on Desktop, matching mobile behavior while gracefully falling back to static decoding if network or decoding fails.

## PR type

- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Collection folders support configuring animated focus GIFs through the shared collection model. On mobile, these collection GIFs animate as intended. However, Desktop previously lacked a dedicated GIF frame decoder for `CollectionCardRemoteImage`, causing configured collection GIFs to render as static images or blank placeholders (#56, #231). 

This PR implements Skia GIF decoding specifically for collection cards to achieve feature parity with mobile.

## Desktop scope

Desktop shared Kotlin code (`desktopMain`):
- `composeApp/src/desktopMain/kotlin/com/nuvio/app/features/home/components/CollectionCardRemoteImage.desktop.kt`

## Issue or approval

Fixes #231, Fixes #56

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Strictly scoped to `CollectionCardRemoteImage.desktop.kt` for collection cards. Does not add third-party dependencies, refactor adjacent image components, or alter non-collection UI elements.

## Testing

- Compiled using `./gradlew compileKotlinDesktop` (verified clean build).
- Tested via `./gradlew run` on Windows 11:
  1. Verified collection cards with GIF URLs load, decode frames, and loop animations smoothly.
  2. Verified static JPG/PNG collection cards render normally.
  3. Verified invalid/unsupported URLs fall back gracefully without crashes.

## Screenshots / Video


https://github.com/user-attachments/assets/735ee347-17e7-495f-b4ac-11a6ab5d0592



## Breaking changes

None

## Linked issues

Fixes #231, Fixes #56
