### PR TITLE
feat(desktop): add Picture-in-Picture mode support for desktop player

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerPlatformEffects.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerPlatformEffects.android.kt
@@ -83,6 +83,8 @@ actual fun ManagePlayerPictureInPicture(
     }
 }
 
+actual fun togglePlayerPictureInPicture() = Unit
+
 @Composable
 actual fun rememberIsInPictureInPicture(): Boolean {
     val context = LocalContext.current

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -330,6 +330,7 @@
     <string name="compose_action_on">On</string>
     <string name="compose_action_pause">Pause</string>
     <string name="compose_action_reload">Reload</string>
+    <string name="compose_player_picture_in_picture">Picture in picture</string>
     <string name="compose_auth_already_have_account">Already have an account? </string>
     <string name="compose_auth_continue_without_account">Continue Without Account</string>
     <string name="compose_auth_create_account">Create Account</string>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerControls.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerControls.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.icons.rounded.Flag
 import androidx.compose.material.icons.rounded.Forward10
 import androidx.compose.material.icons.rounded.Lock
 import androidx.compose.material.icons.rounded.LockOpen
+import androidx.compose.material.icons.rounded.PictureInPictureAlt
 import androidx.compose.material.icons.rounded.Replay10
 import androidx.compose.material.icons.rounded.Speed
 import androidx.compose.material.icons.rounded.SwapHoriz
@@ -89,6 +90,7 @@ internal fun PlayerControlsShell(
     onSourcesClick: (() -> Unit)? = null,
     onEpisodesClick: (() -> Unit)? = null,
     onOpenInExternalPlayer: (() -> Unit)? = null,
+    onPictureInPictureClick: (() -> Unit)? = null,
     onSubmitIntroClick: (() -> Unit)? = null,
     parentalWarnings: List<ParentalWarning> = emptyList(),
     showParentalGuide: Boolean = false,
@@ -151,6 +153,7 @@ internal fun PlayerControlsShell(
                 onLockToggle = onLockToggle,
                 onVideoSettingsClick = onVideoSettingsClick,
                 onOpenInExternalPlayer = onOpenInExternalPlayer,
+                onPictureInPictureClick = onPictureInPictureClick,
                 onBack = onBack,
                 modifier = Modifier
                     .align(Alignment.TopStart)
@@ -219,6 +222,7 @@ private fun PlayerHeader(
     onLockToggle: () -> Unit,
     onVideoSettingsClick: (() -> Unit)?,
     onOpenInExternalPlayer: (() -> Unit)?,
+    onPictureInPictureClick: (() -> Unit)?,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -325,6 +329,15 @@ private fun PlayerHeader(
                             buttonSize = metrics.headerIconSize + 16.dp,
                             iconSize = metrics.headerIconSize,
                             onClick = onOpenInExternalPlayer,
+                        )
+                    }
+                    if (onPictureInPictureClick != null) {
+                        PlayerHeaderIconButton(
+                            icon = Icons.Rounded.PictureInPictureAlt,
+                            contentDescription = stringResource(Res.string.compose_player_picture_in_picture),
+                            buttonSize = metrics.headerIconSize + 16.dp,
+                            iconSize = metrics.headerIconSize,
+                            onClick = onPictureInPictureClick,
                         )
                     }
                     PlayerHeaderIconButton(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerEngine.kt
@@ -37,6 +37,7 @@ enum class PlayerControlsAction {
     KeyboardSeekForward,
     KeyboardVolumeDown,
     KeyboardVolumeUp,
+    PictureInPicture,
     ResizeMode,
     Speed,
     Subtitles,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerPlatformEffects.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerPlatformEffects.kt
@@ -27,6 +27,8 @@ expect fun ManagePlayerPictureInPicture(
     videoSize: IntSize,
 )
 
+expect fun togglePlayerPictureInPicture()
+
 @Composable
 expect fun rememberIsInPictureInPicture(): Boolean
 

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
@@ -519,7 +519,9 @@ private fun PlayerScreenRuntime.currentInitialPositionRequestKey(): String? {
 private fun PlayerScreenRuntime.RenderPlayerControls(displayedPositionMs: Long, isEpisode: Boolean) {
     val isInPip = rememberIsInPictureInPicture()
     AnimatedVisibility(
-        visible = (controlsVisible || showParentalGuide) && !playerControlsLocked && !isInPip,
+        visible = (controlsVisible || showParentalGuide) &&
+            !playerControlsLocked &&
+            (!isInPip || isDesktop),
         enter = fadeIn(),
         exit = fadeOut(),
     ) {
@@ -555,6 +557,11 @@ private fun PlayerScreenRuntime.RenderPlayerControls(displayedPositionMs: Long, 
             onAudioClick = {
                 refreshTracks()
                 showAudioModal = true
+            },
+            onPictureInPictureClick = if (isDesktop) {
+                { togglePlayerPictureInPicture() }
+            } else {
+                null
             },
             onVideoSettingsClick = if (isIos) {
                 {
@@ -694,6 +701,9 @@ private fun PlayerScreenRuntime.handlePlayerControlsAction(action: PlayerControl
                 showVideoSettingsModal = true
                 controlsVisible = true
             }
+        }
+        PlayerControlsAction.PictureInPicture -> {
+            togglePlayerPictureInPicture()
         }
         PlayerControlsAction.DoubleTapSeekBack -> {
             prepareDoubleTapSeekForNativeFallback(PlayerSeekDirection.Backward)

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/PlayerPlatformEffects.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/PlayerPlatformEffects.desktop.kt
@@ -4,9 +4,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.unit.IntSize
 import com.nuvio.app.features.player.desktop.DesktopHostOs
 import com.nuvio.app.features.player.desktop.NativePlayerBridge
+import com.nuvio.app.features.player.desktop.DesktopPlayerPictureInPicture
 
 @Composable
 actual fun LockPlayerToLandscape() = Unit
@@ -30,10 +32,28 @@ actual fun EnterImmersivePlayerMode(keepScreenAwake: Boolean) {
 actual fun ManagePlayerPictureInPicture(
     isPlaying: Boolean,
     videoSize: IntSize,
-) = Unit
+) {
+    SideEffect {
+        DesktopPlayerPictureInPicture.update(isPlaying = isPlaying, videoSize = videoSize)
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            DesktopPlayerPictureInPicture.clear()
+        }
+    }
+}
 
 @Composable
-actual fun rememberIsInPictureInPicture(): Boolean = false
+actual fun rememberIsInPictureInPicture(): Boolean {
+    val version = DesktopPlayerPictureInPicture.changes.collectAsState()
+    version.value
+    return DesktopPlayerPictureInPicture.isEnabled
+}
+
+actual fun togglePlayerPictureInPicture() {
+    DesktopPlayerPictureInPicture.toggle()
+}
 
 @Composable
 actual fun rememberPlayerGestureController(): PlayerGestureController? = null

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopPlayerPictureInPicture.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopPlayerPictureInPicture.kt
@@ -1,0 +1,117 @@
+package com.nuvio.app.features.player.desktop
+
+import androidx.compose.ui.unit.IntSize
+import java.awt.Dimension
+import java.awt.GraphicsEnvironment
+import java.awt.KeyboardFocusManager
+import java.awt.Point
+import java.awt.Rectangle
+import java.awt.Window
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+internal object DesktopPlayerPictureInPicture {
+    private val _changes = MutableStateFlow(0)
+    val changes: StateFlow<Int> = _changes.asStateFlow()
+
+    @Volatile
+    var isEnabled: Boolean = false
+        private set
+
+    private var restoreBounds: Rectangle? = null
+    private var restoreAlwaysOnTop: Boolean = false
+    private var lastVideoSize: IntSize = IntSize.Zero
+
+    fun toggle() {
+        isEnabled = !isEnabled
+        applyToCurrentWindow()
+        notifyChanged()
+    }
+
+    fun update(isPlaying: Boolean, videoSize: IntSize) {
+        lastVideoSize = videoSize
+        if (!isEnabled) return
+        applyToCurrentWindow()
+        notifyChanged()
+    }
+
+    fun clear() {
+        if (isEnabled) {
+            isEnabled = false
+            applyToCurrentWindow()
+            notifyChanged()
+        }
+    }
+
+    private fun applyToCurrentWindow() {
+        val window = currentWindow() ?: return
+        if (isEnabled) {
+            if (isDesktopAppFullscreen(window)) {
+                toggleDesktopAppFullscreen(window)
+            }
+            enterPictureInPicture(window)
+        } else {
+            exitPictureInPicture(window)
+        }
+    }
+
+    private fun enterPictureInPicture(window: Window) {
+        if (restoreBounds == null) {
+            restoreBounds = Rectangle(window.bounds)
+            restoreAlwaysOnTop = window.isAlwaysOnTop
+        }
+
+        val bounds = computePictureInPictureBounds(window)
+        window.isAlwaysOnTop = true
+        window.bounds = bounds
+        window.toFront()
+        window.requestFocus()
+    }
+
+    private fun exitPictureInPicture(window: Window) {
+        val bounds = restoreBounds ?: return
+        window.isAlwaysOnTop = restoreAlwaysOnTop
+        window.bounds = bounds
+        restoreBounds = null
+    }
+
+    private fun computePictureInPictureBounds(window: Window): Rectangle {
+        val graphicsConfiguration = window.graphicsConfiguration
+            ?: GraphicsEnvironment.getLocalGraphicsEnvironment().defaultScreenDevice.defaultConfiguration
+        val screenBounds = graphicsConfiguration.bounds
+        val insets = ToolkitInsets.get(graphicsConfiguration)
+        val availableWidth = (screenBounds.width - insets.left - insets.right).coerceAtLeast(320)
+        val availableHeight = (screenBounds.height - insets.top - insets.bottom).coerceAtLeast(240)
+        val aspectRatio = when {
+            lastVideoSize.width > 0 && lastVideoSize.height > 0 -> lastVideoSize.width.toFloat() / lastVideoSize.height.toFloat()
+            else -> 16f / 9f
+        }.coerceIn(1.0f, 2.4f)
+
+        val targetWidth = (availableWidth * 0.34f).toInt().coerceIn(360, 720)
+        val targetHeight = (targetWidth / aspectRatio).toInt().coerceIn(220, (availableHeight * 0.5f).toInt().coerceAtLeast(220))
+        val width = targetWidth.coerceAtMost(availableWidth)
+        val height = targetHeight.coerceAtMost(availableHeight)
+        val x = screenBounds.x + screenBounds.width - insets.right - width - 24
+        val y = screenBounds.y + screenBounds.height - insets.bottom - height - 24
+        return Rectangle(x.coerceAtLeast(screenBounds.x + insets.left), y.coerceAtLeast(screenBounds.y + insets.top), width, height)
+    }
+
+    private fun currentWindow(): Window? =
+        KeyboardFocusManager.getCurrentKeyboardFocusManager().activeWindow
+            ?: Window.getWindows().firstOrNull { it.isDisplayable && it.isVisible }
+
+    private fun notifyChanged() {
+        _changes.value += 1
+    }
+}
+
+private object ToolkitInsets {
+    fun get(configuration: java.awt.GraphicsConfiguration): java.awt.Insets {
+        val device = configuration.device
+        val toolkit = java.awt.Toolkit.getDefaultToolkit()
+        return runCatching { toolkit.getScreenInsets(configuration) }.getOrElse {
+            java.awt.Insets(0, 0, 0, 0)
+        }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
@@ -331,6 +331,7 @@ internal class NativePlayerController(
             PlayerControlsAction.KeyboardSeekForward -> fallbackSeekBy(10_000L)
             PlayerControlsAction.KeyboardVolumeDown -> adjustFallbackVolume(-5f)
             PlayerControlsAction.KeyboardVolumeUp -> adjustFallbackVolume(5f)
+            PlayerControlsAction.PictureInPicture -> togglePictureInPictureFromShortcut()
             PlayerControlsAction.Speed -> cycleFallbackSpeed()
             else -> Unit
         }
@@ -697,6 +698,7 @@ private fun String.toPlayerControlsAction(): PlayerControlsAction? =
         "keyboardSeekForward" -> PlayerControlsAction.KeyboardSeekForward
         "keyboardVolumeDown" -> PlayerControlsAction.KeyboardVolumeDown
         "keyboardVolumeUp" -> PlayerControlsAction.KeyboardVolumeUp
+        "pictureInPicture", "pip" -> PlayerControlsAction.PictureInPicture
         "resize" -> PlayerControlsAction.ResizeMode
         "speed" -> PlayerControlsAction.Speed
         "subtitles" -> PlayerControlsAction.Subtitles

--- a/composeApp/src/desktopMain/resources/player-ui/controls.html
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.html
@@ -35,6 +35,9 @@
       <path d="M6 6L18 18" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round"/>
       <path d="M18 6L6 18" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round"/>
     </symbol>
+    <symbol id="icon-pip" viewBox="0 0 24 24">
+      <path d="M19 11h-8v6h8v-6zm4-8H1c-.55 0-1 .45-1 1v16c0 .55.45 1 1 1h22c.55 0 1-.45 1-1V4c0-.55-.45-1-1-1zm-2 16H3V6h18v13z" fill="currentColor"/>
+    </symbol>
     <symbol id="icon-fullscreen" viewBox="0 0 24 24">
       <path d="M8 2H4C2.89543 2 2 2.89543 2 4V8" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
       <path d="M22 8L22 4C22 2.89543 21.1046 2 20 2H16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
@@ -120,6 +123,7 @@
         <nav class="header-actions" aria-label="Player actions">
           <button class="header-button" id="submitIntroButton" data-command="submitIntro" aria-label="Submit intro"><svg><use href="#icon-flag"></use></svg></button>
           <button class="header-button" id="videoSettingsButton" data-command="videoSettings" aria-label="Video settings"><svg><use href="#icon-build"></use></svg></button>
+          <button class="header-button" id="pipButton" data-command="pictureInPicture" aria-label="Picture in Picture"><svg><use href="#icon-pip"></use></svg></button>
           <button class="header-button" id="fullscreenButton" data-command="toggleFullscreen" aria-label="Enter fullscreen"><svg><use id="fullscreenIcon" href="#icon-fullscreen"></use></svg></button>
           <button class="header-button" id="backButton" data-command="back" aria-label="Close player"><svg><use href="#icon-close"></use></svg></button>
         </nav>

--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -487,6 +487,7 @@ const nextVolumeToastLabel = delta => {
 const seekToastLabel = command => {
   if (command === "seekBack" || command === "keyboardSeekBack") return "-10s";
   if (command === "seekForward" || command === "keyboardSeekForward") return "+10s";
+  if (command === "pictureInPicture" || command === "pip") return "Picture-in-Picture";
   return "";
 };
 
@@ -2164,7 +2165,7 @@ const actionShortcutCommandForEvent = event => {
     case "KeyE":
       return "episodes";
     case "KeyP":
-      return "keyboardToggle";
+      return "pictureInPicture";
     default:
       return "";
   }

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/PlayerPlatformEffects.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/PlayerPlatformEffects.ios.kt
@@ -51,6 +51,8 @@ actual fun ManagePlayerPictureInPicture(
     videoSize: IntSize,
 ) = Unit
 
+actual fun togglePlayerPictureInPicture() = Unit
+
 @Composable
 actual fun rememberIsInPictureInPicture(): Boolean = false
 


### PR DESCRIPTION
### Description
Adds Picture-in-Picture (PiP) window support for Desktop platforms. Enables users to pop out video playback into an always-on-top floating window that dynamically respects video aspect ratio, preserves bounds for restoration upon exiting, and adds a PiP action button to player UI controls as well as 'P' hotkey binding.

### Changes Included
- Added DesktopPlayerPictureInPicture object to manage window always-on-top state, bounds saving/restoration, and dynamic aspect ratio floating window sizing.
- Implemented togglePlayerPictureInPicture() and expect/actual declarations across Android, iOS, and Desktop in PlayerPlatformEffects.
- Exposed PictureInPicture control action in PlayerControls.kt, PlayerEngine.kt, and PlayerScreenRuntimeUi.kt.
- Updated player Web UI controls (controls.html and controls.js) with a PiP header toggle button, tooltip, toast notification, and KeyP shortcut handler.

### Testing Strategy
- Verified compilation with ./gradlew :composeApp:compileKotlinDesktop.
- Verified PiP toggle from player UI button and keyboard shortcut, window bounds restoration upon exit, and always-on-top window behavior during playback.