### PR TITLE
fix(desktop): unify startup loading screen and fix maximized window flash

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
@@ -605,6 +605,15 @@ fun App(
         var autoSkipProfileSelection by rememberSaveable { mutableStateOf(false) }
         var pendingProfileSwitch by remember { mutableStateOf<PendingProfileSwitch?>(null) }
 
+        // Use the incoming profile's color during a switch so the loading overlay
+        // already shows the correct hue before MainAppContent's own overlay takes over.
+        val gateProfileColor = remember(pendingProfileSwitch, profileState.activeProfile, profileState.profiles) {
+            val sourceProfile = pendingProfileSwitch?.profile
+                ?: profileState.activeProfile
+                ?: profileState.profiles.firstOrNull()
+            sourceProfile?.avatarColorHex?.let(::parseHexColor) ?: Color(0xFF1E88E5)
+        }
+
         LaunchedEffect(gateScreen, onAppReady) {
             if (gateScreen != AppGateScreen.Main.name) {
                 onAppReady?.invoke(false)
@@ -779,7 +788,10 @@ fun App(
             when (currentGate) {
                 AppGateScreen.Loading.name,
                 AppGateScreen.ProfileSwitching.name -> {
-                    AppLaunchOverlay(modifier = Modifier.fillMaxSize())
+                    AppLaunchOverlay(
+                        profileColor = gateProfileColor,
+                        modifier = Modifier.fillMaxSize(),
+                    )
                 }
                 AppGateScreen.Auth.name -> {
                     AuthScreen(modifier = Modifier.fillMaxSize())

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
@@ -27,6 +27,7 @@ import com.nuvio.app.features.player.desktop.applyNativeDesktopWindowChrome
 import com.nuvio.app.features.player.desktop.installDesktopAppFullscreenShortcuts
 import com.nuvio.app.features.player.desktop.preloadNativePlayerBridgeAsync
 import com.nuvio.app.features.player.desktop.registerDesktopAppFullscreenToggle
+import com.nuvio.app.features.profiles.ProfileRepository
 import com.nuvio.app.features.settings.applyDesktopRendererPreference
 import java.awt.Desktop
 import java.awt.Color as AwtColor
@@ -44,6 +45,9 @@ fun main(args: Array<String>) {
     installDesktopOpenUriHandler()
     handleDesktopLaunchArgs(args)
     preloadNativePlayerBridgeAsync()
+    // Load cached profile data synchronously so the profile color is available
+    // on the very first Compose frame (matching Android's SharedPreferences behavior).
+    ProfileRepository.loadCachedProfiles()
 
     application {
         val smokePlayerUrl = (
@@ -55,25 +59,43 @@ fun main(args: Array<String>) {
         val wasMaximizedOnLastExit = remember { DesktopWindowModeStorage.loadWasMaximized() }
         val savedGeometry = remember { DesktopWindowModeStorage.loadWindowedGeometry() }
         val restoresMaximizedWindowPlacement = DesktopHostOs.current != DesktopHostOs.MACOS
+        val initialPlacement = when {
+            wasFullscreenOnLastExit && DesktopHostOs.current != DesktopHostOs.WINDOWS -> {
+                WindowPlacement.Fullscreen
+            }
+            wasMaximizedOnLastExit == false && savedGeometry != null -> {
+                WindowPlacement.Floating
+            }
+            restoresMaximizedWindowPlacement -> {
+                WindowPlacement.Maximized
+            }
+            else -> WindowPlacement.Floating
+        }
+        val isStartingMaximizedOrFullscreen =
+            initialPlacement == WindowPlacement.Maximized || initialPlacement == WindowPlacement.Fullscreen
+        val maxScreenBounds = remember {
+            runCatching {
+                java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment().maximumWindowBounds
+            }.getOrNull()
+        }
+        val initialWidth = when {
+            isStartingMaximizedOrFullscreen && maxScreenBounds != null -> maxScreenBounds.width.dp
+            savedGeometry != null -> savedGeometry.width.dp
+            else -> 1280.dp
+        }
+        val initialHeight = when {
+            isStartingMaximizedOrFullscreen && maxScreenBounds != null -> maxScreenBounds.height.dp
+            savedGeometry != null -> savedGeometry.height.dp
+            else -> 820.dp
+        }
         val windowState = rememberWindowState(
-            width = savedGeometry?.width?.dp ?: 1280.dp,
-            height = savedGeometry?.height?.dp ?: 820.dp,
+            width = initialWidth,
+            height = initialHeight,
             position = savedGeometry?.let { WindowPosition.Absolute(x = it.x.dp, y = it.y.dp) }
                 ?: WindowPosition.PlatformDefault,
             // Windows fullscreen is emulated natively (see DesktopAppFullscreenController)
             // rather than driven by WindowPlacement, so it's restored separately below.
-            placement = when {
-                wasFullscreenOnLastExit && DesktopHostOs.current != DesktopHostOs.WINDOWS -> {
-                    WindowPlacement.Fullscreen
-                }
-                wasMaximizedOnLastExit == false && savedGeometry != null -> {
-                    WindowPlacement.Floating
-                }
-                restoresMaximizedWindowPlacement -> {
-                    WindowPlacement.Maximized
-                }
-                else -> WindowPlacement.Floating
-            },
+            placement = initialPlacement,
         )
         val fullscreenController = remember { DesktopAppFullscreenController() }
 


### PR DESCRIPTION
## Summary

Preloads cached profile data synchronously in main() before Compose initialization so the active profile hue is available from the first frame, and initializes window dimensions using maximumWindowBounds when restoring maximized state on desktop.

## PR type

- [x] Small maintenance only, with no UI or behavior change

## Why

Ensures cached profile state is hydrated before Compose window layout begins to prevent layout color flashing, and avoids black frame initialization on maximized window restore.

## Desktop scope

Desktop application startup lifecycle on Windows, macOS, and Linux in Main.kt and shared App.kt gate overlay color resolution.

## Issue or approval

Small internal startup initialization and window geometry maintenance.

## UI / behavior impact

- [x] No UI change
- [x] No behavior change

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Intentionally does not modify any profile models, networking, sync logic, or UI layout components.

## Testing

Tested on Windows 11 Desktop (x64):
- Built with ./gradlew :composeApp:createDistributable
- Launched Nuvio.exe and verified smooth startup window appearance and profile color matching from frame 1
- Verified maximized window restoration without black screen flash

## Screenshots / Video

### Before
https://github.com/user-attachments/assets/b9237b7c-4728-4f03-ad61-9f62b13295a5


### After
https://github.com/user-attachments/assets/a028a61e-960f-43de-9f10-092f9bf0de9d


## Breaking changes

None

## Linked issues

No linked issue - small maintenance startup preloading and window bounds initialization.
