### PR TITLE
fix(player): show automatic skip notifications

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -1364,6 +1364,9 @@
     <string name="player_skip_intro">Skip Intro</string>
     <string name="player_skip_outro">Skip Outro</string>
     <string name="player_skip_recap">Skip Recap</string>
+    <string name="player_auto_skip_intro_notification">Intro skipped to %1$s</string>
+    <string name="player_auto_skip_recap_notification">Recap skipped to %1$s</string>
+    <string name="player_auto_skip_outro_notification">Outro skipped to %1$s</string>
     <string name="compose_player_no_subtitles_found">No subtitles found</string>
     <string name="lang_afrikaans">Afrikaans</string>
     <string name="lang_albanian">Albanian</string>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerEngine.kt
@@ -219,6 +219,8 @@ data class PlayerControlsState(
     val subtitleAutoSyncIsLoading: Boolean = false,
     val subtitleAutoSyncErrorMessage: String = "",
     val closeModalsToken: Long = 0L,
+    val notificationMessage: String = "",
+    val notificationToken: Long = 0L,
 )
 
 data class PlayerControlFilterItem(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeEffects.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeEffects.kt
@@ -417,6 +417,7 @@ private fun PlayerScreenRuntime.BindPlayerMetadataAndSkipEffects() {
         activeSkipInterval = null
         skipIntervalDismissed = false
         autoSkippedIntervalKeys.clear()
+        playerNotificationMessage = ""
         showNextEpisodeCard = false
         nextEpisodeAutoPlayJob?.cancel()
         nextEpisodeAutoPlaySearching = false
@@ -477,9 +478,19 @@ private fun PlayerScreenRuntime.BindPlayerMetadataAndSkipEffects() {
                 intervalKey !in autoSkippedIntervalKeys
             ) {
                 autoSkippedIntervalKeys.add(intervalKey)
-                controller.seekTo((current.endTime * 1000).toLong())
+                val seekPositionMs = (current.endTime * 1000).toLong()
+                controller.seekTo(seekPositionMs)
                 scheduleProgressSyncAfterSeek()
                 skipIntervalDismissed = true
+                playerNotificationMessage = getString(
+                    when (segmentType) {
+                        AutoSkipSegmentType.INTRO -> Res.string.player_auto_skip_intro_notification
+                        AutoSkipSegmentType.RECAP -> Res.string.player_auto_skip_recap_notification
+                        AutoSkipSegmentType.OUTRO -> Res.string.player_auto_skip_outro_notification
+                    },
+                    formatPlaybackTime(seekPositionMs),
+                )
+                playerNotificationToken += 1L
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeState.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeState.kt
@@ -167,6 +167,8 @@ internal class PlayerScreenRuntime(
     var submitIntroStatusMessage by mutableStateOf<String?>(null)
     var playerControlsPendingP2pSwitch by mutableStateOf<PendingPlayerP2pSwitch?>(null)
     var playerControlsCloseModalsToken by mutableStateOf(0L)
+    var playerNotificationMessage by mutableStateOf("")
+    var playerNotificationToken by mutableStateOf(0L)
     var episodeStreamsPanelState by mutableStateOf(EpisodeStreamsPanelState())
     var playerMetaVideos by mutableStateOf<List<MetaVideo>>(emptyList())
     var skipIntervals by mutableStateOf<List<SkipInterval>>(emptyList())

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
@@ -369,6 +369,8 @@ internal fun PlayerScreenRuntime.RenderPlayerRuntimeUi() {
         subtitleAutoSyncIsLoading = subtitleAutoSyncState.isLoading,
         subtitleAutoSyncErrorMessage = subtitleAutoSyncState.errorMessage.orEmpty(),
         closeModalsToken = playerControlsCloseModalsToken,
+        notificationMessage = playerNotificationMessage,
+        notificationToken = playerNotificationToken,
         showOpeningOverlay = openingOverlayWanted,
         openingArtwork = background ?: poster,
         openingLogo = logo,

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
@@ -1059,6 +1059,10 @@ private fun PlayerControlsState.toControlsJson(isFullscreen: Boolean): String =
         appendJsonArrayField("subtitleOutlineColorSwatches", SubtitleOutlineColorSwatches.map { it.toStorageHexString() }) { append(it.toJsonString()) }
         append(',')
         appendJsonField("closeModalsToken", closeModalsToken)
+        append(',')
+        appendJsonField("notificationMessage", notificationMessage)
+        append(',')
+        appendJsonField("notificationToken", notificationToken)
         append('}')
     }
 

--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -337,6 +337,8 @@ let state = {
   subtitleColorSwatches: [],
   subtitleOutlineColorSwatches: [],
   closeModalsToken: 0,
+  notificationMessage: "",
+  notificationToken: 0,
 };
 let isScrubbing = false;
 let scrubPositionMs = 0;
@@ -2794,6 +2796,7 @@ window.playerUpdate = update => {
 
 window.playerControls = nextState => {
   const previousCloseToken = Number(state.closeModalsToken) || 0;
+  const previousNotificationToken = Number(state.notificationToken) || 0;
   const previousResizeLabel = state.resizeModeLabel || "";
   const previousSpeedLabel = state.playbackSpeedLabel || "";
   const previousVolumeLevel = typeof state.volumeLevel === "number" ? state.volumeLevel : NaN;
@@ -2811,6 +2814,10 @@ window.playerControls = nextState => {
   const closeToken = Number(state.closeModalsToken) || 0;
   if (closeToken !== previousCloseToken) {
     closePlayerModal();
+  }
+  const notificationToken = Number(state.notificationToken) || 0;
+  if (notificationToken !== previousNotificationToken) {
+    showPlayerToast(state.notificationMessage);
   }
   if (state.showP2pConsent && activeModal !== "p2pConsent") {
     openPlayerModal("p2pConsent");


### PR DESCRIPTION
## Summary

Shows a brief player notification whenever the existing automatic skipping behavior skips an Intro or Opening, Recap, or Outro or Ending segment.

The notification names the skipped segment and shows the destination timestamp, for example `Intro skipped to 01:32` or `Outro skipped to 23:12`.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Automatic skipping currently seeks past enabled segments without giving the viewer any feedback. This can make the playback jump look accidental or make it unclear which segment was skipped. The existing manual skip controls already make the action visible, so automatic skips should provide equivalent confirmation.

## Desktop scope

This affects the Desktop player on Windows, macOS, and Linux. Shared player state carries a one time notification message and token because automatic skip detection lives in common player code. Only the Desktop native controls serialize and display the notification.

## Issue or approval

Automatic skipping was approved in #333 and merged in #334. This is a focused follow up that adds missing feedback to that existing behavior.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [x] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

This does not change skip providers, interval selection, automatic skip settings, manual skip behavior, or seek timing. It reuses the existing Desktop player toast and only emits a new message after the automatic skip path requests its seek.

## Testing

Tested on Windows 11.

- `:composeApp:compileKotlinDesktop` passed.
- `:composeApp:desktopTest` passed.
- `node --check composeApp/src/desktopMain/resources/player-ui/controls.js` passed.
- `git diff --check` passed.
- Confirmed an automatic Intro skip shows the segment name and destination timestamp.
- Confirmed an automatic Outro skip shows the segment name and destination timestamp.

## Screenshots / Video

### Intro

<img width="351" height="55" alt="IntroSkipped" src="https://github.com/user-attachments/assets/6fee64ce-bd19-4bdb-b057-493d2f750a38" />

### Outro

<img width="389" height="62" alt="OutroSkipped" src="https://github.com/user-attachments/assets/b3ae26c8-1871-4de8-b7e2-9f5d3703f048" />

## Breaking changes

None.

## Linked issues

Related to #333 and follow up to #334.