### PR TITLE
Fix video-surface click to pause/resume playback

### DIFF
--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -2776,7 +2776,7 @@ root.addEventListener("click", event => {
   if (event.target.closest("button,input")) return;
   window.clearTimeout(tapTimer);
   tapTimer = window.setTimeout(() => {
-    toggleChrome();
+    requestPlaybackState("setPlaybackStateQuiet", false);
   }, 220);
 });
 

--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -1953,7 +1953,6 @@ const isInteractingWithChrome = () =>
 
 const canAutoHideChrome = showOpening => Boolean(
   state.controlsVisible &&
-  state.isPlaying &&
   !state.isLoading &&
   !activeModal &&
   !isScrubbing &&


### PR DESCRIPTION
## Summary

Clicking anywhere on the video surface now toggles play/pause through the same `requestPlaybackState` path used by the play/pause button and keyboard shortcut, instead of only toggling the chrome UI. Chrome auto-hide can now also run while paused, so the pause metadata overlay can appear.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Clicking the video surface only toggled the chrome overlay visibility; it did not pause or resume playback. Users expect clicking the video to toggle playback, matching the play/pause button and keyboard shortcut (also requested in #126, #230).

Fixing this by routing the click through `requestPlaybackState` surfaced a second issue: the auto-hide timer for the chrome only ran while `isPlaying` was true, so once the video click could pause playback, the chrome could get stuck visible indefinitely on pause and the pause metadata overlay (which requires the chrome to be hidden) could never appear. Removed the `isPlaying` gate so the existing idle-timeout auto-hide also applies while paused.

## Desktop scope

Windows, macOS, Linux — the change is in the shared `controls.js` web UI overlay used by the native desktop player. No native bridge changes.

## Issue or approval

Fixes the behavior where clicking the video does not pause/resume playback. Related: #126, #230.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the video-surface click handler and the chrome auto-hide eligibility check are changed. Double-click-to-fullscreen, the play/pause button, and keyboard shortcuts are untouched (they already use `requestPlaybackState`).

## Testing

- `node --check composeApp/src/desktopMain/resources/player-ui/controls.js`
- Manually verified on Windows: clicking the video toggles play/pause, and the pause metadata overlay appears after the chrome auto-hides while paused.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Related: #126, #230.
