### PR TITLE
feat(desktop): add global hardware media key and volume control support

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopPlayerMediaKeyDispatcher.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopPlayerMediaKeyDispatcher.kt
@@ -1,0 +1,89 @@
+package com.nuvio.app.features.player.desktop
+
+import java.awt.KeyEventDispatcher
+import java.awt.KeyboardFocusManager
+import java.awt.event.KeyEvent
+
+private const val VK_VOLUME_MUTE_CODE = 0xAD
+private const val VK_VOLUME_DOWN_CODE = 0xAE
+private const val VK_VOLUME_UP_CODE = 0xAF
+private const val VK_MEDIA_NEXT_TRACK_CODE = 0xB0
+private const val VK_MEDIA_PREV_TRACK_CODE = 0xB1
+private const val VK_MEDIA_STOP_CODE = 0xB2
+private const val VK_MEDIA_PLAY_PAUSE_CODE = 0xB3
+private const val VK_PLAY_CODE = 0xFA
+private const val VK_PAUSE_CODE = 0x13
+
+internal object DesktopPlayerMediaKeyDispatcher {
+    private val dispatcher = KeyEventDispatcher { event ->
+        handle(event)
+    }
+
+    @Volatile
+    private var activeController: NativePlayerController? = null
+    @Volatile
+    private var installed = false
+
+    fun register(controller: NativePlayerController) {
+        activeController = controller
+        installIfNeeded()
+    }
+
+    fun unregister(controller: NativePlayerController) {
+        if (activeController === controller) {
+            activeController = null
+        }
+        uninstallIfPossible()
+    }
+
+    private fun installIfNeeded() {
+        if (installed) return
+        KeyboardFocusManager.getCurrentKeyboardFocusManager().addKeyEventDispatcher(dispatcher)
+        installed = true
+    }
+
+    private fun uninstallIfPossible() {
+        if (activeController != null || !installed) return
+        KeyboardFocusManager.getCurrentKeyboardFocusManager().removeKeyEventDispatcher(dispatcher)
+        installed = false
+    }
+
+    private fun handle(event: KeyEvent): Boolean {
+        if (event.id != KeyEvent.KEY_PRESSED) return false
+        val controller = activeController ?: return false
+        val keyCode = if (event.keyCode != KeyEvent.VK_UNDEFINED) event.keyCode else event.extendedKeyCode
+        return when (keyCode) {
+            VK_MEDIA_PLAY_PAUSE_CODE,
+            VK_PLAY_CODE -> {
+                controller.togglePlaybackFromShortcut()
+                true
+            }
+            VK_MEDIA_STOP_CODE,
+            VK_PAUSE_CODE -> {
+                controller.pause()
+                true
+            }
+            VK_MEDIA_NEXT_TRACK_CODE -> {
+                controller.seekByShortcut(10_000L)
+                true
+            }
+            VK_MEDIA_PREV_TRACK_CODE -> {
+                controller.seekByShortcut(-10_000L)
+                true
+            }
+            VK_VOLUME_UP_CODE -> {
+                controller.adjustVolumeByShortcut(5f)
+                true
+            }
+            VK_VOLUME_DOWN_CODE -> {
+                controller.adjustVolumeByShortcut(-5f)
+                true
+            }
+            VK_VOLUME_MUTE_CODE -> {
+                controller.toggleMuteFromShortcut()
+                true
+            }
+            else -> false
+        }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
@@ -67,6 +67,10 @@ internal class NativePlayerController(
         }
     }
 
+    init {
+        DesktopPlayerMediaKeyDispatcher.register(this)
+    }
+
     fun attach(
         sourceUrl: String,
         sourceHeaders: Map<String, String>,
@@ -331,6 +335,7 @@ internal class NativePlayerController(
             PlayerControlsAction.KeyboardSeekForward -> fallbackSeekBy(10_000L)
             PlayerControlsAction.KeyboardVolumeDown -> adjustFallbackVolume(-5f)
             PlayerControlsAction.KeyboardVolumeUp -> adjustFallbackVolume(5f)
+            PlayerControlsAction.PictureInPicture -> togglePictureInPictureFromShortcut()
             PlayerControlsAction.Speed -> cycleFallbackSpeed()
             else -> Unit
         }
@@ -401,6 +406,7 @@ internal class NativePlayerController(
 
     fun dispose() {
         host.resetCursorVisibility()
+        DesktopPlayerMediaKeyDispatcher.unregister(this)
         disposePlayerHandle()
     }
 
@@ -438,6 +444,42 @@ internal class NativePlayerController(
     override fun seekBy(offsetMs: Long) {
         log.d { "seekBy offsetMs=$offsetMs handle=$handle" }
         handle.takeIf { it != 0L }?.let { NativePlayerBridge.seekBy(it, offsetMs) }
+    }
+
+    fun seekByShortcut(offsetMs: Long) {
+        seekBy(offsetMs)
+    }
+
+    fun togglePlaybackFromShortcut() {
+        val current = handle.takeIf { it != 0L } ?: return
+        val isEnded = NativePlayerBridge.isEnded(current)
+        val isPaused = NativePlayerBridge.isPaused(current)
+        if (isEnded) {
+            NativePlayerBridge.seekTo(current, 0L)
+            NativePlayerBridge.setPaused(current, false)
+        } else {
+            NativePlayerBridge.setPaused(current, !isPaused)
+        }
+    }
+
+    fun adjustVolumeByShortcut(deltaPercent: Float) {
+        adjustFallbackVolume(deltaPercent)
+    }
+
+    fun toggleMuteFromShortcut() {
+        val current = handle.takeIf { it != 0L } ?: return
+        val currentVolume = NativePlayerBridge.volume(current).coerceIn(0f, 1f)
+        if (currentVolume > 0.01f) {
+            rememberedVolumeLevel = currentVolume
+            setFallbackVolume(0f)
+        } else {
+            val restoreLevel = rememberedVolumeLevel.takeIf { it > 0.01f } ?: 1f
+            setFallbackVolume(restoreLevel)
+        }
+    }
+
+    fun togglePictureInPictureFromShortcut() {
+        DesktopPlayerPictureInPicture.toggle()
     }
 
     override fun retry() {
@@ -697,6 +739,7 @@ private fun String.toPlayerControlsAction(): PlayerControlsAction? =
         "keyboardSeekForward" -> PlayerControlsAction.KeyboardSeekForward
         "keyboardVolumeDown" -> PlayerControlsAction.KeyboardVolumeDown
         "keyboardVolumeUp" -> PlayerControlsAction.KeyboardVolumeUp
+        "pictureInPicture", "pip" -> PlayerControlsAction.PictureInPicture
         "resize" -> PlayerControlsAction.ResizeMode
         "speed" -> PlayerControlsAction.Speed
         "subtitles" -> PlayerControlsAction.Subtitles


### PR DESCRIPTION
### Description
Adds support for hardware media keys and volume controls on Desktop platforms using an AWT KeyEventDispatcher. This allows hardware play/pause, stop, track seeking (next/prev), volume adjustment, and volume mute keys (e.g. from headphones or keyboards) to control player playback seamlessly when the window is focused.

### Changes Included
- Added DesktopPlayerMediaKeyDispatcher to map virtual keycodes (VK_MEDIA_PLAY_PAUSE, VK_VOLUME_UP/DOWN, VK_VOLUME_MUTE, VK_MEDIA_NEXT/PREV_TRACK, etc.) to controller actions.
- Registered and unregistered DesktopPlayerMediaKeyDispatcher within NativePlayerController.
- Added shortcut playback toggle, volume adjustment, and mute handlers in NativePlayerController.

### Testing Strategy
- Verified compilation with ./gradlew :composeApp:compileKotlinDesktop.
- Tested playback control, volume up/down, and mute toggles using hardware media keys during active video playback on Windows.