### PR TITLE
Add Discord Rich Presence integration

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -126,6 +126,19 @@ abstract class GenerateRuntimeConfigsTask : DefaultTask() {
             )
         }
 
+        outDir.resolve("com/nuvio/app/features/discordrpc").apply {
+            mkdirs()
+            resolve("DiscordConfig.kt").writeText(
+                """
+                |package com.nuvio.app.features.discordrpc
+                |
+                |object DiscordConfig {
+                |    const val CLIENT_ID = "${props.getProperty("NUVIO_DISCORD_CLIENT_ID", "1538974392376369212")}"
+                |}
+                """.trimMargin()
+            )
+        }
+
         outDir.resolve("com/nuvio/app/features/player/skip").apply {
             mkdirs()
             resolve("IntroDbConfig.kt").writeText(

--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/settings/DiscordRichPresenceStorage.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/settings/DiscordRichPresenceStorage.android.kt
@@ -1,0 +1,10 @@
+package com.nuvio.app.features.settings
+
+internal actual object DiscordRichPresencePlatform {
+    actual val isSupported: Boolean = false
+}
+
+internal actual object DiscordRichPresenceStorage {
+    actual fun loadEnabled(): Boolean? = null
+    actual fun saveEnabled(enabled: Boolean) = Unit
+}

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -487,6 +487,7 @@
     <string name="settings_advanced_section_startup">STARTUP</string>
     <string name="settings_advanced_section_windows_graphics">WINDOWS GRAPHICS</string>
     <string name="settings_advanced_section_diagnostics">DIAGNOSTICS</string>
+    <string name="settings_advanced_section_discord">DISCORD</string>
     <string name="settings_advanced_section_cache">CACHE</string>
     <string name="settings_advanced_remember_last_profile">Remember Last Profile</string>
     <string name="settings_advanced_remember_last_profile_description">Remember last selected profile at startup</string>
@@ -496,6 +497,8 @@
     <string name="settings_advanced_sentry_reports">Sentry Crash Reports</string>
     <string name="settings_advanced_sentry_reports_subtitle">Send crash and ANR reports with safe context. On by default.</string>
     <string name="settings_advanced_sentry_reports_subtitle_desktop">Send crash reports with safe diagnostic context. On by default.</string>
+    <string name="settings_advanced_discord_rich_presence">Discord Rich Presence</string>
+    <string name="settings_advanced_discord_rich_presence_description">Show what you're browsing or watching on your Discord profile. Off by default.</string>
     <string name="sentry_enable_dialog_title">Turn on crash reports?</string>
     <string name="sentry_enable_dialog_subtitle">Crash reports help identify device-specific failures without asking you to reproduce the issue with ADB logs.</string>
     <string name="sentry_enable_dialog_subtitle_desktop">Crash reports help identify Windows and macOS failures without asking you to collect logs manually.</string>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
@@ -138,7 +138,9 @@ import com.nuvio.app.core.ui.NuvioTokens
 import com.nuvio.app.core.ui.LocalNuvioBottomNavigationOverlayPadding
 import com.nuvio.app.core.ui.NativeNavigationTab
 import com.nuvio.app.core.ui.NativeProfileSwitcherController
+import com.nuvio.app.core.ui.AppPresenceState
 import com.nuvio.app.core.ui.NativeTabBridge
+import com.nuvio.app.core.ui.PresenceSnapshot
 import com.nuvio.app.core.ui.desktopUiScaleForWindow
 import com.nuvio.app.core.ui.isLiquidGlassNativeTabBarSupported
 import com.nuvio.app.core.ui.localizedContinueWatchingSubtitle
@@ -1098,6 +1100,19 @@ private fun MainAppContent(
         if (selectedTab != AppScreenTab.Search) {
             searchFocusRequestCount = 0
         }
+    }
+
+    LaunchedEffect(selectedTab, navBackStack.lastOrNull()) {
+        val topRoute = navBackStack.lastOrNull()
+        if (topRoute is PlayerRoute) return@LaunchedEffect
+        val detailTitle = (topRoute as? DetailRoute)?.title
+        AppPresenceState.publish(
+            if (!detailTitle.isNullOrBlank()) {
+                PresenceSnapshot.Details(detailTitle)
+            } else {
+                PresenceSnapshot.Tab(selectedTab)
+            },
+        )
     }
 
     var profileSwitchLoading by remember { mutableStateOf(false) }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/AppPresenceState.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/AppPresenceState.kt
@@ -1,0 +1,29 @@
+package com.nuvio.app.core.ui
+
+import com.nuvio.app.AppScreenTab
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+internal object AppPresenceState {
+    private val _current = MutableStateFlow<PresenceSnapshot?>(null)
+    val current: StateFlow<PresenceSnapshot?> = _current.asStateFlow()
+
+    fun publish(snapshot: PresenceSnapshot?) {
+        _current.value = snapshot
+    }
+}
+
+internal sealed interface PresenceSnapshot {
+    data class Tab(val tab: AppScreenTab) : PresenceSnapshot
+
+    data class Details(val title: String) : PresenceSnapshot
+
+    data class Player(
+        val title: String,
+        val episodeLabel: String?,
+        val posterUrl: String?,
+        val isPlaying: Boolean,
+        val positionMs: Long,
+    ) : PresenceSnapshot
+}

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.layout.onSizeChanged
 import co.touchlab.kermit.Logger
 import com.nuvio.app.core.format.formatReleaseDateForDisplay
 import com.nuvio.app.core.i18n.localizedByteUnit
+import com.nuvio.app.core.ui.AppPresenceState
+import com.nuvio.app.core.ui.PresenceSnapshot
 import com.nuvio.app.core.ui.nuvio
 import com.nuvio.app.features.debrid.DebridSettingsRepository
 import com.nuvio.app.features.debrid.DirectDebridPlaybackResolver
@@ -51,6 +53,25 @@ internal fun PlayerScreenRuntime.RenderPlayerRuntimeUi() {
     val episodeNumber = activeEpisodeNumber
     val episodeTitle = activeEpisodeTitle
     val isEpisode = seasonNumber != null && episodeNumber != null
+
+    LaunchedEffect(runtime.title, runtime.poster, seasonNumber, episodeNumber, episodeTitle, playbackSnapshot.isPlaying) {
+        val episodeLabel = if (isEpisode) {
+            val base = "S${seasonNumber}E${episodeNumber}"
+            if (!episodeTitle.isNullOrBlank()) "$base - $episodeTitle" else base
+        } else {
+            null
+        }
+        AppPresenceState.publish(
+            PresenceSnapshot.Player(
+                title = runtime.title,
+                episodeLabel = episodeLabel,
+                posterUrl = runtime.poster,
+                isPlaying = playbackSnapshot.isPlaying,
+                positionMs = playbackSnapshot.positionMs,
+            ),
+        )
+    }
+
     val currentGestureFeedback = liveGestureFeedback ?: gestureFeedback
     val isP2pPlaybackActive = activeTorrentInfoHash != null
     val p2pConnecting = p2pStreamingState as? P2pStreamingState.Connecting

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/AdvancedSettingsPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/AdvancedSettingsPage.kt
@@ -37,6 +37,8 @@ import nuvio.composeapp.generated.resources.action_cancel
 import nuvio.composeapp.generated.resources.settings_advanced_clear_cw_cache
 import nuvio.composeapp.generated.resources.settings_advanced_clear_cw_cache_done
 import nuvio.composeapp.generated.resources.settings_advanced_clear_cw_cache_subtitle
+import nuvio.composeapp.generated.resources.settings_advanced_discord_rich_presence
+import nuvio.composeapp.generated.resources.settings_advanced_discord_rich_presence_description
 import nuvio.composeapp.generated.resources.settings_advanced_opengl_renderer
 import nuvio.composeapp.generated.resources.settings_advanced_opengl_renderer_description
 import nuvio.composeapp.generated.resources.settings_advanced_opengl_renderer_external_description
@@ -44,6 +46,7 @@ import nuvio.composeapp.generated.resources.settings_advanced_remember_last_prof
 import nuvio.composeapp.generated.resources.settings_advanced_remember_last_profile_description
 import nuvio.composeapp.generated.resources.settings_advanced_section_cache
 import nuvio.composeapp.generated.resources.settings_advanced_section_diagnostics
+import nuvio.composeapp.generated.resources.settings_advanced_section_discord
 import nuvio.composeapp.generated.resources.settings_advanced_section_startup
 import nuvio.composeapp.generated.resources.settings_advanced_section_windows_graphics
 import nuvio.composeapp.generated.resources.settings_advanced_sentry_reports
@@ -159,6 +162,30 @@ internal fun LazyListScope.advancedSettingsContent(
                         showSentryDialog = false
                     },
                 )
+            }
+        }
+    }
+    if (DiscordRichPresenceRepository.isSupported) {
+        item {
+            val discordEnabledFlow = remember {
+                DiscordRichPresenceRepository.ensureLoaded()
+                DiscordRichPresenceRepository.enabled
+            }
+            val discordEnabled by discordEnabledFlow.collectAsStateWithLifecycle()
+
+            SettingsSection(
+                title = stringResource(Res.string.settings_advanced_section_discord),
+                isTablet = isTablet,
+            ) {
+                SettingsGroup(isTablet = isTablet) {
+                    SettingsSwitchRow(
+                        title = stringResource(Res.string.settings_advanced_discord_rich_presence),
+                        description = stringResource(Res.string.settings_advanced_discord_rich_presence_description),
+                        checked = discordEnabled,
+                        isTablet = isTablet,
+                        onCheckedChange = DiscordRichPresenceRepository::setEnabled,
+                    )
+                }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/DiscordRichPresenceRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/DiscordRichPresenceRepository.kt
@@ -1,0 +1,28 @@
+package com.nuvio.app.features.settings
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+internal object DiscordRichPresenceRepository {
+    val isSupported: Boolean
+        get() = DiscordRichPresencePlatform.isSupported
+
+    private val _enabled = MutableStateFlow(false)
+    val enabled: StateFlow<Boolean> = _enabled.asStateFlow()
+
+    private var hasLoaded = false
+
+    fun ensureLoaded() {
+        if (hasLoaded) return
+        hasLoaded = true
+        _enabled.value = DiscordRichPresenceStorage.loadEnabled() ?: false
+    }
+
+    fun setEnabled(enabled: Boolean) {
+        ensureLoaded()
+        if (_enabled.value == enabled) return
+        _enabled.value = enabled
+        DiscordRichPresenceStorage.saveEnabled(enabled)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/DiscordRichPresenceStorage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/DiscordRichPresenceStorage.kt
@@ -1,0 +1,10 @@
+package com.nuvio.app.features.settings
+
+internal expect object DiscordRichPresencePlatform {
+    val isSupported: Boolean
+}
+
+internal expect object DiscordRichPresenceStorage {
+    fun loadEnabled(): Boolean?
+    fun saveEnabled(enabled: Boolean)
+}

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.window.rememberWindowState
 import androidx.compose.ui.unit.dp
 import com.nuvio.app.core.deeplink.handleAppUrl
 import com.nuvio.app.core.diagnostics.SentryInitializer
+import com.nuvio.app.features.discordrpc.DiscordPresenceManager
 import com.nuvio.app.features.p2p.P2pStreamingEngine
 import com.nuvio.app.features.plugins.configureDesktopQuickJsLibrary
 import com.nuvio.app.features.player.PlatformPlayerSurface
@@ -48,6 +49,7 @@ fun main(args: Array<String>) {
     // Load cached profile data synchronously so the profile color is available
     // on the very first Compose frame (matching Android's SharedPreferences behavior).
     ProfileRepository.loadCachedProfiles()
+    DiscordPresenceManager.start()
 
     application {
         val smokePlayerUrl = (
@@ -102,6 +104,7 @@ fun main(args: Array<String>) {
         Window(
             onCloseRequest = {
                 P2pStreamingEngine.shutdown()
+                DiscordPresenceManager.shutdown()
                 SentryInitializer.close()
                 exitApplication()
             },

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/discordrpc/DiscordActivity.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/discordrpc/DiscordActivity.kt
@@ -1,0 +1,23 @@
+package com.nuvio.app.features.discordrpc
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class DiscordActivity(
+    val details: String? = null,
+    val state: String? = null,
+    val timestamps: DiscordActivityTimestamps? = null,
+    val assets: DiscordActivityAssets? = null,
+)
+
+@Serializable
+internal data class DiscordActivityTimestamps(
+    val start: Long? = null,
+)
+
+@Serializable
+internal data class DiscordActivityAssets(
+    @SerialName("large_image") val largeImage: String? = null,
+    @SerialName("large_text") val largeText: String? = null,
+)

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/discordrpc/DiscordIpcClient.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/discordrpc/DiscordIpcClient.kt
@@ -1,0 +1,182 @@
+package com.nuvio.app.features.discordrpc
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.io.Closeable
+import java.io.EOFException
+import java.io.RandomAccessFile
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.channels.SocketChannel
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Locale
+import java.util.UUID
+
+private const val OpcodeHandshake = 0
+private const val OpcodeFrame = 1
+
+private val discordIpcJson = Json { ignoreUnknownKeys = true }
+
+@Serializable
+private data class HandshakePayload(
+    val v: Int = 1,
+    @SerialName("client_id") val clientId: String,
+)
+
+@Serializable
+private data class SetActivityArgs(
+    val pid: Int,
+    val activity: DiscordActivity?,
+)
+
+@Serializable
+private data class SetActivityCommand(
+    val cmd: String = "SET_ACTIVITY",
+    val nonce: String,
+    val args: SetActivityArgs,
+)
+
+private interface DiscordPipe : Closeable {
+    fun write(bytes: ByteArray)
+    fun readFully(buffer: ByteArray)
+}
+
+private class WindowsNamedPipe(private val file: RandomAccessFile) : DiscordPipe {
+    override fun write(bytes: ByteArray) = file.write(bytes)
+    override fun readFully(buffer: ByteArray) = file.readFully(buffer)
+    override fun close() = file.close()
+}
+
+private class UnixSocketPipe(private val channel: SocketChannel) : DiscordPipe {
+    override fun write(bytes: ByteArray) {
+        val buffer = ByteBuffer.wrap(bytes)
+        while (buffer.hasRemaining()) channel.write(buffer)
+    }
+
+    override fun readFully(buffer: ByteArray) {
+        val target = ByteBuffer.wrap(buffer)
+        while (target.hasRemaining()) {
+            if (channel.read(target) < 0) throw EOFException("discord ipc socket closed")
+        }
+    }
+
+    override fun close() = channel.close()
+}
+
+private fun openWindowsPipe(): DiscordPipe? {
+    for (i in 0..9) {
+        val file = runCatching { RandomAccessFile("\\\\.\\pipe\\discord-ipc-$i", "rw") }.getOrNull()
+        if (file != null) return WindowsNamedPipe(file)
+    }
+    return null
+}
+
+private fun openUnixSocket(): DiscordPipe? {
+    val candidateDirs = listOfNotNull(
+        System.getenv("XDG_RUNTIME_DIR"),
+        System.getenv("TMPDIR"),
+        "/tmp",
+        "/var/run",
+    )
+    for (dir in candidateDirs) {
+        for (i in 0..9) {
+            val path = Path.of(dir, "discord-ipc-$i")
+            if (!Files.exists(path)) continue
+            val channel = runCatching {
+                SocketChannel.open(StandardProtocolFamily.UNIX).apply {
+                    connect(UnixDomainSocketAddress.of(path))
+                }
+            }.getOrNull()
+            if (channel != null) return UnixSocketPipe(channel)
+        }
+    }
+    return null
+}
+
+private fun openTransport(): DiscordPipe? {
+    val osName = System.getProperty("os.name").orEmpty().lowercase(Locale.ROOT)
+    return if (osName.contains("win")) openWindowsPipe() else openUnixSocket()
+}
+
+private fun writeFrame(pipe: DiscordPipe, opcode: Int, payload: String) {
+    val payloadBytes = payload.toByteArray(Charsets.UTF_8)
+    val header = ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN)
+    header.putInt(opcode)
+    header.putInt(payloadBytes.size)
+    pipe.write(header.array())
+    pipe.write(payloadBytes)
+}
+
+private fun readFrame(pipe: DiscordPipe): Pair<Int, String> {
+    val headerBytes = ByteArray(8)
+    pipe.readFully(headerBytes)
+    val header = ByteBuffer.wrap(headerBytes).order(ByteOrder.LITTLE_ENDIAN)
+    val opcode = header.int
+    val length = header.int
+    require(length in 0..1_048_576) { "unreasonable discord ipc frame length: $length" }
+    val payloadBytes = ByteArray(length)
+    if (length > 0) pipe.readFully(payloadBytes)
+    return opcode to payloadBytes.toString(Charsets.UTF_8)
+}
+
+internal class DiscordIpcClient(private val clientId: String) {
+    private val log = Logger.withTag("DiscordIpcClient")
+    private val pid = ProcessHandle.current().pid().toInt()
+    private var pipe: DiscordPipe? = null
+
+    suspend fun connect(): Boolean = withContext(Dispatchers.IO) {
+        if (pipe != null) return@withContext true
+        val opened = openTransport() ?: return@withContext false
+        try {
+            writeFrame(opened, OpcodeHandshake, discordIpcJson.encodeToString(HandshakePayload(clientId = clientId)))
+            val (opcode, payload) = readFrame(opened)
+            val evt = discordIpcJson.parseToJsonElement(payload).jsonObject["evt"]?.jsonPrimitive?.contentOrNull
+            check(opcode == OpcodeFrame && evt == "READY") { "unexpected handshake response: opcode=$opcode evt=$evt" }
+            pipe = opened
+            true
+        } catch (e: CancellationException) {
+            runCatching { opened.close() }
+            throw e
+        } catch (e: Exception) {
+            log.d { "handshake failed: ${e.message}" }
+            runCatching { opened.close() }
+            false
+        }
+    }
+
+    suspend fun setActivity(activity: DiscordActivity?): Boolean = withContext(Dispatchers.IO) {
+        val currentPipe = pipe ?: return@withContext false
+        try {
+            val command = SetActivityCommand(
+                nonce = UUID.randomUUID().toString(),
+                args = SetActivityArgs(pid = pid, activity = activity),
+            )
+            writeFrame(currentPipe, OpcodeFrame, discordIpcJson.encodeToString(command))
+            readFrame(currentPipe)
+            true
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.d { "setActivity failed: ${e.message}" }
+            disconnect()
+            false
+        }
+    }
+
+    suspend fun disconnect() = withContext(Dispatchers.IO) {
+        runCatching { pipe?.close() }
+        pipe = null
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/discordrpc/DiscordIpcClient.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/discordrpc/DiscordIpcClient.kt
@@ -27,7 +27,10 @@ import java.util.UUID
 private const val OpcodeHandshake = 0
 private const val OpcodeFrame = 1
 
-private val discordIpcJson = Json { ignoreUnknownKeys = true }
+private val discordIpcJson = Json {
+    ignoreUnknownKeys = true
+    explicitNulls = true
+}
 
 @Serializable
 private data class HandshakePayload(
@@ -43,7 +46,7 @@ private data class SetActivityArgs(
 
 @Serializable
 private data class SetActivityCommand(
-    val cmd: String = "SET_ACTIVITY",
+    val cmd: String,
     val nonce: String,
     val args: SetActivityArgs,
 )
@@ -160,11 +163,21 @@ internal class DiscordIpcClient(private val clientId: String) {
         val currentPipe = pipe ?: return@withContext false
         try {
             val command = SetActivityCommand(
+                cmd = "SET_ACTIVITY",
                 nonce = UUID.randomUUID().toString(),
                 args = SetActivityArgs(pid = pid, activity = activity),
             )
-            writeFrame(currentPipe, OpcodeFrame, discordIpcJson.encodeToString(command))
-            readFrame(currentPipe)
+            val encodedCommand = discordIpcJson.encodeToString(command)
+            writeFrame(currentPipe, OpcodeFrame, encodedCommand)
+            val (responseOpcode, responsePayload) = readFrame(currentPipe)
+            val response = discordIpcJson.parseToJsonElement(responsePayload).jsonObject
+            val responseCommand = response["cmd"]?.jsonPrimitive?.contentOrNull
+            val responseEvent = response["evt"]?.jsonPrimitive?.contentOrNull
+            val responseNonce = response["nonce"]?.jsonPrimitive?.contentOrNull
+            check(responseOpcode == OpcodeFrame) { "unexpected Discord response opcode=$responseOpcode" }
+            check(responseCommand == "SET_ACTIVITY" && responseNonce == command.nonce) {
+                "unexpected Discord response cmd=$responseCommand evt=$responseEvent nonce=$responseNonce"
+            }
             true
         } catch (e: CancellationException) {
             throw e

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/discordrpc/DiscordPresenceManager.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/discordrpc/DiscordPresenceManager.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -43,12 +44,13 @@ internal object DiscordPresenceManager {
         syncJob?.cancel()
         syncJob = scope.launch {
             while (isActive) {
-                if (client.connect()) {
+                val connected = client.connect()
+                if (connected) {
                     lastActivity = null
                     try {
-                        AppPresenceState.current.collectLatest { snapshot ->
-                            val activity = snapshot?.toDiscordActivity()
-                            if (activity == lastActivity) return@collectLatest
+                        AppPresenceState.current.collect { snapshot ->
+                            val activity = snapshot?.toDiscordActivity() ?: DiscordActivity(details = "Browsing Nuvio")
+                            if (activity == lastActivity) return@collect
                             if (client.setActivity(activity)) {
                                 lastActivity = activity
                             } else {
@@ -68,19 +70,31 @@ internal object DiscordPresenceManager {
         syncJob?.cancel()
         syncJob = null
         if (lastActivity != null) client.setActivity(null)
+        delay(300L)
         lastActivity = null
         client.disconnect()
     }
 }
 
+private fun String.toDiscordEpisodeLabel(): String {
+    val match = Regex("""S(\d+)E(\d+)(?:\s*-\s*(.*))?""").matchEntire(trim())
+        ?: return this
+    val season = match.groupValues[1]
+    val episode = match.groupValues[2]
+    val title = match.groupValues.getOrNull(3).orEmpty().trim()
+    return if (title.isBlank()) "S$season, E$episode" else "S$season, E$episode: $title"
+}
+
+
 private fun PresenceSnapshot.toDiscordActivity(): DiscordActivity = when (this) {
     is PresenceSnapshot.Tab -> DiscordActivity(details = "Browsing ${tab.name}")
     is PresenceSnapshot.Details -> DiscordActivity(details = "Viewing $title")
     is PresenceSnapshot.Player -> DiscordActivity(
-        details = title,
-        state = episodeLabel ?: if (isPlaying) "Watching" else "Paused",
+        details = if (isPlaying) "Watching: $title" else "Paused: $title",
+        state = episodeLabel?.toDiscordEpisodeLabel() ?: if (isPlaying) "Watching" else "Paused",
         timestamps = if (isPlaying) {
-            DiscordActivityTimestamps(start = System.currentTimeMillis() - positionMs)
+            // Discord expects Unix timestamps in seconds, not milliseconds.
+            DiscordActivityTimestamps(start = (System.currentTimeMillis() - positionMs) / 1_000L)
         } else {
             null
         },

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/discordrpc/DiscordPresenceManager.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/discordrpc/DiscordPresenceManager.kt
@@ -1,0 +1,89 @@
+package com.nuvio.app.features.discordrpc
+
+import co.touchlab.kermit.Logger
+import com.nuvio.app.core.ui.AppPresenceState
+import com.nuvio.app.core.ui.PresenceSnapshot
+import com.nuvio.app.features.settings.DiscordRichPresenceRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+
+private class DiscordDisconnected : Exception()
+
+private const val ReconnectDelayMs = 15_000L
+
+internal object DiscordPresenceManager {
+    private val log = Logger.withTag("DiscordPresenceManager")
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val client = DiscordIpcClient(DiscordConfig.CLIENT_ID)
+    private var syncJob: Job? = null
+    private var lastActivity: DiscordActivity? = null
+
+    fun start() {
+        if (DiscordConfig.CLIENT_ID.isBlank()) return
+        DiscordRichPresenceRepository.ensureLoaded()
+        scope.launch {
+            DiscordRichPresenceRepository.enabled.collectLatest { enabled ->
+                if (enabled) startSync() else stopSync()
+            }
+        }
+    }
+
+    fun shutdown() {
+        runBlocking { stopSync() }
+    }
+
+    private suspend fun startSync() {
+        syncJob?.cancel()
+        syncJob = scope.launch {
+            while (isActive) {
+                if (client.connect()) {
+                    lastActivity = null
+                    try {
+                        AppPresenceState.current.collectLatest { snapshot ->
+                            val activity = snapshot?.toDiscordActivity()
+                            if (activity == lastActivity) return@collectLatest
+                            if (client.setActivity(activity)) {
+                                lastActivity = activity
+                            } else {
+                                throw DiscordDisconnected()
+                            }
+                        }
+                    } catch (e: DiscordDisconnected) {
+                        log.d { "Discord IPC disconnected, retrying" }
+                    }
+                }
+                delay(ReconnectDelayMs)
+            }
+        }
+    }
+
+    private suspend fun stopSync() {
+        syncJob?.cancel()
+        syncJob = null
+        if (lastActivity != null) client.setActivity(null)
+        lastActivity = null
+        client.disconnect()
+    }
+}
+
+private fun PresenceSnapshot.toDiscordActivity(): DiscordActivity = when (this) {
+    is PresenceSnapshot.Tab -> DiscordActivity(details = "Browsing ${tab.name}")
+    is PresenceSnapshot.Details -> DiscordActivity(details = "Viewing $title")
+    is PresenceSnapshot.Player -> DiscordActivity(
+        details = title,
+        state = episodeLabel ?: if (isPlaying) "Watching" else "Paused",
+        timestamps = if (isPlaying) {
+            DiscordActivityTimestamps(start = System.currentTimeMillis() - positionMs)
+        } else {
+            null
+        },
+        assets = posterUrl?.let { DiscordActivityAssets(largeImage = it, largeText = title) },
+    )
+}

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/settings/DiscordRichPresenceStorage.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/settings/DiscordRichPresenceStorage.desktop.kt
@@ -1,0 +1,19 @@
+package com.nuvio.app.features.settings
+
+import com.nuvio.app.core.storage.DesktopStorage
+
+internal actual object DiscordRichPresencePlatform {
+    actual val isSupported: Boolean = true
+}
+
+internal actual object DiscordRichPresenceStorage {
+    private const val enabledKey = "enabled"
+    private val store = DesktopStorage.store("nuvio_discord_rich_presence")
+
+    actual fun loadEnabled(): Boolean? =
+        if (store.contains(enabledKey)) store.getBoolean(enabledKey) else null
+
+    actual fun saveEnabled(enabled: Boolean) {
+        store.putBoolean(enabledKey, enabled)
+    }
+}

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/settings/DiscordRichPresenceStorage.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/settings/DiscordRichPresenceStorage.ios.kt
@@ -1,0 +1,10 @@
+package com.nuvio.app.features.settings
+
+internal actual object DiscordRichPresencePlatform {
+    actual val isSupported: Boolean = false
+}
+
+internal actual object DiscordRichPresenceStorage {
+    actual fun loadEnabled(): Boolean? = null
+    actual fun saveEnabled(enabled: Boolean) = Unit
+}


### PR DESCRIPTION
## Summary

Adds an opt-in Discord Rich Presence integration for the desktop app. When enabled, Discord shows what you're doing in Nuvio: browsing a tab, viewing a title's details, or watching (with poster, episode info, and elapsed time).

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [x] Approved larger or directional change

## Why

Requested feature, approved as maintainer. Implemented as a self-contained IPC client talking directly to Discord's local socket/named-pipe protocol (no new dependency), gated behind a single off-by-default toggle in Settings → Advanced.

## Desktop scope

Windows, macOS, Linux.

## Issue or approval

Approved as maintainer.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only adds the new Discord IPC client/manager, a presence-state bridge from navigation/player, and one settings toggle. No existing behavior changes for users who leave it off (default).

## Testing

- `./gradlew :composeApp:compileKotlinDesktop` passes.
- Manual: TODO — needs a real desktop build with the actual Discord client running to confirm the IPC handshake, activity updates, and poster image rendering end to end.

## Screenshots / Video

Not a UI change (aside from the one new settings toggle row).

## Breaking changes

None.

## Linked issues

No linked issue — maintainer-approved feature.
