### PR TITLE
fix(desktop): exit macOS fullscreen from a maximized window

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopAppFullscreen.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopAppFullscreen.kt
@@ -1,5 +1,6 @@
 package com.nuvio.app.features.player.desktop
 
+import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.window.WindowPlacement
 import androidx.compose.ui.window.WindowState
 import java.awt.GraphicsEnvironment
@@ -79,7 +80,7 @@ internal class DesktopAppFullscreenController {
         if (DesktopHostOs.current == DesktopHostOs.WINDOWS) {
             toggleWindowsFullscreen(window)
         } else {
-            toggleComposeFullscreen(windowState)
+            toggleComposeFullscreen(window, windowState)
         }
     }
 
@@ -111,15 +112,38 @@ internal class DesktopAppFullscreenController {
             windowState.placement == WindowPlacement.Fullscreen
         }
 
-    private fun toggleComposeFullscreen(windowState: WindowState) {
-        if (windowState.placement == WindowPlacement.Fullscreen) {
-            windowState.placement = restoreWindowPlacement
+    private fun toggleComposeFullscreen(window: Window, windowState: WindowState) {
+        if (isFullscreen(window, windowState)) {
+            if (DesktopHostOs.current == DesktopHostOs.MACOS) {
+                applyMacosComposeFullscreenExit(
+                    restorePlacement = restoreWindowPlacement,
+                    requestNativeFullscreenExit = { requestNativeComposeFullscreenExit(window) },
+                    clearComposeFullscreen = {
+                        (window as? ComposeWindow)?.placement = WindowPlacement.Floating
+                    },
+                    setStatePlacement = { placement ->
+                        windowState.placement = placement
+                    },
+                )
+            } else {
+                windowState.placement = restoreWindowPlacement
+            }
         } else {
             restoreWindowPlacement = windowState.placement
                 .takeUnless { it == WindowPlacement.Fullscreen }
                 ?: WindowPlacement.Floating
             windowState.placement = WindowPlacement.Fullscreen
         }
+    }
+
+    private fun requestNativeComposeFullscreenExit(window: Window): Boolean {
+        if (DesktopHostOs.current != DesktopHostOs.MACOS) return false
+        return runCatching {
+            NativePlayerBridge.setMacosWindowFullscreen(
+                windowViewPtr = AwtNativeViewResolver.resolveNativeViewPointer(window),
+                fullscreen = false,
+            )
+        }.isSuccess
     }
 
     private fun toggleWindowsFullscreen(window: Window) {
@@ -169,6 +193,28 @@ internal class DesktopAppFullscreenController {
         val window: Window,
         val windowHwnd: Long,
     )
+}
+
+/**
+ * ComposeWindow does not clear its fullscreen flag when placement is changed directly from
+ * Fullscreen to Maximized on macOS. Let AppKit complete its asynchronous fullscreen exit and let
+ * Compose's native window listener restore WindowState; writing Maximized during that transition
+ * can alter the frame AppKit is restoring. The Compose fallback is only used if the native macOS
+ * request cannot be made.
+ */
+internal fun applyMacosComposeFullscreenExit(
+    restorePlacement: WindowPlacement,
+    requestNativeFullscreenExit: () -> Boolean,
+    clearComposeFullscreen: () -> Unit,
+    setStatePlacement: (WindowPlacement) -> Unit,
+) {
+    if (requestNativeFullscreenExit()) return
+
+    val targetPlacement = restorePlacement
+        .takeUnless { it == WindowPlacement.Fullscreen }
+        ?: WindowPlacement.Floating
+    clearComposeFullscreen()
+    setStatePlacement(targetPlacement)
 }
 
 internal fun installDesktopAppFullscreenShortcuts(window: Window): () -> Unit {

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerBridge.kt
@@ -78,6 +78,7 @@ internal object NativePlayerBridge {
         width: Int,
         height: Int,
     )
+    external fun setMacosWindowFullscreen(windowViewPtr: Long, fullscreen: Boolean)
 
     external fun setSubtitleDelayMs(handle: Long, delayMs: Int)
     external fun applySubtitleStyle(

--- a/composeApp/src/desktopMain/native/macos/player_bridge.mm
+++ b/composeApp/src/desktopMain/native/macos/player_bridge.mm
@@ -2425,6 +2425,26 @@ static NSArray<NSString *> *jstringArrayToNSArray(JNIEnv *env, jobjectArray valu
     return result;
 }
 
+extern "C" JNIEXPORT void JNICALL
+Java_com_nuvio_app_features_player_desktop_NativePlayerBridge_setMacosWindowFullscreen(
+    JNIEnv * /* env */,
+    jobject /* bridge */,
+    jlong windowViewPtr,
+    jboolean fullscreen
+) {
+    NSView *windowView = (__bridge NSView *)(void *)(intptr_t)windowViewPtr;
+    if (!windowView) return;
+    BOOL requestedFullscreen = fullscreen == JNI_TRUE;
+    runOnMainAsync(^{
+        NSWindow *window = windowView.window;
+        if (!window) return;
+        BOOL isFullscreen = (window.styleMask & NSWindowStyleMaskFullScreen) != 0;
+        if (isFullscreen != requestedFullscreen) {
+            [window toggleFullScreen:nil];
+        }
+    });
+}
+
 extern "C" JNIEXPORT jlong JNICALL
 Java_com_nuvio_app_features_player_desktop_NativePlayerBridge_create(
     JNIEnv *env,

--- a/composeApp/src/desktopTest/kotlin/com/nuvio/app/features/player/desktop/DesktopAppFullscreenTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/nuvio/app/features/player/desktop/DesktopAppFullscreenTest.kt
@@ -1,0 +1,64 @@
+package com.nuvio.app.features.player.desktop
+
+import androidx.compose.ui.window.WindowPlacement
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DesktopAppFullscreenTest {
+    @Test
+    fun `native fullscreen exit lets the window listener restore placement`() {
+        val updates = mutableListOf<String>()
+
+        applyMacosComposeFullscreenExit(
+            restorePlacement = WindowPlacement.Maximized,
+            requestNativeFullscreenExit = {
+                updates += "native"
+                true
+            },
+            clearComposeFullscreen = { updates += "compose" },
+            setStatePlacement = { updates += "state:$it" },
+        )
+
+        assertEquals(listOf("native"), updates)
+    }
+
+    @Test
+    fun `compose fallback clears fullscreen before restoring maximized placement`() {
+        val updates = mutableListOf<Pair<String, WindowPlacement>>()
+
+        applyMacosComposeFullscreenExit(
+            restorePlacement = WindowPlacement.Maximized,
+            requestNativeFullscreenExit = { false },
+            clearComposeFullscreen = { updates += "compose" to WindowPlacement.Floating },
+            setStatePlacement = { updates += "state" to it },
+        )
+
+        assertEquals(
+            listOf(
+                "compose" to WindowPlacement.Floating,
+                "state" to WindowPlacement.Maximized,
+            ),
+            updates,
+        )
+    }
+
+    @Test
+    fun `fullscreen cannot be restored as its own exit placement`() {
+        val updates = mutableListOf<Pair<String, WindowPlacement>>()
+
+        applyMacosComposeFullscreenExit(
+            restorePlacement = WindowPlacement.Fullscreen,
+            requestNativeFullscreenExit = { false },
+            clearComposeFullscreen = { updates += "compose" to WindowPlacement.Floating },
+            setStatePlacement = { updates += "state" to it },
+        )
+
+        assertEquals(
+            listOf(
+                "compose" to WindowPlacement.Floating,
+                "state" to WindowPlacement.Floating,
+            ),
+            updates,
+        )
+    }
+}


### PR DESCRIPTION

## Summary

Fix the app-wide fullscreen toggle on macOS when fullscreen was entered from a maximized window.

- Exit native macOS fullscreen through AppKit instead of requesting a direct Compose `Fullscreen` to `Maximized` placement transition.
- Let Compose observe AppKit's asynchronous fullscreen-exit completion before updating `WindowState`, preserving the maximized frame that macOS restores.
- Retain a Compose fallback if the native macOS request cannot be made.
- Add regression coverage for the native-exit and fallback ordering.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

When the macOS window is maximized before entering fullscreen, the in-app fullscreen toggle changes its icon on exit but the native window remains fullscreen. Compose's direct `Fullscreen` to `Maximized` placement transition does not reliably clear the native macOS fullscreen state.

Requesting the exit through `NSWindow.toggleFullScreen` clears the native state correctly. Waiting for AppKit and Compose's native window listener to restore placement also avoids racing the fullscreen-exit animation, which previously left a gap along the right edge of the restored maximized window.

## Desktop scope

macOS desktop only.

The Kotlin entry point is in `desktopMain`, but the native request is guarded by `DesktopHostOs.MACOS` and implemented only in the macOS Objective-C++ bridge. Windows retains its existing Win32 borderless-fullscreen implementation. Linux retains its previous Compose fullscreen path. Android and iOS are unaffected.

## Issue or approval

Fixes #130

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

This PR only changes macOS fullscreen exit handling. It does not add or change Escape behavior, keyboard shortcuts, fullscreen entry behavior, player navigation, window-state persistence, Windows/Linux fullscreen behavior, mobile behavior, styling, dependencies, or unrelated window management.

## Testing

- Ran `./gradlew :composeApp:desktopTest :composeApp:packageDmg -Pcompose.desktop.packaging.checkJdkVendor=false --no-configuration-cache` successfully on macOS arm64.
- Verified the packaged DMG with `hdiutil verify`.
- Confirmed the new JNI symbol is present in the packaged macOS native bridge.
- Manually tested from Home/Main: maximize the window, enter fullscreen with the in-app toggle, exit with the same toggle, and confirm the app returns to the full maximized width without a right-edge gap.
- Manually confirmed the existing fullscreen toggle still works when starting from a normal floating window.

## Screenshots / Video

Before: reproduction details and screenshot are available in #130.

After: 

https://github.com/user-attachments/assets/8cf36581-3f52-4965-a1ec-bc9d80922b70

## Breaking changes

None.

## Linked issues

Fixes #130
