### PR TITLE
fix(desktop): restore window frame state and repaint to fix white border artifact when exiting borderless fullscreen

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopAppFullscreen.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopAppFullscreen.kt
@@ -3,6 +3,7 @@ package com.nuvio.app.features.player.desktop
 import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.window.WindowPlacement
 import androidx.compose.ui.window.WindowState
+import java.awt.Frame
 import java.awt.GraphicsEnvironment
 import java.awt.KeyEventDispatcher
 import java.awt.KeyboardFocusManager
@@ -78,7 +79,7 @@ internal class DesktopAppFullscreenController {
 
     fun toggle(window: Window, windowState: WindowState) {
         if (DesktopHostOs.current == DesktopHostOs.WINDOWS) {
-            toggleWindowsFullscreen(window)
+            toggleWindowsFullscreen(window, windowState)
         } else {
             toggleComposeFullscreen(window, windowState)
         }
@@ -96,7 +97,7 @@ internal class DesktopAppFullscreenController {
     fun applyRestoredFullscreenState(window: Window, windowState: WindowState, fullscreen: Boolean) {
         if (!fullscreen) return
         if (DesktopHostOs.current == DesktopHostOs.WINDOWS) {
-            enterWindowsFullscreen(window)
+            enterWindowsFullscreen(window, windowState)
         } else {
             restoreWindowPlacement = windowState.placement
                 .takeUnless { it == WindowPlacement.Fullscreen }
@@ -146,21 +147,24 @@ internal class DesktopAppFullscreenController {
         }.isSuccess
     }
 
-    private fun toggleWindowsFullscreen(window: Window) {
+    private fun toggleWindowsFullscreen(window: Window, windowState: WindowState) {
         if (windowsFullscreenState?.window === window) {
-            exitWindowsFullscreen(window)
+            exitWindowsFullscreen(window, windowState)
         } else {
-            enterWindowsFullscreen(window)
+            enterWindowsFullscreen(window, windowState)
         }
     }
 
-    private fun enterWindowsFullscreen(window: Window) {
+    private fun enterWindowsFullscreen(window: Window, windowState: WindowState) {
         val gc = window.graphicsConfiguration
             ?: GraphicsEnvironment.getLocalGraphicsEnvironment().defaultScreenDevice.defaultConfiguration
         val screenBounds = gc.bounds
         val transform = gc.defaultTransform
         val scaleX = transform.scaleX
         val scaleY = transform.scaleY
+
+        val wasMaximized = (window as? Frame)?.extendedState == Frame.MAXIMIZED_BOTH ||
+            windowState.placement == WindowPlacement.Maximized
 
         val hwnd = AwtNativeViewResolver.resolveNativeViewPointer(window)
         NativePlayerBridge.setWindowBorderlessFullscreen(
@@ -171,12 +175,16 @@ internal class DesktopAppFullscreenController {
             width = (screenBounds.width * scaleX).toInt(),
             height = (screenBounds.height * scaleY).toInt(),
         )
-        windowsFullscreenState = WindowsFullscreenState(window = window, windowHwnd = hwnd)
+        windowsFullscreenState = WindowsFullscreenState(
+            window = window,
+            windowHwnd = hwnd,
+            wasMaximized = wasMaximized,
+        )
         window.toFront()
         window.requestFocus()
     }
 
-    private fun exitWindowsFullscreen(window: Window) {
+    private fun exitWindowsFullscreen(window: Window, windowState: WindowState? = null) {
         val fullscreenState = windowsFullscreenState?.takeIf { it.window === window } ?: return
         NativePlayerBridge.setWindowBorderlessFullscreen(
             windowHwnd = fullscreenState.windowHwnd,
@@ -186,12 +194,27 @@ internal class DesktopAppFullscreenController {
             width = 0,
             height = 0,
         )
+        val wasMaximized = fullscreenState.wasMaximized
         windowsFullscreenState = null
+
+        if (window is Frame) {
+            if (wasMaximized) {
+                window.extendedState = Frame.NORMAL
+                window.extendedState = Frame.MAXIMIZED_BOTH
+                windowState?.placement = WindowPlacement.Maximized
+            } else {
+                window.extendedState = Frame.NORMAL
+                windowState?.placement = WindowPlacement.Floating
+            }
+            window.revalidate()
+            window.repaint()
+        }
     }
 
     private data class WindowsFullscreenState(
         val window: Window,
         val windowHwnd: Long,
+        val wasMaximized: Boolean,
     )
 }
 


### PR DESCRIPTION
## Summary

Fixes a 1px white border rendering artifact around the window when exiting borderless video player fullscreen on Windows, ensuring the frame state is properly restored and repainted.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

When entering Win32 borderless fullscreen, the window borders are stripped and resized to cover the monitor. Upon exiting fullscreen back to maximized or floating mode:
1. Java AWT's internal `extendedState` can retain `MAXIMIZED_BOTH` without dispatching the required `WM_NCCALCSIZE`/`WM_SIZE` messages to Windows DWM, leaving an unpainted 1px white border artifact around the frame.
2. The pre-fullscreen maximized state was not captured, and Compose's `WindowState.placement` was not updated on exit.

Cycling `extendedState` (`Frame.NORMAL` → `Frame.MAXIMIZED_BOTH` or `Frame.NORMAL`), updating `windowState.placement`, and invoking `window.revalidate()` + `window.repaint()` forces Windows DWM to recalculate non-client margins and repaint the window cleanly.

## Desktop scope

Windows desktop application (`composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopAppFullscreen.kt`).

## Issue or approval

Fixes #328

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Intentionally limited strictly to Win32 borderless fullscreen state exit handling in `DesktopAppFullscreenController`. Does not modify player controls, native C++ bridges, or non-Windows windowing logic.

## Testing

- Verified clean compilation with `./gradlew compileKotlinDesktop` (BUILD SUCCESSFUL).
- Executed local desktop build on Windows 11 via `./gradlew run`.
- Tested entering and exiting player fullscreen from both maximized window state and standard floating windowed state:
  - Exiting from a maximized window cleanly restores maximized state without the 1px white border artifact.
  - Exiting from a floating window cleanly restores floating bounds.
- Tested fullscreen toggling via `F11` keyboard shortcut and player UI buttons to ensure real-time icon and state synchronization (`notifyChanged()`).

## Screenshots / Video

### Before Fix (White Border Artifact)
> Watch in fullscreen to see the 1px white border along the bottom/edges upon exit

https://github.com/user-attachments/assets/efb54826-2877-487d-aac5-fb1dd51a1f2d

---

### After Fix (Clean Frame Repaint)

https://github.com/user-attachments/assets/d28cb1b8-e3d0-49b5-86cb-45562004fcb5

Demonstration showing entering/exiting player fullscreen from a maximized window on Windows and verifying the white border artifact is completely resolved.

## Breaking changes

None.

## Linked issues

Fixes #328
