### PR TITLE
fix(desktop): maximize to the screen the window is on, not the primar…

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
@@ -30,6 +30,7 @@ import com.nuvio.app.features.player.desktop.applyNativeDesktopWindowChrome
 import com.nuvio.app.features.player.desktop.installDesktopAppFullscreenShortcuts
 import com.nuvio.app.features.player.desktop.preloadNativePlayerBridgeAsync
 import com.nuvio.app.features.player.desktop.registerDesktopAppFullscreenToggle
+import com.nuvio.app.features.player.desktop.trackMaximizedBoundsForCurrentScreen
 import com.nuvio.app.features.profiles.ProfileRepository
 import com.nuvio.app.features.settings.AppIconRepository
 import com.nuvio.app.features.settings.applyDesktopRendererPreference
@@ -188,9 +189,11 @@ fun main(args: Array<String>) {
                     },
                 )
                 val uninstallFullscreenShortcuts = installDesktopAppFullscreenShortcuts(window)
+                val untrackMaximizedBounds = window.trackMaximizedBoundsForCurrentScreen()
                 onDispose {
                     fullscreenController.dispose(window)
                     uninstallFullscreenShortcuts()
+                    untrackMaximizedBounds()
                     unregisterFullscreenToggle()
                 }
             }

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopMaximizedBounds.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopMaximizedBounds.kt
@@ -1,0 +1,65 @@
+package com.nuvio.app.features.player.desktop
+
+import java.awt.Frame
+import java.awt.GraphicsConfiguration
+import java.awt.Rectangle
+import java.awt.Toolkit
+import java.awt.Window
+import java.awt.event.ComponentAdapter
+import java.awt.event.ComponentEvent
+
+/**
+ * Keeps a window's maximized bounds pointed at the screen it is actually on.
+ *
+ * AWT constrains maximizing with bounds derived from the primary screen, so the
+ * first maximize after a window crosses to a monitor with a different scale
+ * factor is the wrong size. Setting them explicitly, and again on each change of
+ * screen, hands AWT the right rectangle before it is asked for one.
+ *
+ * Upstream: JDK-8176359, JDK-8231564, JDK-8187616, JDK-8263086.
+ *
+ * Windows only; macOS has its own maximize semantics.
+ */
+internal fun Window.trackMaximizedBoundsForCurrentScreen(): () -> Unit {
+    val frame = this as? Frame ?: return {}
+    if (DesktopHostOs.current != DesktopHostOs.WINDOWS) return {}
+
+    var lastConfiguration: GraphicsConfiguration? = null
+
+    fun apply() {
+        val configuration = frame.graphicsConfiguration ?: return
+        // Writing maximized bounds mid-maximize can disturb the frame, so only
+        // a real change of screen triggers a recompute.
+        if (configuration === lastConfiguration) return
+        lastConfiguration = configuration
+        frame.maximizedBounds = configuration.workArea()
+    }
+
+    apply()
+    val listener = object : ComponentAdapter() {
+        override fun componentMoved(event: ComponentEvent) = apply()
+        override fun componentResized(event: ComponentEvent) = apply()
+    }
+    frame.addComponentListener(listener)
+    return { frame.removeComponentListener(listener) }
+}
+
+/**
+ * The screen less whatever the desktop reserves, so a maximized window still
+ * stops at the taskbar.
+ *
+ * In the same user space `setMaximizedBounds` is documented to take. A JDK
+ * exhibiting JDK-8187616 would need `defaultTransform` applied here.
+ */
+private fun GraphicsConfiguration.workArea(): Rectangle {
+    val screen = bounds
+    val insets = runCatching {
+        Toolkit.getDefaultToolkit().getScreenInsets(this)
+    }.getOrNull() ?: return Rectangle(screen)
+    return Rectangle(
+        screen.x + insets.left,
+        screen.y + insets.top,
+        (screen.width - insets.left - insets.right).coerceAtLeast(1),
+        (screen.height - insets.top - insets.bottom).coerceAtLeast(1),
+    )
+}


### PR DESCRIPTION
## Summary

On Windows with two monitors at different scale factors, the first maximize after dragging the window to the other screen comes out the wrong size — it overhangs or falls short by roughly the ratio between the two scales. Maximizing a second time is correct, because by then the window has settled on the new screen and the bounds are recomputed.

This sets the maximized bounds explicitly from the window's current `GraphicsConfiguration`, and again whenever the window changes screen, so AWT is handed the right rectangle before it is asked for one.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

AWT constrains maximizing with bounds derived from the primary screen. This is long-standing and still open upstream:

- **JDK-8176359** — the default screen's maximized bounds are used for a secondary screen
- **JDK-8231564** — broken with two or more monitors above 100% scale
- **JDK-8187616** — display scaling ignored, leaving the window short by the scale factor
- **JDK-8263086** — inconsistent `setExtendedState` bounds across two monitors

- **Old behavior:** maximizing filled the work area of the monitor the window was on.
- **Broken behavior:** after the window moves to a monitor with a different scale, the first maximize is sized for the other monitor's scale factor and does not fit. The second is correct.
- **New behavior:** the first maximize fills the correct monitor, in both directions.
- **How it was tested:** see Testing below.

The screen's work area is used rather than its full bounds, so a maximized window still stops at the taskbar. The recompute is skipped unless the `GraphicsConfiguration` has actually changed, because writing maximized bounds during a maximize can itself disturb the frame.

## Desktop scope

Windows only. `DesktopHostOs.WINDOWS` gates the whole thing — that is where the fault is, and macOS has its own maximize semantics that should not be overridden. Linux is unaffected. No shared/common code changed.

## Issue or approval

Fixes #383

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Intentionally not changed:

- The app's own fullscreen path (`DesktopAppFullscreen.kt`), which already resolves the monitor natively via `GetMonitorInfo` and is unaffected by this bug.
- macOS and Linux maximize behavior.
- Window geometry persistence and restore.

No UI polish, no refactors, no formatting changes, no new dependencies. Two files: one new 81-line file and a 6-line hook in `Main.kt`.

## Testing

- Windows 10, three monitors: 1440p @ 125% and 1080p @ 100%.
- Built and ran with `gradlew.bat :composeApp:run`.
- **Before:** windowed on one monitor, dragged to the other, dragged to the top to maximize — wrong size, did not fit. Maximizing again was correct. Same in both directions.
- **After:** the first maximize fits correctly on both monitors, in both directions, repeatedly.
- `gradlew.bat :composeApp:compileKotlinDesktop` passes.

Note: `GraphicsConfiguration.getBounds()` values were correct as passed on this JDK, so no `defaultTransform` scaling was needed. JDK-8187616 suggests some JDK versions may require it; the one place that would change is noted in a comment.

## Screenshots / Video

Not a UI change — no components, layout, or styling changed. Screen recording of the window geometry before and after included below, since the effect is visually observable.

<<DROP THE RECORDING HERE>>

https://github.com/user-attachments/assets/88785c27-15d0-4085-8961-28b0a47c8eed


## Breaking changes

None.

## Linked issues

Fixes #383