### PR TITLE
feat(desktop): add global hardware media key and volume control support

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopPlayerMediaKeyDispatcher.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopPlayerMediaKeyDispatcher.kt
@@ -1,0 +1,89 @@
+package com.nuvio.app.features.player.desktop
+
+import java.awt.KeyEventDispatcher
+import java.awt.KeyboardFocusManager
+import java.awt.event.KeyEvent
+
+private const val VK_VOLUME_MUTE_CODE = 0xAD
+private const val VK_VOLUME_DOWN_CODE = 0xAE
+private const val VK_VOLUME_UP_CODE = 0xAF
+private const val VK_MEDIA_NEXT_TRACK_CODE = 0xB0
+private const val VK_MEDIA_PREV_TRACK_CODE = 0xB1
+private const val VK_MEDIA_STOP_CODE = 0xB2
+private const val VK_MEDIA_PLAY_PAUSE_CODE = 0xB3
+private const val VK_PLAY_CODE = 0xFA
+private const val VK_PAUSE_CODE = 0x13
+
+internal object DesktopPlayerMediaKeyDispatcher {
+    private val dispatcher = KeyEventDispatcher { event ->
+        handle(event)
+    }
+
+    @Volatile
+    private var activeController: NativePlayerController? = null
+    @Volatile
+    private var installed = false
+
+    fun register(controller: NativePlayerController) {
+        activeController = controller
+        installIfNeeded()
+    }
+
+    fun unregister(controller: NativePlayerController) {
+        if (activeController === controller) {
+            activeController = null
+        }
+        uninstallIfPossible()
+    }
+
+    private fun installIfNeeded() {
+        if (installed) return
+        KeyboardFocusManager.getCurrentKeyboardFocusManager().addKeyEventDispatcher(dispatcher)
+        installed = true
+    }
+
+    private fun uninstallIfPossible() {
+        if (activeController != null || !installed) return
+        KeyboardFocusManager.getCurrentKeyboardFocusManager().removeKeyEventDispatcher(dispatcher)
+        installed = false
+    }
+
+    private fun handle(event: KeyEvent): Boolean {
+        if (event.id != KeyEvent.KEY_PRESSED) return false
+        val controller = activeController ?: return false
+        val keyCode = if (event.keyCode != KeyEvent.VK_UNDEFINED) event.keyCode else event.extendedKeyCode
+        return when (keyCode) {
+            VK_MEDIA_PLAY_PAUSE_CODE,
+            VK_PLAY_CODE -> {
+                controller.togglePlaybackFromShortcut()
+                true
+            }
+            VK_MEDIA_STOP_CODE,
+            VK_PAUSE_CODE -> {
+                controller.pause()
+                true
+            }
+            VK_MEDIA_NEXT_TRACK_CODE -> {
+                controller.seekByShortcut(10_000L)
+                true
+            }
+            VK_MEDIA_PREV_TRACK_CODE -> {
+                controller.seekByShortcut(-10_000L)
+                true
+            }
+            VK_VOLUME_UP_CODE -> {
+                controller.adjustVolumeByShortcut(5f)
+                true
+            }
+            VK_VOLUME_DOWN_CODE -> {
+                controller.adjustVolumeByShortcut(-5f)
+                true
+            }
+            VK_VOLUME_MUTE_CODE -> {
+                controller.toggleMuteFromShortcut()
+                true
+            }
+            else -> false
+        }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
@@ -335,7 +335,6 @@ internal class NativePlayerController(
             PlayerControlsAction.KeyboardSeekForward -> fallbackSeekBy(10_000L)
             PlayerControlsAction.KeyboardVolumeDown -> adjustFallbackVolume(-5f)
             PlayerControlsAction.KeyboardVolumeUp -> adjustFallbackVolume(5f)
-            PlayerControlsAction.PictureInPicture -> togglePictureInPictureFromShortcut()
             PlayerControlsAction.Speed -> cycleFallbackSpeed()
             else -> Unit
         }
@@ -476,10 +475,6 @@ internal class NativePlayerController(
             val restoreLevel = rememberedVolumeLevel.takeIf { it > 0.01f } ?: 1f
             setFallbackVolume(restoreLevel)
         }
-    }
-
-    fun togglePictureInPictureFromShortcut() {
-        DesktopPlayerPictureInPicture.toggle()
     }
 
     override fun retry() {
@@ -739,7 +734,6 @@ private fun String.toPlayerControlsAction(): PlayerControlsAction? =
         "keyboardSeekForward" -> PlayerControlsAction.KeyboardSeekForward
         "keyboardVolumeDown" -> PlayerControlsAction.KeyboardVolumeDown
         "keyboardVolumeUp" -> PlayerControlsAction.KeyboardVolumeUp
-        "pictureInPicture", "pip" -> PlayerControlsAction.PictureInPicture
         "resize" -> PlayerControlsAction.ResizeMode
         "speed" -> PlayerControlsAction.Speed
         "subtitles" -> PlayerControlsAction.Subtitles

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
@@ -67,6 +67,10 @@ internal class NativePlayerController(
         }
     }
 
+    init {
+        DesktopPlayerMediaKeyDispatcher.register(this)
+    }
+
     fun attach(
         sourceUrl: String,
         sourceHeaders: Map<String, String>,
@@ -331,6 +335,7 @@ internal class NativePlayerController(
             PlayerControlsAction.KeyboardSeekForward -> fallbackSeekBy(10_000L)
             PlayerControlsAction.KeyboardVolumeDown -> adjustFallbackVolume(-5f)
             PlayerControlsAction.KeyboardVolumeUp -> adjustFallbackVolume(5f)
+            PlayerControlsAction.PictureInPicture -> togglePictureInPictureFromShortcut()
             PlayerControlsAction.Speed -> cycleFallbackSpeed()
             else -> Unit
         }
@@ -401,6 +406,7 @@ internal class NativePlayerController(
 
     fun dispose() {
         host.resetCursorVisibility()
+        DesktopPlayerMediaKeyDispatcher.unregister(this)
         disposePlayerHandle()
     }
 
@@ -438,6 +444,42 @@ internal class NativePlayerController(
     override fun seekBy(offsetMs: Long) {
         log.d { "seekBy offsetMs=$offsetMs handle=$handle" }
         handle.takeIf { it != 0L }?.let { NativePlayerBridge.seekBy(it, offsetMs) }
+    }
+
+    fun seekByShortcut(offsetMs: Long) {
+        seekBy(offsetMs)
+    }
+
+    fun togglePlaybackFromShortcut() {
+        val current = handle.takeIf { it != 0L } ?: return
+        val isEnded = NativePlayerBridge.isEnded(current)
+        val isPaused = NativePlayerBridge.isPaused(current)
+        if (isEnded) {
+            NativePlayerBridge.seekTo(current, 0L)
+            NativePlayerBridge.setPaused(current, false)
+        } else {
+            NativePlayerBridge.setPaused(current, !isPaused)
+        }
+    }
+
+    fun adjustVolumeByShortcut(deltaPercent: Float) {
+        adjustFallbackVolume(deltaPercent)
+    }
+
+    fun toggleMuteFromShortcut() {
+        val current = handle.takeIf { it != 0L } ?: return
+        val currentVolume = NativePlayerBridge.volume(current).coerceIn(0f, 1f)
+        if (currentVolume > 0.01f) {
+            rememberedVolumeLevel = currentVolume
+            setFallbackVolume(0f)
+        } else {
+            val restoreLevel = rememberedVolumeLevel.takeIf { it > 0.01f } ?: 1f
+            setFallbackVolume(restoreLevel)
+        }
+    }
+
+    fun togglePictureInPictureFromShortcut() {
+        DesktopPlayerPictureInPicture.toggle()
     }
 
     override fun retry() {
@@ -697,6 +739,7 @@ private fun String.toPlayerControlsAction(): PlayerControlsAction? =
         "keyboardSeekForward" -> PlayerControlsAction.KeyboardSeekForward
         "keyboardVolumeDown" -> PlayerControlsAction.KeyboardVolumeDown
         "keyboardVolumeUp" -> PlayerControlsAction.KeyboardVolumeUp
+        "pictureInPicture", "pip" -> PlayerControlsAction.PictureInPicture
         "resize" -> PlayerControlsAction.ResizeMode
         "speed" -> PlayerControlsAction.Speed
         "subtitles" -> PlayerControlsAction.Subtitles


### PR DESCRIPTION
## Summary
Adds desktop-wide hardware media key handling for play/pause, stop, next/previous seek, volume up/down, and mute.

## PR type
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why
Desktop playback did not consistently respond to media keys from keyboards and headsets while the player was focused.

## Desktop scope
Windows and macOS desktop playback control paths. No Android or iOS behavior is changed.

## Issue or approval
No linked issue: requested and approved as a desktop playback correction by the repository owner.

## UI / behavior impact
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a linked bug/regression
- [ ] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

## Policy check
- [x] I have read and understood CONTRIBUTING.md.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no UI change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries
No UI changes, no Android/iOS changes, no playback engine replacement, and no dependency changes.

## Testing
- :composeApp:compileKotlinDesktop
- :composeApp:desktopTest
- Manual Windows desktop playback with play/pause, stop, seek, volume, and mute media keys.

## Screenshots / Video
Not a UI change.

## Breaking changes
None.

## Linked issues
No linked issue: requested and approved as a desktop playback correction by the repository owner.