### PR TITLE
feat(player): add visual buffer and preload progress indicator to seekbar

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -881,7 +881,6 @@ val buildWindowsPlayerBridge = tasks.register<Exec>("buildWindowsPlayerBridge") 
     outputs.file(windowsPlayerBridgeOutput)
     outputs.file(windowsPlayerBridgeImportLib)
     outputs.file(windowsPlayerBridgePdb)
-    onlyIf { !windowsPlayerBridgeOutput.get().asFile.exists() }
     commandLine(windowsPlayerBridgeCommand)
 }
 

--- a/composeApp/src/desktopMain/native/macos/player_bridge.mm
+++ b/composeApp/src/desktopMain/native/macos/player_bridge.mm
@@ -1538,10 +1538,12 @@ static void setMpvOptionString(mpv_handle *mpv, const char *name, const char *va
                     return;
                 }
                 [self applyHdrForPolledGamma:gamma primaries:primaries reason:@"sync" force:NO];
+                double buffered = position + cacheAhead;
                 NSString *script = [NSString stringWithFormat:
-                    @"window.playerUpdate({duration:%0.3f,position:%0.3f,paused:%@,loading:%@,audioTracks:%@,subtitleTracks:%@})",
+                    @"window.playerUpdate({duration:%0.3f,position:%0.3f,buffered:%0.3f,paused:%@,loading:%@,audioTracks:%@,subtitleTracks:%@})",
                     duration,
                     position,
+                    fmax(buffered, 0.0),
                     paused ? @"true" : @"false",
                     loading ? @"true" : @"false",
                     audioTracks,

--- a/composeApp/src/desktopMain/native/windows/player_bridge.cpp
+++ b/composeApp/src/desktopMain/native/windows/player_bridge.cpp
@@ -1730,6 +1730,7 @@ private:
         if (!webView) return;
         double duration = doubleProperty("duration", 0.0);
         double position = doubleProperty("time-pos", 0.0);
+        double buffered = std::max(0.0, (double)bufferedPositionMs() / 1000.0);
         bool paused = isPaused();
         bool loading = isLoading();
         std::string audioTracks = audioTracksJson();
@@ -1738,6 +1739,7 @@ private:
         std::ostringstream script;
         script << "window.playerUpdate({duration:" << duration
                << ",position:" << position
+               << ",buffered:" << buffered
                << ",paused:" << (paused ? "true" : "false")
                << ",loading:" << (loading ? "true" : "false")
                << ",audioTracks:" << audioTracks

--- a/composeApp/src/desktopMain/resources/player-ui/controls.css
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.css
@@ -31,7 +31,8 @@
   --theme-selected-surface-hover: #2d4565;
   --theme-selected-ring: rgba(47, 111, 237, .35);
   --theme-timeline-fill: #fff;
-  --theme-timeline-track: rgba(255, 255, 255, .28);
+  --theme-timeline-buffered: rgba(255, 255, 255, .55);
+  --theme-timeline-track: rgba(255, 255, 255, .22);
   --theme-buffering: #fff;
   --theme-buffering-track: rgba(255, 255, 255, .28);
   --theme-control-foreground: #fff;
@@ -1343,7 +1344,12 @@ button:disabled {
   height: 10px;
   border-radius: 999px;
   background:
-    linear-gradient(to right, var(--theme-timeline-fill) 0 var(--progress, 0%), var(--theme-timeline-track) var(--progress, 0%) 100%);
+    linear-gradient(
+      to right,
+      var(--theme-timeline-fill) 0 var(--progress, 0%),
+      var(--theme-timeline-buffered, rgba(255, 255, 255, .55)) var(--progress, 0%) var(--buffered, var(--progress, 0%)),
+      var(--theme-timeline-track) var(--buffered, var(--progress, 0%)) 100%
+    );
 }
 
 .scrub::-webkit-slider-thumb {

--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -2787,7 +2787,15 @@ window.playerControls = nextState => {
   const currentPlaybackState = pendingIsPlaying === null
     ? state.isPlaying
     : pendingIsPlaying;
-  state = { ...state, ...nextState, isPlaying: currentPlaybackState };
+  const mediaChanged = Boolean(
+    (typeof nextState.title === "string" && nextState.title !== state.title) ||
+    (typeof nextState.episodeText === "string" && nextState.episodeText !== state.episodeText) ||
+    (typeof nextState.streamTitle === "string" && nextState.streamTitle !== state.streamTitle)
+  );
+  const bufferedMs = nextState.bufferedMs !== undefined
+    ? Math.max(0, Number(nextState.bufferedMs) || 0)
+    : (mediaChanged ? 0 : (Number(state.bufferedMs) || 0));
+  state = { ...state, ...nextState, bufferedMs, isPlaying: currentPlaybackState };
   hasReceivedPlayerControls = true;
   const closeToken = Number(state.closeModalsToken) || 0;
   if (closeToken !== previousCloseToken) {

--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -290,6 +290,7 @@ let state = {
   showExternalPlayer: false,
   durationMs: 0,
   positionMs: 0,
+  bufferedMs: 0,
   audioTracks: [],
   subtitleTracks: [],
   sourceIsLoading: false,
@@ -694,10 +695,14 @@ const formatTime = milliseconds => {
     : `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
 };
 
-const setProgress = (positionMs, durationMs) => {
+const setProgress = (positionMs, durationMs, bufferedMs = state.bufferedMs) => {
   const percent = durationMs > 0 ? Math.max(0, Math.min(100, positionMs / durationMs * 100)) : 0;
+  const bufferedPercent = durationMs > 0
+    ? Math.max(percent, Math.min(100, (Number(bufferedMs) || 0) / durationMs * 100))
+    : 0;
   seek.value = Math.round(percent * 10);
   seek.style.setProperty("--progress", `${percent}%`);
+  seek.style.setProperty("--buffered", `${bufferedPercent}%`);
   positionLabel.textContent = formatTime(positionMs);
   durationLabel.textContent = formatTime(durationMs);
   if (timeLabel) {
@@ -2733,6 +2738,9 @@ volumeSlider.addEventListener("input", () => {
 window.playerUpdate = update => {
   const durationMs = Math.round((Number(update.duration) || 0) * 1000);
   const positionMs = Math.round((Number(update.position) || 0) * 1000);
+  const bufferedMs = update.buffered != null
+    ? Math.round((Number(update.buffered) || 0) * 1000)
+    : Math.max(positionMs, Number(state.bufferedMs) || 0);
   const audioTracks = normalizeTracks(update.audioTracks);
   const subtitleTracks = normalizeTracks(update.subtitleTracks);
   const audioTracksChanged = trackListSignature(audioTracks) !== trackListSignature(state.audioTracks);
@@ -2748,6 +2756,7 @@ window.playerUpdate = update => {
     ...state,
     durationMs,
     positionMs,
+    bufferedMs,
     isPlaying: pendingIsPlaying === null ? nativeIsPlaying : pendingIsPlaying,
     isLoading: Boolean(update.loading || update.isLoading),
     audioTracks,


### PR DESCRIPTION
## Summary

Adds a secondary semi-transparent buffered progress line ahead of the primary playback tracker on the desktop player seekbar, providing real-time visual feedback on download health and cached stream data.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [x] Approved larger or directional change

## Why

Currently, the video player only displays the active playhead position on the seekbar without indicating how much media data has been buffered or cached ahead by the demuxer. Users cannot tell if a stream is healthy or about to stall until playback abruptly halts. Adding a visual buffered line brings the desktop player in line with expected video player standards (e.g. YouTube, Netflix).

## Desktop scope

Desktop player web controls overlay (`controls.css`, `controls.js`) and native player bridge (`player_bridge.cpp`, `player_bridge.mm`, `build.gradle.kts`).

## Issue or approval

Fixes #320

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [x] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only introduces the buffered duration property to the native player periodic update loop and renders the secondary `--buffered` bar in the seekbar gradient CSS. Does not modify playback engines, seeking algorithms, or non-desktop components.

## Testing

- Built and compiled native bridge on Windows with `.\gradlew.bat :composeApp:buildWindowsPlayerBridge`.
- Verified on Windows 11 with `.\gradlew.bat :composeApp:run`.
- Verified that during streaming, a secondary semi-transparent bar extends ahead of the active playhead reflecting cached packets.
- Verified seeking backward and forward dynamically updates both position and buffer state.

## Screenshots / Video

- **Feature**: Semi-transparent buffer line renders on the player seekbar between current playback position and buffered boundary.
<img width="1855" height="249" alt="image" src="https://github.com/user-attachments/assets/35fc9798-c6e7-4746-a62e-0e6574318be8" />

## Breaking changes

None.

## Linked issues

Fixes #320
