### PR TITLE
fix(player): make play and pause controls reliable

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
@@ -727,6 +727,13 @@ private fun PlayerScreenRuntime.handlePlayerControlsEvent(type: String, value: D
             controlsVisible = true
             controlsActivityTick += 1
         }
+        "setPlaybackState",
+        "setPlaybackStateQuiet" -> {
+            shouldPlay = value >= 0.5
+            if (type == "setPlaybackState") {
+                controlsVisible = true
+            }
+        }
         "reloadSources" -> {
             prepareSourcesForPlayerControls(forceRefresh = true)
         }

--- a/composeApp/src/desktopMain/native/macos/player_bridge.mm
+++ b/composeApp/src/desktopMain/native/macos/player_bridge.mm
@@ -2291,6 +2291,17 @@ static void setMpvOptionString(mpv_handle *mpv, const char *name, const char *va
         [self syncControls];
         return;
     }
+    if ([type isEqualToString:@"setPlaybackState"] || [type isEqualToString:@"setPlaybackStateQuiet"]) {
+        BOOL shouldPlay = value && value.doubleValue >= 0.5;
+        if (shouldPlay && [self isEnded]) {
+            [self seekToMilliseconds:0];
+        }
+        [self setPaused:!shouldPlay];
+        if (_eventSink && _eventMethod) {
+            [self sendPlayerEvent:type value:shouldPlay ? 1.0 : 0.0];
+        }
+        return;
+    }
     if ([type isEqualToString:@"toggleFullscreen"]) {
         [self beginFullscreenTransitionWithReason:@"control-toggle"];
     }

--- a/composeApp/src/desktopMain/native/windows/player_bridge.cpp
+++ b/composeApp/src/desktopMain/native/windows/player_bridge.cpp
@@ -1703,6 +1703,15 @@ private:
             syncControls();
             return;
         }
+        if (type == "setPlaybackState" || type == "setPlaybackStateQuiet") {
+            bool shouldPlay = value >= 0.5;
+            if (shouldPlay && isEnded()) {
+                seekToMilliseconds(0);
+            }
+            setPaused(!shouldPlay);
+            sendPlayerEvent(type, value);
+            return;
+        }
         sendPlayerEvent(type, value);
     }
 

--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -348,6 +348,10 @@ let selectedEpisodeSeason = null;
 let episodeStreamFilterId = "";
 let activeSubtitleLanguageKey = "";
 let pendingSubtitleOptionId = "";
