### PR TITLE
fix(desktop): make the profile top-bar pill fully clickable

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
@@ -4440,6 +4440,7 @@ private fun TabletFloatingTopBar(
                         tokens.colors.surface
                     },
                     shape = tokens.shapes.chip,
+                    modifier = Modifier.clickable { onTabSelected(AppScreenTab.Settings) },
                 ) {
                     Row(
                         modifier = Modifier.padding(horizontal = tokens.spacing.listGap, vertical = tokens.spacing.controlGap),
@@ -4454,7 +4455,6 @@ private fun TabletFloatingTopBar(
                         )
                         Text(
                             text = stringResource(Res.string.compose_nav_profile),
-                            modifier = Modifier.clickable { onTabSelected(AppScreenTab.Settings) },
                             style = MaterialTheme.typography.labelLarge,
                             color = if (selectedTab == AppScreenTab.Settings) {
                                 tokens.colors.textPrimary


### PR DESCRIPTION
## Summary

Make the desktop Top Bar Profile pill use one click target for its full visible surface.

- Move the Profile navigation click handler from the label child to the containing `Surface`.
- Keep the existing profile avatar handlers intact, including quick profile switching.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

The Profile item in the desktop Top Bar is drawn as one rounded pill, but only the avatar and the `Profile` label have click handlers. The padding and gap inside the same visible pill are dead areas, so clicking them leaves the app on the current screen. Home, Search, and Library already make their complete visible pills clickable.

The outer Profile `Surface` now handles navigation to the Profile/Settings section. The label no longer owns a separate handler, so the entire pill follows the same hit-target behavior as the other top-bar tabs while the existing avatar interaction remains in place.

## Desktop scope

The change is in `composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt`, in the shared `TabletFloatingTopBar` composable used by the desktop floating Top Bar path. Runtime verification was performed on macOS 26.5.2 arm64. The desktop Sidebar layout, native bottom tabs, Home/Search/Library handlers, and profile avatar interaction were not changed.

## Issue or approval

Fixes #432

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

This PR only changes the Profile pill's click target in the floating Top Bar. It does not change visual styling, spacing, profile switching, long-press behavior, Sidebar navigation, native bottom tabs, other tab handlers, or unrelated navigation.

## Testing

- `./gradlew :composeApp:desktopTest --no-configuration-cache` passed on macOS 26.5.2 arm64.
- `git diff --check` passed before commit.
- The automated desktop test task completed successfully. No separate packaged-app click-through is claimed here; the exact manual reproduction is documented in #432.

## Screenshots / Video

Not a UI change. The pill appearance is unchanged; this fix changes only its click target.

## Breaking changes

None.

## Linked issues

Fixes #432

Related to #430, which GitHub automation closed because it had no labels.
