### PR TITLE
fix(player): remember the player volume between streams

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopPlayerVolumeStorage.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopPlayerVolumeStorage.kt
@@ -1,0 +1,15 @@
+package com.nuvio.app.features.player.desktop
+
+import com.nuvio.app.core.storage.DesktopStorage
+
+internal object DesktopPlayerVolumeStorage {
+    private const val VolumeLevelKey = "volume_level"
+    private val store = DesktopStorage.store("nuvio_player_runtime")
+
+    fun loadVolumeLevel(): Float? =
+        store.getFloat(VolumeLevelKey)?.coerceIn(0f, 1f)
+
+    fun saveVolumeLevel(level: Float) {
+        store.putFloat(VolumeLevelKey, level.coerceIn(0f, 1f))
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopPlayerVolumeStorage.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopPlayerVolumeStorage.kt
@@ -1,15 +1,30 @@
 package com.nuvio.app.features.player.desktop
 
 import com.nuvio.app.core.storage.DesktopStorage
+import javax.swing.Timer
 
 internal object DesktopPlayerVolumeStorage {
     private const val VolumeLevelKey = "volume_level"
+    private const val PersistDelayMs = 250
+
     private val store = DesktopStorage.store("nuvio_player_runtime")
+
+    private var pendingVolumeLevel: Float? = null
+
+    private val persistTimer = Timer(PersistDelayMs) {
+        pendingVolumeLevel?.let { level ->
+            store.putFloat(VolumeLevelKey, level)
+            pendingVolumeLevel = null
+        }
+    }.apply {
+        isRepeats = false
+    }
 
     fun loadVolumeLevel(): Float? =
         store.getFloat(VolumeLevelKey)?.coerceIn(0f, 1f)
 
     fun saveVolumeLevel(level: Float) {
-        store.putFloat(VolumeLevelKey, level.coerceIn(0f, 1f))
+        pendingVolumeLevel = level.coerceIn(0f, 1f)
+        persistTimer.restart()
     }
 }

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
@@ -42,7 +42,7 @@ internal class NativePlayerController(
         const val TEARDOWN_WAIT_MS = 5_000L
 
         @Volatile
-        var rememberedVolumeLevel: Float = 1f
+        var rememberedVolumeLevel: Float = DesktopPlayerVolumeStorage.loadVolumeLevel() ?: 1f
     }
 
     @Volatile
@@ -350,6 +350,7 @@ internal class NativePlayerController(
         if (current != 0L) {
             val nextLevel = level.coerceIn(0f, 1f)
             rememberedVolumeLevel = nextLevel
+            DesktopPlayerVolumeStorage.saveVolumeLevel(nextLevel)
             NativePlayerBridge.setVolume(current, nextLevel)
             controlsState = controlsState.copy(volumeLevel = nextLevel)
             updateControls(controlsState)


### PR DESCRIPTION
## Summary

The desktop player now remembers its volume between streams and across app restarts instead of returning to 100% every time.

This is a current Dev resubmission of #278.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Desktop already keeps the selected volume while a player instance exists, but that value only lives in memory. Tearing the player down or closing Nuvio loses it, so the next stream starts at full volume.

This stores the same clamped volume value through the existing desktop storage helper and restores it when the native player controller starts.

## Desktop scope

Desktop shared behavior on Windows and macOS. The preference uses the existing machine-local desktop storage.

## Issue or approval

Fixes #331.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Two files. No new setting, no player UI change, and no change to mute or in-session volume behavior.

## Testing

Windows 11 on current Dev:

- `:composeApp:compileKotlinDesktop`
- `:composeApp:desktopTest`
- `git diff --check`

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #331.