### PR TITLE
Sdh subtitle stripping

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.android.kt
@@ -41,6 +41,7 @@ actual object PlayerSettingsStorage {
     private const val subtitleBoldKey = "subtitle_bold"
     private const val subtitleFontSizeSpKey = "subtitle_font_size_sp"
     private const val subtitleBottomOffsetKey = "subtitle_bottom_offset"
+    private const val subtitleStripSdhKey = "subtitle_strip_sdh"
     private const val subtitleUseForcedSubtitlesKey = "subtitle_use_forced_subtitles"
     private const val subtitleShowOnlyPreferredLanguagesKey = "subtitle_show_only_preferred_languages"
     private const val addonSubtitleStartupModeKey = "addon_subtitle_startup_mode"
@@ -115,6 +116,7 @@ actual object PlayerSettingsStorage {
         subtitleBoldKey,
         subtitleFontSizeSpKey,
         subtitleBottomOffsetKey,
+        subtitleStripSdhKey,
         subtitleUseForcedSubtitlesKey,
         subtitleShowOnlyPreferredLanguagesKey,
         addonSubtitleStartupModeKey,
@@ -498,6 +500,23 @@ actual object PlayerSettingsStorage {
         preferences
             ?.edit()
             ?.putInt(ProfileScopedKey.of(subtitleBottomOffsetKey), bottomOffset)
+            ?.apply()
+    }
+
+    actual fun loadSubtitleStripSdh(): Boolean? =
+        preferences?.let { sharedPreferences ->
+            val key = ProfileScopedKey.of(subtitleStripSdhKey)
+            if (sharedPreferences.contains(key)) {
+                sharedPreferences.getBoolean(key, SubtitleStyleState.DEFAULT.stripSdh)
+            } else {
+                null
+            }
+        }
+
+    actual fun saveSubtitleStripSdh(enabled: Boolean) {
+        preferences
+            ?.edit()
+            ?.putBoolean(ProfileScopedKey.of(subtitleStripSdhKey), enabled)
             ?.apply()
     }
 
@@ -1154,6 +1173,7 @@ actual object PlayerSettingsStorage {
         loadSubtitleBold()?.let { put(subtitleBoldKey, encodeSyncBoolean(it)) }
         loadSubtitleFontSizeSp()?.let { put(subtitleFontSizeSpKey, encodeSyncInt(it)) }
         loadSubtitleBottomOffset()?.let { put(subtitleBottomOffsetKey, encodeSyncInt(it)) }
+        loadSubtitleStripSdh()?.let { put(subtitleStripSdhKey, encodeSyncBoolean(it)) }
         loadSubtitleUseForcedSubtitles()?.let { put(subtitleUseForcedSubtitlesKey, encodeSyncBoolean(it)) }
         loadSubtitleShowOnlyPreferredLanguages()?.let { put(subtitleShowOnlyPreferredLanguagesKey, encodeSyncBoolean(it)) }
         loadAddonSubtitleStartupMode()?.let { put(addonSubtitleStartupModeKey, encodeSyncString(it)) }
@@ -1232,6 +1252,7 @@ actual object PlayerSettingsStorage {
         payload.decodeSyncBoolean(subtitleBoldKey)?.let(::saveSubtitleBold)
         payload.decodeSyncInt(subtitleFontSizeSpKey)?.let(::saveSubtitleFontSizeSp)
         payload.decodeSyncInt(subtitleBottomOffsetKey)?.let(::saveSubtitleBottomOffset)
+        payload.decodeSyncBoolean(subtitleStripSdhKey)?.let(::saveSubtitleStripSdh)
         payload.decodeSyncBoolean(subtitleUseForcedSubtitlesKey)?.let(::saveSubtitleUseForcedSubtitles)
         payload.decodeSyncBoolean(subtitleShowOnlyPreferredLanguagesKey)?.let(::saveSubtitleShowOnlyPreferredLanguages)
         payload.decodeSyncString(addonSubtitleStartupModeKey)?.let(::saveAddonSubtitleStartupMode)

--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -1046,6 +1046,8 @@
     <string name="settings_playback_subtitle_show_preferred_only">Alleen voorkeurstalen tonen</string>
     <string name="settings_playback_subtitle_show_preferred_only_description">Toon alleen ondertitels die overeenkomen met je voorkeurstalen voor ondertiteling.</string>
     <string name="settings_playback_subtitle_size">Ondertitelgrootte</string>
+    <string name="settings_playback_subtitle_strip_sdh">SDH-informatie verwijderen</string>
+    <string name="settings_playback_subtitle_strip_sdh_description">Verberg geluidsbeschrijvingen en sprekerlabels in tekstondertitels.</string>
     <string name="settings_playback_subtitle_text_color">Tekstkleur</string>
     <string name="settings_playback_subtitle_use_forced">Geforceerde ondertitels gebruiken</string>
     <string name="settings_playback_subtitle_use_forced_description">Geef de voorkeur aan geforceerde ondertitels bij het matchen van je taalinstellingen voor ondertiteling.</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -1099,6 +1099,8 @@
     <string name="settings_playback_subtitle_show_preferred_only">Show Only Preferred Languages</string>
     <string name="settings_playback_subtitle_show_preferred_only_description">Only show subtitles matching your preferred subtitle languages.</string>
     <string name="settings_playback_subtitle_size">Subtitle Size</string>
+    <string name="settings_playback_subtitle_strip_sdh">Strip SDH Subtitles</string>
+    <string name="settings_playback_subtitle_strip_sdh_description">Hide sound descriptions and speaker labels from text subtitles.</string>
     <string name="settings_playback_subtitle_text_color">Text Color</string>
     <string name="settings_playback_subtitle_use_forced">Use Forced Subtitles</string>
     <string name="settings_playback_subtitle_use_forced_description">Prefer forced subtitles when audio matches the subtitle language; if unavailable, select nothing.</string>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSettingsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSettingsRepository.kt
@@ -291,6 +291,8 @@ object PlayerSettingsRepository {
                 ?: SubtitleStyleState.DEFAULT.fontSizeSp).coerceIn(subtitleFontSizeRangeSp),
             bottomOffset = PlayerSettingsStorage.loadSubtitleBottomOffset()
                 ?: SubtitleStyleState.DEFAULT.bottomOffset,
+            stripSdh = PlayerSettingsStorage.loadSubtitleStripSdh()
+                ?: SubtitleStyleState.DEFAULT.stripSdh,
             useForcedSubtitles = PlayerSettingsStorage.loadSubtitleUseForcedSubtitles()
                 ?: SubtitleStyleState.DEFAULT.useForcedSubtitles,
             showOnlyPreferredLanguages = PlayerSettingsStorage.loadSubtitleShowOnlyPreferredLanguages()
@@ -536,6 +538,7 @@ object PlayerSettingsRepository {
         PlayerSettingsStorage.saveSubtitleBold(normalized.bold)
         PlayerSettingsStorage.saveSubtitleFontSizeSp(normalized.fontSizeSp)
         PlayerSettingsStorage.saveSubtitleBottomOffset(normalized.bottomOffset)
+        PlayerSettingsStorage.saveSubtitleStripSdh(normalized.stripSdh)
         PlayerSettingsStorage.saveSubtitleUseForcedSubtitles(normalized.useForcedSubtitles)
         PlayerSettingsStorage.saveSubtitleShowOnlyPreferredLanguages(normalized.showOnlyPreferredLanguages)
     }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.kt
@@ -47,6 +47,8 @@ internal expect object PlayerSettingsStorage {
     fun saveSubtitleFontSizeSp(fontSizeSp: Int)
     fun loadSubtitleBottomOffset(): Int?
     fun saveSubtitleBottomOffset(bottomOffset: Int)
+    fun loadSubtitleStripSdh(): Boolean?
+    fun saveSubtitleStripSdh(enabled: Boolean)
     fun loadSubtitleUseForcedSubtitles(): Boolean?
     fun saveSubtitleUseForcedSubtitles(enabled: Boolean)
     fun loadSubtitleShowOnlyPreferredLanguages(): Boolean?

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/SubtitleAudioModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/SubtitleAudioModels.kt
@@ -63,6 +63,7 @@ data class SubtitleStyleState(
     val bold: Boolean = false,
     val fontSizeSp: Int = 18,
     val bottomOffset: Int = 20,
+    val stripSdh: Boolean = false,
     val useForcedSubtitles: Boolean = false,
     val showOnlyPreferredLanguages: Boolean = false,
 ) {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/PlaybackSettingsPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/PlaybackSettingsPage.kt
@@ -525,6 +525,21 @@ private fun PlaybackSettingsSection(
                     onClick = { showSecondarySubtitleDialog = true },
                 )
                 SettingsGroupDivider(isTablet = isTablet)
+                if (isDesktop) {
+                    SettingsSwitchRow(
+                        title = stringResource(Res.string.settings_playback_subtitle_strip_sdh),
+                        description = stringResource(Res.string.settings_playback_subtitle_strip_sdh_description),
+                        checked = autoPlayPlayerSettings.subtitleStyle.stripSdh,
+                        enabled = otherSubtitleOptionsEnabled,
+                        isTablet = isTablet,
+                        onCheckedChange = { enabled ->
+                            PlayerSettingsRepository.setSubtitleStyle(
+                                autoPlayPlayerSettings.subtitleStyle.copy(stripSdh = enabled),
+                            )
+                        },
+                    )
+                    SettingsGroupDivider(isTablet = isTablet)
+                }
                 SettingsSwitchRow(
                     title = stringResource(Res.string.settings_playback_subtitle_use_forced),
                     description = stringResource(Res.string.settings_playback_subtitle_use_forced_description),

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.desktop.kt
@@ -39,6 +39,7 @@ internal actual object PlayerSettingsStorage {
     private const val subtitleBoldKey = "subtitle_bold"
     private const val subtitleFontSizeSpKey = "subtitle_font_size_sp"
     private const val subtitleBottomOffsetKey = "subtitle_bottom_offset"
+    private const val subtitleStripSdhKey = "subtitle_strip_sdh"
     private const val subtitleUseForcedSubtitlesKey = "subtitle_use_forced_subtitles"
     private const val subtitleShowOnlyPreferredLanguagesKey = "subtitle_show_only_preferred_languages"
     private const val addonSubtitleStartupModeKey = "addon_subtitle_startup_mode"
@@ -112,6 +113,7 @@ internal actual object PlayerSettingsStorage {
         subtitleBoldKey,
         subtitleFontSizeSpKey,
         subtitleBottomOffsetKey,
+        subtitleStripSdhKey,
         subtitleUseForcedSubtitlesKey,
         subtitleShowOnlyPreferredLanguagesKey,
         addonSubtitleStartupModeKey,
@@ -206,6 +208,8 @@ internal actual object PlayerSettingsStorage {
     actual fun saveSubtitleFontSizeSp(fontSizeSp: Int) = saveInt(subtitleFontSizeSpKey, fontSizeSp)
     actual fun loadSubtitleBottomOffset(): Int? = loadInt(subtitleBottomOffsetKey)
     actual fun saveSubtitleBottomOffset(bottomOffset: Int) = saveInt(subtitleBottomOffsetKey, bottomOffset)
+    actual fun loadSubtitleStripSdh(): Boolean? = loadBoolean(subtitleStripSdhKey)
+    actual fun saveSubtitleStripSdh(enabled: Boolean) = saveBoolean(subtitleStripSdhKey, enabled)
     actual fun loadSubtitleUseForcedSubtitles(): Boolean? = loadBoolean(subtitleUseForcedSubtitlesKey)
     actual fun saveSubtitleUseForcedSubtitles(enabled: Boolean) = saveBoolean(subtitleUseForcedSubtitlesKey, enabled)
     actual fun loadSubtitleShowOnlyPreferredLanguages(): Boolean? = loadBoolean(subtitleShowOnlyPreferredLanguagesKey)
@@ -345,6 +349,7 @@ internal actual object PlayerSettingsStorage {
         loadSubtitleBold()?.let { put(subtitleBoldKey, encodeSyncBoolean(it)) }
         loadSubtitleFontSizeSp()?.let { put(subtitleFontSizeSpKey, encodeSyncInt(it)) }
         loadSubtitleBottomOffset()?.let { put(subtitleBottomOffsetKey, encodeSyncInt(it)) }
+        loadSubtitleStripSdh()?.let { put(subtitleStripSdhKey, encodeSyncBoolean(it)) }
         loadSubtitleUseForcedSubtitles()?.let { put(subtitleUseForcedSubtitlesKey, encodeSyncBoolean(it)) }
         loadSubtitleShowOnlyPreferredLanguages()?.let { put(subtitleShowOnlyPreferredLanguagesKey, encodeSyncBoolean(it)) }
         loadAddonSubtitleStartupMode()?.let { put(addonSubtitleStartupModeKey, encodeSyncString(it)) }
@@ -422,6 +427,7 @@ internal actual object PlayerSettingsStorage {
         payload.decodeSyncBoolean(subtitleBoldKey)?.let(::saveSubtitleBold)
         payload.decodeSyncInt(subtitleFontSizeSpKey)?.let(::saveSubtitleFontSizeSp)
         payload.decodeSyncInt(subtitleBottomOffsetKey)?.let(::saveSubtitleBottomOffset)
+        payload.decodeSyncBoolean(subtitleStripSdhKey)?.let(::saveSubtitleStripSdh)
         payload.decodeSyncBoolean(subtitleUseForcedSubtitlesKey)?.let(::saveSubtitleUseForcedSubtitles)
         payload.decodeSyncBoolean(subtitleShowOnlyPreferredLanguagesKey)?.let(::saveSubtitleShowOnlyPreferredLanguages)
         payload.decodeSyncString(addonSubtitleStartupModeKey)?.let(::saveAddonSubtitleStartupMode)

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerBridge.kt
@@ -91,6 +91,7 @@ internal object NativePlayerBridge {
         fontSize: Float,
         subPos: Int,
         useLibass: Boolean,
+        stripSdh: Boolean,
     )
     external fun warmupWebView2(controlsPageUrl: String): Boolean
     external fun shutdownWebView2Warmup()

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
@@ -580,6 +580,7 @@ internal class NativePlayerController(
             fontSize = style.toMpvSubtitleFontSize(),
             subPos = style.toMpvSubtitlePosition(),
             useLibass = useLibass,
+            stripSdh = style.stripSdh,
         )
     }
 

--- a/composeApp/src/desktopMain/native/macos/player_bridge.mm
+++ b/composeApp/src/desktopMain/native/macos/player_bridge.mm
@@ -2104,7 +2104,7 @@ static void setMpvOptionString(mpv_handle *mpv, const char *name, const char *va
     }
     if (stripSdhChanged) {
         [self setStringProperty:"sub-filter-sdh" value:stripSdh ? @"yes" : @"no"];
-        [self setStringProperty:"sub-filter-sdh-harder" value:@"no"];
+        [self setStringProperty:"sub-filter-sdh-harder" value:stripSdh ? @"yes" : @"no"];
     }
 
     _hasAppliedSubtitleStyle = YES;

--- a/composeApp/src/desktopMain/native/macos/player_bridge.mm
+++ b/composeApp/src/desktopMain/native/macos/player_bridge.mm
@@ -123,7 +123,8 @@
                                     bold:(BOOL)bold
                                 fontSize:(double)fontSize
                                   subPos:(int)subPos
-                               useLibass:(BOOL)useLibass;
+                               useLibass:(BOOL)useLibass
+                                stripSdh:(BOOL)stripSdh;
 - (void)handleScriptMessage:(NSDictionary *)message;
 - (void)focusControlsWebViewIfNeeded;
 - (void)layoutNativeSubviews;
@@ -1062,6 +1063,7 @@ static void setMpvOptionString(mpv_handle *mpv, const char *name, const char *va
     BOOL _appliedSubtitleBold;
     double _appliedSubtitleFontSize;
     int64_t _appliedSubtitlePosition;
+    BOOL _appliedSubtitleStripSdh;
 }
 
 - (instancetype)initWithHostView:(NSView *)hostView
@@ -2037,7 +2039,8 @@ static void setMpvOptionString(mpv_handle *mpv, const char *name, const char *va
                                     bold:(BOOL)bold
                                 fontSize:(double)fontSize
                                   subPos:(int)subPos
-                               useLibass:(BOOL)useLibass {
+                               useLibass:(BOOL)useLibass
+                                stripSdh:(BOOL)stripSdh {
     if (!_mpv) return;
     double size = MAX(18.0, MIN(96.0, fontSize));
     double scale = useLibass ? size / 54.0 : 1.0;
@@ -2057,6 +2060,7 @@ static void setMpvOptionString(mpv_handle *mpv, const char *name, const char *va
     BOOL outlineColorChanged =
         !_hasAppliedSubtitleStyle || ![_appliedSubtitleOutlineColor isEqualToString:resolvedOutlineColor];
     BOOL outlineSizeChanged = !_hasAppliedSubtitleStyle || _appliedSubtitleOutlineSize != outline;
+    BOOL stripSdhChanged = !_hasAppliedSubtitleStyle || _appliedSubtitleStripSdh != stripSdh;
 
     if (modeChanged) {
         [self setStringProperty:"sub-ass-override" value:useLibass ? @"scale" : @"force"];
@@ -2098,6 +2102,10 @@ static void setMpvOptionString(mpv_handle *mpv, const char *name, const char *va
             mpv_set_property(_mpv, "sub-outline-size", MPV_FORMAT_DOUBLE, &outline);
         }
     }
+    if (stripSdhChanged) {
+        [self setStringProperty:"sub-filter-sdh" value:stripSdh ? @"yes" : @"no"];
+        [self setStringProperty:"sub-filter-sdh-harder" value:@"no"];
+    }
 
     _hasAppliedSubtitleStyle = YES;
     _appliedSubtitleUseLibass = useLibass;
@@ -2108,6 +2116,7 @@ static void setMpvOptionString(mpv_handle *mpv, const char *name, const char *va
     _appliedSubtitleBold = bold;
     _appliedSubtitleFontSize = size;
     _appliedSubtitlePosition = position;
+    _appliedSubtitleStripSdh = stripSdh;
 }
 
 - (double)doubleProperty:(const char *)name fallback:(double)fallback {
@@ -2941,7 +2950,8 @@ Java_com_nuvio_app_features_player_desktop_NativePlayerBridge_applySubtitleStyle
     jboolean bold,
     jfloat fontSize,
     jint subPos,
-    jboolean useLibass
+    jboolean useLibass,
+    jboolean stripSdh
 ) {
     if (handle == 0) return;
     std::string text = jstringToString(env, textColor);
@@ -2956,6 +2966,7 @@ Java_com_nuvio_app_features_player_desktop_NativePlayerBridge_applySubtitleStyle
                                             bold:bold == JNI_TRUE
                                         fontSize:(double)fontSize
                                           subPos:(int)subPos
-                                       useLibass:useLibass == JNI_TRUE];
+                                       useLibass:useLibass == JNI_TRUE
+                                        stripSdh:stripSdh == JNI_TRUE];
     });
 }

--- a/composeApp/src/desktopMain/native/windows/player_bridge.cpp
+++ b/composeApp/src/desktopMain/native/windows/player_bridge.cpp
@@ -1232,7 +1232,7 @@ public:
         }
         if (stripSdhChanged) {
             setStringProperty("sub-filter-sdh", stripSdh ? "yes" : "no");
-            setStringProperty("sub-filter-sdh-harder", "no");
+            setStringProperty("sub-filter-sdh-harder", stripSdh ? "yes" : "no");
         }
 
         hasAppliedSubtitleStyle = true;

--- a/composeApp/src/desktopMain/native/windows/player_bridge.cpp
+++ b/composeApp/src/desktopMain/native/windows/player_bridge.cpp
@@ -1157,7 +1157,8 @@ public:
         bool bold,
         double fontSize,
         int subPos,
-        bool useLibass
+        bool useLibass,
+        bool stripSdh
     ) {
         double size = std::max(18.0, std::min(96.0, fontSize));
         int64_t position = std::max(0, std::min(150, subPos));
@@ -1177,6 +1178,7 @@ public:
         bool outlineColorChanged =
             !hasAppliedSubtitleStyle || appliedSubtitleOutlineColor != resolvedOutlineColor;
         bool outlineSizeChanged = !hasAppliedSubtitleStyle || appliedSubtitleOutlineSize != outline;
+        bool stripSdhChanged = !hasAppliedSubtitleStyle || appliedSubtitleStripSdh != stripSdh;
 
         if (modeChanged) {
             setStringProperty("sub-ass-override", useLibass ? "scale" : "force");
@@ -1228,6 +1230,10 @@ public:
                 mpvApi().setProperty(mpv, "sub-outline-size", MPV_FORMAT_DOUBLE, &outline);
             }
         }
+        if (stripSdhChanged) {
+            setStringProperty("sub-filter-sdh", stripSdh ? "yes" : "no");
+            setStringProperty("sub-filter-sdh-harder", "no");
+        }
 
         hasAppliedSubtitleStyle = true;
         appliedSubtitleUseLibass = useLibass;
@@ -1238,6 +1244,7 @@ public:
         appliedSubtitleBold = bold;
         appliedSubtitleFontSize = size;
         appliedSubtitlePosition = position;
+        appliedSubtitleStripSdh = stripSdh;
     }
 
 private:
@@ -1273,6 +1280,7 @@ private:
     bool appliedSubtitleBold = false;
     double appliedSubtitleFontSize = 0.0;
     int64_t appliedSubtitlePosition = 0;
+    bool appliedSubtitleStripSdh = false;
 
     JavaVM *javaVm = nullptr;
     jobject eventSink = nullptr;
@@ -2501,7 +2509,8 @@ Java_com_nuvio_app_features_player_desktop_NativePlayerBridge_applySubtitleStyle
     jboolean bold,
     jfloat fontSize,
     jint subPos,
-    jboolean useLibass
+    jboolean useLibass,
+    jboolean stripSdh
 ) {
     auto player = playerFromHandle(handle);
     if (!player) return;
@@ -2513,6 +2522,7 @@ Java_com_nuvio_app_features_player_desktop_NativePlayerBridge_applySubtitleStyle
         bold == JNI_TRUE,
         fontSize,
         subPos,
-        useLibass == JNI_TRUE
+        useLibass == JNI_TRUE,
+        stripSdh == JNI_TRUE
     );
 }

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.ios.kt
@@ -39,6 +39,7 @@ actual object PlayerSettingsStorage {
     private const val subtitleBoldKey = "subtitle_bold"
     private const val subtitleFontSizeSpKey = "subtitle_font_size_sp"
     private const val subtitleBottomOffsetKey = "subtitle_bottom_offset"
+    private const val subtitleStripSdhKey = "subtitle_strip_sdh"
     private const val subtitleUseForcedSubtitlesKey = "subtitle_use_forced_subtitles"
     private const val subtitleShowOnlyPreferredLanguagesKey = "subtitle_show_only_preferred_languages"
     private const val addonSubtitleStartupModeKey = "addon_subtitle_startup_mode"
@@ -112,6 +113,7 @@ actual object PlayerSettingsStorage {
         subtitleBoldKey,
         subtitleFontSizeSpKey,
         subtitleBottomOffsetKey,
+        subtitleStripSdhKey,
         subtitleUseForcedSubtitlesKey,
         subtitleShowOnlyPreferredLanguagesKey,
         addonSubtitleStartupModeKey,
@@ -444,6 +446,12 @@ actual object PlayerSettingsStorage {
 
     actual fun saveSubtitleBottomOffset(bottomOffset: Int) {
         NSUserDefaults.standardUserDefaults.setInteger(bottomOffset.toLong(), forKey = ProfileScopedKey.of(subtitleBottomOffsetKey))
+    }
+
+    actual fun loadSubtitleStripSdh(): Boolean? = loadBoolean(subtitleStripSdhKey)
+
+    actual fun saveSubtitleStripSdh(enabled: Boolean) {
+        saveBoolean(subtitleStripSdhKey, enabled)
     }
 
     actual fun loadSubtitleUseForcedSubtitles(): Boolean? = loadBoolean(subtitleUseForcedSubtitlesKey)
@@ -961,6 +969,7 @@ actual object PlayerSettingsStorage {
         loadSubtitleBold()?.let { put(subtitleBoldKey, encodeSyncBoolean(it)) }
         loadSubtitleFontSizeSp()?.let { put(subtitleFontSizeSpKey, encodeSyncInt(it)) }
         loadSubtitleBottomOffset()?.let { put(subtitleBottomOffsetKey, encodeSyncInt(it)) }
+        loadSubtitleStripSdh()?.let { put(subtitleStripSdhKey, encodeSyncBoolean(it)) }
         loadSubtitleUseForcedSubtitles()?.let { put(subtitleUseForcedSubtitlesKey, encodeSyncBoolean(it)) }
         loadSubtitleShowOnlyPreferredLanguages()?.let { put(subtitleShowOnlyPreferredLanguagesKey, encodeSyncBoolean(it)) }
         loadAddonSubtitleStartupMode()?.let { put(addonSubtitleStartupModeKey, encodeSyncString(it)) }
@@ -1038,6 +1047,7 @@ actual object PlayerSettingsStorage {
         payload.decodeSyncBoolean(subtitleBoldKey)?.let(::saveSubtitleBold)
         payload.decodeSyncInt(subtitleFontSizeSpKey)?.let(::saveSubtitleFontSizeSp)
         payload.decodeSyncInt(subtitleBottomOffsetKey)?.let(::saveSubtitleBottomOffset)
+        payload.decodeSyncBoolean(subtitleStripSdhKey)?.let(::saveSubtitleStripSdh)
         payload.decodeSyncBoolean(subtitleUseForcedSubtitlesKey)?.let(::saveSubtitleUseForcedSubtitles)
         payload.decodeSyncBoolean(subtitleShowOnlyPreferredLanguagesKey)?.let(::saveSubtitleShowOnlyPreferredLanguages)
         payload.decodeSyncString(addonSubtitleStartupModeKey)?.let(::saveAddonSubtitleStartupMode)


### PR DESCRIPTION
## Summary

Adds a “Strip SDH subtitles” setting. MPV uses its native SDH filter.
<!-- What changed in this PR? -->

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [x] Approved larger or directional change

## Why
SDH descriptions such as `[GLASS SHATTERING]` and speaker labels could not be hidden, disrupting subtitle playback for affected users.
<!-- Why this change is needed. Explain the user-visible bug, regression, maintenance need, docs error, or approved request. -->

## Desktop scope
All platforms, I will push a fix for Linux when the player gets added.
<!-- This repository branch is for the desktop app. Explain which desktop platform(s) are affected: Windows, macOS, Linux, or desktop shared code. -->
<!-- If shared/common code changed, explain why it is needed for desktop behavior. -->

## Issue or approval

<!-- Required. Link the bug issue or approved feature request. For docs/translation/maintenance with no issue, explain why no issue is needed. -->
<!-- Examples: Fixes #123 / Approved in #456 / No linked issue: typo-only docs fix. -->
Discussed privately
## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [x] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries
No harder filtering mode, bitmap-subtitle filtering, unrelated subtitle changes, or UI polish.
<!-- List anything intentionally not changed. If this is a bug fix, confirm it does not include extra UI polish or behavior tweaks. -->

## Testing
Copies over behavior from tested mobile implementation. Seperate desktop testing wasn't done.
<!-- What you tested and how. Include desktop OS/version, installer/updater checks if relevant, commands, and manual desktop flows. Do not write only "not tested" unless this is docs/translation-only. -->

## Screenshots / Video

<!-- Required for any desktop UI change. Write "Not a UI change" only if no UI changed. -->

## Breaking changes
None
<!-- Any breaking behavior/config/schema changes? If none, write: None. -->

## Linked issues

<!-- Required for bug fixes, UI glitch fixes, behavior fixes, and approved changes. For docs/translation/maintenance with no issue, write: No linked issue - reason. -->
[Discord Feature Request](https://discord.com/channels/1379902184207941732/1535674425796726814)