### PR TITLE
feat(player): add playback speed selector modal, top-right OSD, and dynamic speedometer icon

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerControls.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerControls.kt
@@ -1,8 +1,19 @@
 package com.nuvio.app.features.player
 
+import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import com.nuvio.app.core.ui.nuvio
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -548,9 +559,19 @@ private fun ProgressControls(
                         painter = aspectRatioPainter,
                         onClick = onResizeModeClick,
                     )
+                    val isSpeedActive = kotlin.math.abs(playbackSnapshot.playbackSpeed - 1.0f) > 0.05f
+                    val speedActiveColor = if (isSpeedActive) MaterialTheme.nuvio.colors.accent else Color.White
+
                     PlayerActionPillButton(
                         label = formatPlaybackSpeedLabel(playbackSnapshot.playbackSpeed),
-                        icon = Icons.Rounded.Speed,
+                        customIcon = {
+                            SpeedometerGaugeIcon(
+                                speed = playbackSnapshot.playbackSpeed,
+                                modifier = Modifier.size(18.dp),
+                                tint = speedActiveColor,
+                            )
+                        },
+                        labelColor = speedActiveColor,
                         onClick = onSpeedClick,
                     )
                     PlayerActionPillButton(
@@ -707,11 +728,114 @@ private fun TimePill(
 }
 
 @Composable
+private fun SpeedometerGaugeIcon(
+    speed: Float,
+    modifier: Modifier = Modifier,
+    tint: Color = Color.White,
+) {
+    val rotationDeg = when {
+        speed <= 0.25f -> -80f
+        speed <= 0.50f -> -55f
+        speed <= 0.75f -> -28f
+        speed <= 1.00f -> 0f
+        speed <= 1.25f -> 28f
+        speed <= 1.50f -> 55f
+        speed <= 1.75f -> 72f
+        else -> 85f
+    }
+    val animatedRotation by animateFloatAsState(
+        targetValue = rotationDeg,
+        animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+    )
+
+    Canvas(modifier = modifier) {
+        val strokeWidth = 1.5.dp.toPx()
+        val padding = strokeWidth / 2f + 1.25.dp.toPx()
+
+        val w = size.width - padding * 2
+        val h = size.height - padding * 2
+
+        val baselineY = padding + h * 0.88f
+        val center = Offset(size.width / 2f, baselineY)
+
+        val radius = minOf(w, h) / 2f
+        val arcTopLeft = Offset(center.x - radius, center.y - radius)
+        val arcSize = Size(radius * 2, radius * 2)
+
+        val startArcAngle = 160f
+        val totalSweepAngle = 220f
+        val endArcAngle = startArcAngle + totalSweepAngle
+        val needleAngle = 270f + animatedRotation
+        val gapHalfDeg = 14f
+
+        val seg1Sweep = (needleAngle - gapHalfDeg) - startArcAngle
+        if (seg1Sweep > 0f) {
+            drawArc(
+                color = tint,
+                startAngle = startArcAngle,
+                sweepAngle = minOf(seg1Sweep, totalSweepAngle),
+                useCenter = false,
+                topLeft = arcTopLeft,
+                size = arcSize,
+                style = Stroke(width = strokeWidth, cap = StrokeCap.Round),
+            )
+        }
+
+        val seg2Start = needleAngle + gapHalfDeg
+        val seg2Sweep = endArcAngle - seg2Start
+        if (seg2Sweep > 0f) {
+            drawArc(
+                color = tint,
+                startAngle = seg2Start,
+                sweepAngle = seg2Sweep,
+                useCenter = false,
+                topLeft = arcTopLeft,
+                size = arcSize,
+                style = Stroke(width = strokeWidth, cap = StrokeCap.Round),
+            )
+        }
+
+        val leftX = center.x + radius * cos(startArcAngle * (PI.toFloat() / 180f))
+        val rightX = center.x + radius * cos(endArcAngle * (PI.toFloat() / 180f))
+        drawLine(
+            color = tint,
+            start = Offset(leftX, baselineY),
+            end = Offset(rightX, baselineY),
+            strokeWidth = strokeWidth,
+            cap = StrokeCap.Round,
+        )
+
+        drawCircle(
+            color = tint,
+            radius = strokeWidth * 1.1f,
+            center = center,
+        )
+
+        val rad = needleAngle * (PI.toFloat() / 180f)
+        val needleLength = radius * 1.14f
+        val needleEnd = Offset(
+            x = center.x + needleLength * cos(rad),
+            y = center.y + needleLength * sin(rad),
+        )
+
+        drawLine(
+            color = tint,
+            start = center,
+            end = needleEnd,
+            strokeWidth = strokeWidth,
+            cap = StrokeCap.Round,
+        )
+    }
+}
+
+@Composable
 private fun PlayerActionPillButton(
     label: String,
     onClick: () -> Unit,
     icon: ImageVector? = null,
     painter: Painter? = null,
+    customIcon: (@Composable () -> Unit)? = null,
+    labelColor: Color = Color.White,
 ) {
     Row(
         modifier = Modifier
@@ -722,24 +846,26 @@ private fun PlayerActionPillButton(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         when {
+            customIcon != null -> customIcon()
+
             painter != null -> Icon(
                 painter = painter,
                 contentDescription = label,
-                tint = Color.White,
+                tint = labelColor,
                 modifier = Modifier.size(18.dp),
             )
 
             icon != null -> Icon(
                 imageVector = icon,
                 contentDescription = label,
-                tint = Color.White,
+                tint = labelColor,
                 modifier = Modifier.size(18.dp),
             )
         }
         Text(
             text = label,
             style = MaterialTheme.nuvioTypeScale.labelSm,
-            color = Color.White,
+            color = labelColor,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             softWrap = false,

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
@@ -287,6 +287,10 @@ internal class NativePlayerController(
                 onDesktopFullscreenChanged()
             }
             "volumeChange" -> setFallbackVolume(value.toFloat())
+            "setPlaybackSpeed" -> {
+                log.d { "handleControlEvent setPlaybackSpeed speed=${value.toFloat()} handle=$handle" }
+                setPlaybackSpeed(value.toFloat())
+            }
             else -> {
                 val eventHandled = onEvent(type, value)
                 if (type.shouldLogNativeControlEvent()) {

--- a/composeApp/src/desktopMain/resources/player-ui/controls.css
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.css
@@ -1467,6 +1467,30 @@ button:disabled {
   overflow: hidden;
 }
 
+/* VLC Style Text OSD Overlay */
+.vlc-osd {
+  position: absolute;
+  top: 88px;
+  right: 48px;
+  z-index: 100;
+  color: #ffffff;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.95), 0 0 4px rgba(0, 0, 0, 0.95);
+  opacity: 0;
+  transform: translateY(-4px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  pointer-events: none;
+  user-select: none;
+}
+
+.vlc-osd.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
 .action {
   min-width: 0;
   display: flex;

--- a/composeApp/src/desktopMain/resources/player-ui/controls.css
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.css
@@ -1508,6 +1508,31 @@ button:disabled {
   flex: 0 0 auto;
 }
 
+.speed-icon-svg {
+  width: 24px !important;
+  height: 24px !important;
+  overflow: visible;
+}
+
+.speed-icon-svg #speedNeedle {
+  color: var(--theme-control-foreground);
+  transition: transform 0.25s ease, color 0.25s ease;
+}
+
+.speed-icon-svg.redline #speedNeedle {
+  color: #ff355e;
+}
+
+.speed-icon-svg .speed-gauge-frame {
+  stroke: var(--theme-control-foreground);
+  transition: stroke 0.2s ease;
+}
+
+.speed-icon-svg.redline .speed-gauge-frame {
+  stroke: url(#speedRedlineGradient);
+  filter: drop-shadow(0 0 5px rgba(255, 53, 94, 0.7));
+}
+
 .action span {
   min-width: 0;
   overflow: hidden;

--- a/composeApp/src/desktopMain/resources/player-ui/controls.css
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.css
@@ -3079,3 +3079,12 @@ svg {
   fill: currentColor;
   stroke: none;
 }
+
+.speed-icon-svg {
+  width: 20px;
+  height: 20px;
+  display: block;
+  flex-shrink: 0;
+  margin: 0;
+  padding: 0;
+}

--- a/composeApp/src/desktopMain/resources/player-ui/controls.html
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.html
@@ -201,7 +201,26 @@
               <svg><use id="toggleIcon" href="#icon-play"></use></svg><span id="toggleLabel">Play</span>
             </button>
             <button class="action" data-command="resize"><svg><use href="#icon-aspect"></use></svg><span id="resizeLabel">Fit</span></button>
-            <button class="action" data-command="speed"><svg><use href="#icon-speed"></use></svg><span id="speedLabel">1x</span></button>
+            <button class="action" data-command="speed" aria-label="Playback Speed">
+              <svg class="speed-icon-svg" id="speedIconSvg" viewBox="0 0 24 24">
+                <defs>
+                  <linearGradient id="speedRedlineGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+                    <stop offset="0%" stop-color="#00e5ff" />
+                    <stop offset="25%" stop-color="#39ff14" />
+                    <stop offset="50%" stop-color="#ffea00" />
+                    <stop offset="75%" stop-color="#ff7300" />
+                    <stop offset="100%" stop-color="#ff355e" />
+                  </linearGradient>
+                </defs>
+                <path class="speed-gauge-frame" fill="none" stroke="#ffffff" stroke-width="2.25" stroke-linecap="round"
+                  d="M 5.5 17.5 A 8.5 8.5 0 1 1 18.5 17.5" />
+                <g id="speedNeedle" style="transform-origin: 12px 12px; transition: transform 0.25s ease;">
+                  <path fill="currentColor" d="M 10.5 12.0 L 11.4 6.2 C 11.7 5.6 12.3 5.6 12.6 6.2 L 13.5 12.0 Z" />
+                  <circle cx="12" cy="12.0" r="2.4" fill="currentColor" />
+                </g>
+              </svg>
+              <span id="speedLabel">1x</span>
+            </button>
             <button class="action" data-command="subtitles"><svg><use href="#icon-subs"></use></svg><span id="subtitlesLabel">Subs</span></button>
             <button class="action" data-command="audio"><svg><use href="#icon-audio"></use></svg><span id="audioLabel">Audio</span></button>
             <button class="action optional" id="sourcesButton" data-command="sources"><svg><use href="#icon-swap"></use></svg><span id="sourcesLabel">Sources</span></button>

--- a/composeApp/src/desktopMain/resources/player-ui/controls.html
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.html
@@ -85,6 +85,7 @@
   </svg>
 
   <div class="player" id="playerRoot" tabindex="-1">
+    <div id="vlcOsd" class="vlc-osd" aria-live="polite"></div>
     <div class="top-gradient"></div>
     <div class="bottom-gradient"></div>
     <section class="opening-overlay" id="openingOverlay" aria-label="Opening player" aria-hidden="true">

--- a/composeApp/src/desktopMain/resources/player-ui/controls.html
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.html
@@ -204,19 +204,22 @@
             <button class="action" data-command="speed" aria-label="Playback Speed">
               <svg class="speed-icon-svg" id="speedIconSvg" viewBox="0 0 24 24">
                 <defs>
-                  <linearGradient id="speedRedlineGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-                    <stop offset="0%" stop-color="#00e5ff" />
-                    <stop offset="25%" stop-color="#39ff14" />
-                    <stop offset="50%" stop-color="#ffea00" />
-                    <stop offset="75%" stop-color="#ff7300" />
-                    <stop offset="100%" stop-color="#ff355e" />
-                  </linearGradient>
+                  <mask id="speedGaugeMask">
+                    <rect x="0" y="0" width="24" height="24" fill="#ffffff" />
+                    <g id="speedMaskNeedle" style="transform-origin: 12px 13.5px; transition: transform 0.25s ease;">
+                      <rect x="9.3" y="1.5" width="5.4" height="7.5" fill="#000000" rx="1.0" />
+                    </g>
+                  </mask>
                 </defs>
-                <path class="speed-gauge-frame" fill="none" stroke="#ffffff" stroke-width="2.25" stroke-linecap="round"
-                  d="M 5.5 17.5 A 8.5 8.5 0 1 1 18.5 17.5" />
-                <g id="speedNeedle" style="transform-origin: 12px 12px; transition: transform 0.25s ease;">
-                  <path fill="currentColor" d="M 10.5 12.0 L 11.4 6.2 C 11.7 5.6 12.3 5.6 12.6 6.2 L 13.5 12.0 Z" />
-                  <circle cx="12" cy="12.0" r="2.4" fill="currentColor" />
+                <g mask="url(#speedGaugeMask)">
+                  <path class="speed-gauge-base" fill="none" stroke="#ffffff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"
+                    d="M 4.0 13.5 C 4.0 16.8 6.0 18.8 8.8 18.8 L 15.2 18.8 C 18.0 18.8 20.0 16.8 20.0 13.5" />
+                  <path class="speed-gauge-arch" fill="none" stroke="#ffffff" stroke-width="2.2" stroke-linecap="round"
+                    d="M 4.0 13.5 A 8.0 8.0 0 0 1 20.0 13.5" />
+                </g>
+                <g id="speedNeedle" style="transform-origin: 12px 13.5px; transition: transform 0.25s ease;">
+                  <path fill="currentColor" d="M 10.9 13.5 L 11.5 4.8 C 11.8 4.2 12.2 4.2 12.5 4.8 L 13.1 13.5 Z" />
+                  <circle cx="12" cy="13.5" r="2.0" fill="currentColor" />
                 </g>
               </svg>
               <span id="speedLabel">1x</span>

--- a/composeApp/src/desktopMain/resources/player-ui/controls.html
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.html
@@ -218,6 +218,12 @@
       <section class="player-toast" id="playerToast" aria-live="polite" aria-atomic="true" aria-hidden="true">
         <span class="player-toast-text" id="playerToastText"></span>
       </section>
+      <section class="modal-layer player-rail-modal" id="speedModal" aria-label="Playback Speed" hidden>
+        <div class="track-panel audio-rail-panel">
+          <div class="track-header" id="speedPanelTitle">Playback Speed</div>
+          <div class="track-list" id="speedOptionList"></div>
+        </div>
+      </section>
       <section class="modal-layer player-rail-modal" id="audioModal" aria-label="Audio tracks" hidden>
         <div class="track-panel audio-rail-panel">
           <div class="track-header" id="audioPanelTitle">Audio tracks</div>

--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -69,6 +69,9 @@ const sourcesButton = document.getElementById("sourcesButton");
 const episodesButton = document.getElementById("episodesButton");
 const audioModal = document.getElementById("audioModal");
 const subtitleModal = document.getElementById("subtitleModal");
+const speedModal = document.getElementById("speedModal");
+const speedOptionList = document.getElementById("speedOptionList");
+const speedPanelTitle = document.getElementById("speedPanelTitle");
 const audioPanelTitle = document.getElementById("audioPanelTitle");
 const audioTrackList = document.getElementById("audioTrackList");
 const subtitleTrackList = document.getElementById("subtitleTrackList");
@@ -822,6 +825,7 @@ const rangePositionMs = () => {
 const modalByName = {
   audio: audioModal,
   subtitles: subtitleModal,
+  speed: speedModal,
   sources: sourceModal,
   episodes: episodesModal,
   submitIntro: submitIntroModal,
@@ -926,6 +930,46 @@ const appendEmptyTrackState = (container, label) => {
   empty.className = "track-empty";
   empty.textContent = label;
   container.appendChild(empty);
+};
+
+const speedOptions = [
+  { value: 0.25, label: "0.25x" },
+  { value: 0.5, label: "0.5x" },
+  { value: 0.75, label: "0.75x" },
+  { value: 1.0, label: "1x (Normal)" },
+  { value: 1.25, label: "1.25x" },
+  { value: 1.5, label: "1.5x" },
+  { value: 1.75, label: "1.75x" },
+  { value: 2.0, label: "2x" },
+];
+
+const renderSpeedOptionList = () => {
+  if (!speedOptionList) return;
+  speedOptionList.textContent = "";
+  if (speedPanelTitle) {
+    speedPanelTitle.textContent = state.speedPanelTitle || "Playback Speed";
+  }
+
+  const currentSpeedStr = String(state.playbackSpeedLabel || "1x");
+  const currentSpeedNum = parseFloat(currentSpeedStr.replace("x", "")) || 1.0;
+
+  speedOptions.forEach(opt => {
+    const isSelected = Math.abs(currentSpeedNum - opt.value) < 0.05;
+    const row = document.createElement("button");
+    row.type = "button";
+    row.className = `track-row${isSelected ? " selected" : ""}`;
+    row.addEventListener("click", event => {
+      event.stopPropagation();
+      send("setPlaybackSpeed", opt.value);
+      window.setTimeout(closePlayerModal, 120);
+    });
+    const labelElement = document.createElement("span");
+    labelElement.className = "track-label";
+    labelElement.textContent = opt.label;
+    row.appendChild(labelElement);
+    row.appendChild(buildCheckIcon());
+    speedOptionList.appendChild(row);
+  });
 };
 
 const renderAudioTrackList = () => {
@@ -1670,6 +1714,7 @@ const renderP2pConsentModal = () => {
 const renderActiveModal = () => {
   if (activeModal === "audio") renderAudioTrackList();
   if (activeModal === "subtitles") renderSubtitleModal();
+  if (activeModal === "speed") renderSpeedOptionList();
   if (activeModal === "sources") renderSourceModal();
   if (activeModal === "episodes") renderEpisodesModal();
   if (activeModal === "submitIntro") renderSubmitIntroModal();
@@ -2292,6 +2337,10 @@ document.querySelectorAll("[data-command]").forEach(button => {
     }
     if (command === "subtitles") {
       openPlayerModal("subtitles");
+      return;
+    }
+    if (command === "speed") {
+      openPlayerModal("speed");
       return;
     }
     if (command === "sources") {

--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -33,6 +33,7 @@ const resizeLabel = document.getElementById("resizeLabel");
 const speedLabel = document.getElementById("speedLabel");
 const speedIconSvg = document.getElementById("speedIconSvg");
 const speedNeedle = document.getElementById("speedNeedle");
+const speedMaskNeedle = document.getElementById("speedMaskNeedle");
 const subtitlesLabel = document.getElementById("subtitlesLabel");
 const audioLabel = document.getElementById("audioLabel");
 const sourcesLabel = document.getElementById("sourcesLabel");
@@ -2066,24 +2067,20 @@ const renderChrome = () => {
   setText(streamTitle, state.streamTitle);
   setText(providerName, state.providerName);
   resizeLabel.textContent = state.resizeModeLabel || "Fit";
-  speedLabel.textContent = state.playbackSpeedLabel || "1x";
   const speedVal = parseFloat(String(state.playbackSpeedLabel || "1x").replace("x", "")) || 1.0;
-  const is2xRedline = Math.abs(speedVal - 2.0) < 0.05;
-  if (speedIconSvg) {
-    speedIconSvg.classList.toggle("redline", is2xRedline);
-  }
   if (speedNeedle) {
     let rotationDeg = 0;
-    if (speedVal <= 0.25) rotationDeg = -105;
-    else if (speedVal <= 0.5) rotationDeg = -70;
-    else if (speedVal <= 0.75) rotationDeg = -35;
+    if (speedVal <= 0.25) rotationDeg = -102;
+    else if (speedVal <= 0.5) rotationDeg = -68;
+    else if (speedVal <= 0.75) rotationDeg = -34;
     else if (speedVal <= 1.0) rotationDeg = 0;
-    else if (speedVal <= 1.25) rotationDeg = 35;
-    else if (speedVal <= 1.5) rotationDeg = 70;
-    else if (speedVal <= 1.75) rotationDeg = 90;
-    else rotationDeg = 105;
+    else if (speedVal <= 1.25) rotationDeg = 34;
+    else if (speedVal <= 1.5) rotationDeg = 68;
+    else if (speedVal <= 1.75) rotationDeg = 85;
+    else rotationDeg = 102;
 
-    speedNeedle.style.transform = `rotate(${rotationDeg}deg)`;
+    if (speedNeedle) speedNeedle.style.transform = `rotate(${rotationDeg}deg)`;
+    if (speedMaskNeedle) speedMaskNeedle.style.transform = `rotate(${rotationDeg}deg)`;
   }
   subtitlesLabel.textContent = state.subtitlesLabel || "Subs";
   audioLabel.textContent = state.audioLabel || "Audio";

--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -31,6 +31,8 @@ const streamTitle = document.getElementById("streamTitle");
 const providerName = document.getElementById("providerName");
 const resizeLabel = document.getElementById("resizeLabel");
 const speedLabel = document.getElementById("speedLabel");
+const speedIconSvg = document.getElementById("speedIconSvg");
+const speedNeedle = document.getElementById("speedNeedle");
 const subtitlesLabel = document.getElementById("subtitlesLabel");
 const audioLabel = document.getElementById("audioLabel");
 const sourcesLabel = document.getElementById("sourcesLabel");
@@ -2065,6 +2067,24 @@ const renderChrome = () => {
   setText(providerName, state.providerName);
   resizeLabel.textContent = state.resizeModeLabel || "Fit";
   speedLabel.textContent = state.playbackSpeedLabel || "1x";
+  const speedVal = parseFloat(String(state.playbackSpeedLabel || "1x").replace("x", "")) || 1.0;
+  const is2xRedline = Math.abs(speedVal - 2.0) < 0.05;
+  if (speedIconSvg) {
+    speedIconSvg.classList.toggle("redline", is2xRedline);
+  }
+  if (speedNeedle) {
+    let rotationDeg = 0;
+    if (speedVal <= 0.25) rotationDeg = -105;
+    else if (speedVal <= 0.5) rotationDeg = -70;
+    else if (speedVal <= 0.75) rotationDeg = -35;
+    else if (speedVal <= 1.0) rotationDeg = 0;
+    else if (speedVal <= 1.25) rotationDeg = 35;
+    else if (speedVal <= 1.5) rotationDeg = 70;
+    else if (speedVal <= 1.75) rotationDeg = 90;
+    else rotationDeg = 105;
+
+    speedNeedle.style.transform = `rotate(${rotationDeg}deg)`;
+  }
   subtitlesLabel.textContent = state.subtitlesLabel || "Subs";
   audioLabel.textContent = state.audioLabel || "Audio";
   sourcesLabel.textContent = state.sourcesLabel || "Sources";
@@ -2683,7 +2703,7 @@ window.playerControls = nextState => {
     pendingSettingToastCommand = "";
     showPlayerToast(settingToastLabel("resize"));
   } else if ((state.playbackSpeedLabel || "") !== previousSpeedLabel && previousSpeedLabel !== "") {
-    showVlcOsd(`Speed ${state.playbackSpeedLabel}`);
+    showVlcOsd(`${state.playbackSpeedLabel} Speed`);
   }
   const nextVolumeLevel = typeof state.volumeLevel === "number" ? state.volumeLevel : NaN;
   if (

--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -38,6 +38,8 @@ const episodesLabel = document.getElementById("episodesLabel");
 const submitIntroButton = document.getElementById("submitIntroButton");
 const videoSettingsButton = document.getElementById("videoSettingsButton");
 const backButton = document.getElementById("backButton");
+const vlcOsd = document.getElementById("vlcOsd");
+let vlcOsdTimer = null;
 const openingOverlay = document.getElementById("openingOverlay");
 const openingArtwork = document.getElementById("openingArtwork");
 const openingBackButton = document.getElementById("openingBackButton");
@@ -485,6 +487,18 @@ const nextVolumeToastLabel = delta => {
     return `Volume ${Math.round(nextLevel * 100)}%`;
   }
   return volumeToastLabel(delta);
+};
+
+const showVlcOsd = text => {
+  if (!vlcOsd) return;
+  vlcOsd.textContent = text;
+  vlcOsd.classList.add("visible");
+  if (vlcOsdTimer) {
+    window.clearTimeout(vlcOsdTimer);
+  }
+  vlcOsdTimer = window.setTimeout(() => {
+    vlcOsd.classList.remove("visible");
+  }, 1600);
 };
 
 const seekToastLabel = command => {
@@ -2668,9 +2682,8 @@ window.playerControls = nextState => {
   if (pendingSettingToastCommand === "resize" && (state.resizeModeLabel || "") !== previousResizeLabel) {
     pendingSettingToastCommand = "";
     showPlayerToast(settingToastLabel("resize"));
-  } else if (pendingSettingToastCommand === "speed" && (state.playbackSpeedLabel || "") !== previousSpeedLabel) {
-    pendingSettingToastCommand = "";
-    showPlayerToast(settingToastLabel("speed"));
+  } else if ((state.playbackSpeedLabel || "") !== previousSpeedLabel && previousSpeedLabel !== "") {
+    showVlcOsd(`Speed ${state.playbackSpeedLabel}`);
   }
   const nextVolumeLevel = typeof state.volumeLevel === "number" ? state.volumeLevel : NaN;
   if (

--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -2700,7 +2700,7 @@ window.playerControls = nextState => {
     pendingSettingToastCommand = "";
     showPlayerToast(settingToastLabel("resize"));
   } else if ((state.playbackSpeedLabel || "") !== previousSpeedLabel && previousSpeedLabel !== "") {
-    showVlcOsd(`${state.playbackSpeedLabel} Speed`);
+    showVlcOsd(`Speed: ${state.playbackSpeedLabel}`);
   }
   const nextVolumeLevel = typeof state.volumeLevel === "number" ? state.volumeLevel : NaN;
   if (


### PR DESCRIPTION
## Summary

- **Playback Speed Selector Modal**: Adds a dedicated Playback Speed modal supporting speeds from 0.25x to 2.0x (in 0.25x increments).
- **Dynamic Speedometer Gauge Icon**: Replaces the static speed icon with a dynamic SVG gauge icon featuring real-time needle rotation (-102° at 0.25x to +102° at 2.0x), curved tub base, center pivot at (12, 13.5), and rotated cutout masking.
- **Top-Right VLC-style OSD**: Moves desktop speed adjustment feedback to a clean top-right OSD message (`Speed: {speed}`).
- **Active State Accent Highlight**: Automatically highlights the speed control pill in theme accent color whenever custom speed (≠ 1.0x) is selected.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

**Provides a reference implementation for feature request #337 for maintainer evaluation.** Improves desktop player usability and visual feedback during video playback by introducing a dedicated speed selector modal and top-right OSD notifications, while establishing 1:1 design and feature parity with NuvioMobile.

## Desktop scope

Desktop shared player UI web view resources (`composeApp/src/desktopMain/resources/player-ui/controls.html`, `controls.js`, `controls.css`) and common Compose player action controls (`composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerControls.kt`).

## Issue or approval

Linked to Feature Request #337. **Submitted for maintainer evaluation and review. A companion PR for NuvioMobile is also ready to share full 1:1 design and feature parity across both platforms.**

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [ ] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [ ] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Intentionally limited to player speed controls, dedicated speed modal selection, top-right OSD feedback, and dynamic gauge icon rendering. Does not touch player engine core logic, stream fetching, audio/subtitle selection, or unrelated UI controls.

## Testing

- **Platform**: Windows 11 Desktop
- **Commands**: Executed `./gradlew compileKotlinDesktop` and `./gradlew run`.
- **Manual Flows**: Tested cold launch, opening the dedicated Playback Speed modal, switching speeds from 0.25x through 2.0x, verifying top-right OSD text (`Speed: 1.5x`), needle rotation animations, and action pill accent highlight.

## Screenshots / Video

> Selection Modal Screenshot: Demonstrates the new speed options (0.25x to 2.0x) and layout.

<img width="842" height="933" alt="Screenshot 2026-08-11 231353" src="https://github.com/user-attachments/assets/eeead610-cbfc-40d4-adb8-a060a7d01241" />

> OSD Toast Screenshot: Shows the top-right text feedback (Speed: 1.5x) during playback.

<img width="2552" height="1288" alt="Screenshot 2026-08-11 231640" src="https://github.com/user-attachments/assets/3eb1e43e-98db-46f5-bdf4-2ab107f22e73" />

> Short Video Demo: Highlights the dynamic gauge needle rotating smoothly and the action pill accent highlighting in real time as speeds change.

https://github.com/user-attachments/assets/2e5a9e5b-df6f-4588-9ef9-4f4049d21130



## Breaking changes

None.

## Linked issues

Linked to #337 