+let pendingIsPlaying = null;
+let pendingPlaybackTimer = 0;
+let lastNativeIsPlaying = true;
+let suppressNextPointerToggleClick = false;
 let submitIntroDraft = {
   segmentType: "intro",
   startTime: "00:00",
@@ -2156,6 +2160,28 @@ const isTextEntryTarget = target => {
   return Boolean(element && element.type !== "range");
 };
 
+const requestPlaybackState = (eventType, revealControls) => {
+  const currentIsPlaying = pendingIsPlaying === null
+    ? Boolean(state.isPlaying)
+    : pendingIsPlaying;
+  const nextIsPlaying = !currentIsPlaying;
+  pendingIsPlaying = nextIsPlaying;
+  state = {
+    ...state,
+    isPlaying: nextIsPlaying,
+    controlsVisible: revealControls ? true : state.controlsVisible,
+  };
+  renderChrome();
+  send(eventType, nextIsPlaying ? 1 : 0);
+
+  window.clearTimeout(pendingPlaybackTimer);
+  pendingPlaybackTimer = window.setTimeout(() => {
+    pendingPlaybackTimer = 0;
+    pendingIsPlaying = null;
+    state = { ...state, isPlaying: lastNativeIsPlaying };
+    renderChrome();
+  }, 1500);
+};
 const shortcutCommandForEvent = event => {
   if (event.metaKey || event.ctrlKey || event.altKey) return "";
   switch (event.code) {
@@ -2373,6 +2399,14 @@ document.querySelectorAll("[data-command]").forEach(button => {
     }
     noteChromeActivity(true);
     const command = button.dataset.command;
+    if (command === "toggle") {
+      if (event.detail !== 0 && suppressNextPointerToggleClick) {
+        suppressNextPointerToggleClick = false;
+        return;
+      }
+      requestPlaybackState("setPlaybackState", true);
+      return;
+    }
     if (command === "audio") {
       openPlayerModal("audio");
       return;
@@ -2404,6 +2438,12 @@ document.querySelectorAll("[data-command]").forEach(button => {
     showCommandToast(command);
     send(command, 0);
   });
+});
+
+toggle.addEventListener("pointerdown", event => {
+  if (!event.isPrimary || event.button !== 0) return;
+  suppressNextPointerToggleClick = true;
+  requestPlaybackState("setPlaybackState", true);
 });
 
 openingOverlay.addEventListener("click", event => {
@@ -2651,11 +2691,18 @@ window.playerUpdate = update => {
   const subtitleTracks = normalizeTracks(update.subtitleTracks);
   const audioTracksChanged = trackListSignature(audioTracks) !== trackListSignature(state.audioTracks);
   const subtitleTracksChanged = trackListSignature(subtitleTracks) !== trackListSignature(state.subtitleTracks);
+  const nativeIsPlaying = !Boolean(update.paused);
+  lastNativeIsPlaying = nativeIsPlaying;
+  if (pendingIsPlaying !== null && nativeIsPlaying === pendingIsPlaying) {
+    pendingIsPlaying = null;
+    window.clearTimeout(pendingPlaybackTimer);
+    pendingPlaybackTimer = 0;
+  }
   state = {
     ...state,
     durationMs,
     positionMs,
-    isPlaying: !Boolean(update.paused),
+    isPlaying: pendingIsPlaying === null ? nativeIsPlaying : pendingIsPlaying,
     isLoading: Boolean(update.loading || update.isLoading),
     audioTracks,
     subtitleTracks,
@@ -2682,7 +2729,10 @@ window.playerControls = nextState => {
   const previousEpisodeStreamsVisible = Boolean(state.episodeStreamsVisible);
   const previousSelectedSubtitleLanguageKey = state.selectedSubtitleLanguageKey || "__off__";
   const previousSelectedSubtitleOptionId = state.selectedSubtitleOptionId || "";
-  state = { ...state, ...nextState };
+  const currentPlaybackState = pendingIsPlaying === null
+    ? state.isPlaying
+    : pendingIsPlaying;
+  state = { ...state, ...nextState, isPlaying: currentPlaybackState };
   hasReceivedPlayerControls = true;
   const closeToken = Number(state.closeModalsToken) || 0;
   if (closeToken !== previousCloseToken) {
@@ -2778,6 +2828,10 @@ document.addEventListener("keydown", event => {
   }
   if (command === "keyboardVolumeDown") {
     sendKeyboardVolume(-1);
+    return;
+  }
+  if (command === "keyboardToggle") {
+    requestPlaybackState("setPlaybackStateQuiet", false);
     return;
   }
   showCommandToast(command);


### PR DESCRIPTION
## Summary

Makes the Desktop player play and pause control respond immediately and consistently.

Each mouse press now sends one explicit desired playback state directly to the native player. The matching release click is consumed instead of toggling a second time, and the button updates immediately while waiting for libmpv to confirm the state. Keyboard play and pause uses the same explicit path.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

The current button can feel delayed, ignore a click, or require another click. A slightly longer press can also be handled once on pointer down and again on click release, which can undo the first playback change.

The native bridge previously depended on a generic toggle event and later state synchronization. Sending the intended play or pause state directly removes that ambiguity.

## Desktop scope

Windows and macOS native player bridges and the shared Desktop player control event path. No Android, mobile, subtitle, stream, or auto-play behavior is changed.

## Issue or approval

Fixes #365

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

This only changes Desktop play and pause input handling. Seeking, volume, track selection, buffering, stream loading, end-of-file handling, auto-play, and player layout are unchanged.

## Testing

Windows 11, built from source against current `Dev`.

- Checked repeated mouse play and pause input, including quick clicks and longer presses.
- Checked keyboard play and pause through the same explicit state path.
- Checked immediate icon state followed by native libmpv confirmation.
- Ran `node --check composeApp/src/desktopMain/resources/player-ui/controls.js`.
- Ran a clean `./gradlew.bat :composeApp:buildWindowsPlayerBridge :composeApp:desktopTest` build.

The macOS bridge follows the same explicit state path but was not runtime-tested on macOS.

## Screenshots / Video

Not a UI change. The existing play and pause button is unchanged.

## Breaking changes

None.

## Linked issues

Fixes #365