### PR TITLE
Handle mouse wheel to control volume

### DIFF
--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -2862,6 +2862,15 @@ root.addEventListener("dblclick", event => {
   togglePlayerFullscreen();
 });
 
+root.addEventListener("wheel", event => {
+  if (activeModal) return;
+  event.preventDefault();
+  const delta = Math.sign(event.deltaY) * -1;
+  if (delta !== 0) {
+    sendKeyboardVolume(delta);
+  }
+}, { passive: false });
+
 document.addEventListener("keydown", event => {
   if (event.key === "Escape" && activeModal) {
     event.preventDefault();


### PR DESCRIPTION
## Summary

Add a 'wheel' listener on the player root to let the mouse wheel adjust volume when no modal is active. The handler prevents default scrolling (uses `{ passive: false }`), maps wheel direction via `Math.sign(event.deltaY) * -1`, and calls `sendKeyboardVolume(delta)` for non-zero deltas. This enables volume changes with the wheel while avoiding interference when a modal is open. Volume is changed in 5% increments.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [x] Approved larger or directional change

## Why

Desktop users typically expect to be able to scroll with their mouse wheel anywhere over the video player to quickly adjust the volume. This PR implements this expected behavior smoothly by routing mouse wheel interactions through the existing keyboard volume overlay logic.

## Desktop scope

This change affects the shared desktop webview overlay (`controls.js`), applying to Windows, macOS, and Linux desktop builds. 

## Issue or approval

Approved on discord #0000

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

This PR is strictly limited to adding the mouse wheel listener in the JavaScript overlay layer. It intentionally does not modify any native Kotlin volume handling, as the existing `sendKeyboardVolume` handles everything needed.

## Testing

Tested on Windows by building the distributable (`.\gradlew.bat createDistributable`). Verified that scrolling up and down successfully adjusts the volume and triggers the native UI toast. Verified that scrolling does *not* affect the volume when a modal (like Subtitles or Episodes) is currently open, allowing native modal scrolling.

## Screenshots / Video

Not a UI change (reuses the existing volume toast).

## Breaking changes

None.

## Linked issues

None.
