### PR TITLE
fix(home): standardize home section horizontal padding to 16dp to align with other screens

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/components/HomeSectionLayout.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/components/HomeSectionLayout.kt
@@ -3,4 +3,4 @@ package com.nuvio.app.features.home.components
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
-internal fun homeSectionHorizontalPaddingForWidth(maxWidthDp: Float): Dp = 16.dp
+internal fun homeSectionHorizontalPaddingForWidth(): Dp = 16.dp

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/components/HomeSectionLayout.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/components/HomeSectionLayout.kt
@@ -3,10 +3,4 @@ package com.nuvio.app.features.home.components
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
-internal fun homeSectionHorizontalPaddingForWidth(maxWidthDp: Float): Dp =
-    when {
-        maxWidthDp >= 1440f -> 32.dp
-        maxWidthDp >= 1024f -> 28.dp
-        maxWidthDp >= 768f -> 24.dp
-        else -> 16.dp
-    }
+internal fun homeSectionHorizontalPaddingForWidth(maxWidthDp: Float): Dp = 16.dp


### PR DESCRIPTION
## Summary

Standardizes `homeSectionHorizontalPaddingForWidth` to return standard `16.dp` so that HomeScreen sections align identically to Library, Settings, and Search screens.

## PR type

- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

`HomeScreen` was previously applying adaptive responsive padding (`24.dp`, `28.dp`, and `32.dp`) on wide viewports, while all other screens (Library, Settings, Search headers) use the standard `16.dp` margin. On Desktop, this caused HomeScreen content to be noticeably more indented to the right (by an extra 8dp–16dp) than other tabs, creating a visual jumping artifact when switching tabs. Standardizing to `16.dp` aligns all screens seamlessly.

## Desktop scope

Common desktop/compose UI in `HomeSectionLayout.kt` affecting layout alignment across all desktop platforms (Windows, macOS, Linux).

## Issue or approval

Fixes #376

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only standardizes `homeSectionHorizontalPaddingForWidth` to `16.dp`. Does not modify any carousel sizing, item widths, or navigation tab behaviors.

## Testing

- Tested on Windows 11 with `.\gradlew compileKotlinDesktop` and `.\gradlew :composeApp:run`.
- Verified HomeScreen left margin aligns with Library, Settings, and Search tabs.
- Verified tab switching between Home, Library, and Settings has zero horizontal jumping.

## Screenshots / Video

- **Before**: HomeScreen was indented by 28dp/32dp, misaligned with Library and Settings tabs at 16dp.
- 
<img width="1855" height="1079" alt="image" src="https://github.com/user-attachments/assets/0862f6a0-a93a-4031-9157-eb8d7d225029" />

- **After**: HomeScreen and other tabs share the exact same 16dp left padding.
- 
<img width="1858" height="1079" alt="image" src="https://github.com/user-attachments/assets/d6645c2b-c1bd-434f-97e0-2b84221ce888" />


## Breaking changes

None.

## Linked issues

Fixes #376
