### PR TITLE
fix: per-episode rating from addon metadata is never parsed

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsModels.kt
@@ -93,6 +93,7 @@ data class MetaVideo(
     val episode: Int? = null,
     val overview: String? = null,
     val runtime: Int? = null,
+    val rating: Double? = null,
     val streams: List<StreamItem> = emptyList(),
 )
 

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsParser.kt
@@ -235,6 +235,7 @@ internal object MetaDetailsParser {
                 episode = video.int("episode"),
                 overview = video.string("overview") ?: video.string("description"),
                 runtime = video.int("runtime"),
+                rating = video.string("rating")?.trim()?.toDoubleOrNull()?.takeIf { it > 0.0 },
                 streams = video.embeddedStreams(),
             )
         }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/components/DetailSeriesContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/components/DetailSeriesContent.kt
@@ -321,7 +321,7 @@ fun DetailSeriesContent(
                                     video = episode,
                                     fallbackImage = meta.background ?: meta.poster,
                                     progressEntry = progressByVideoId[episodeVideoId],
-                                    imdbRating = episode.seasonEpisodeKey()?.let { episodeRatings[it] },
+                                    imdbRating = episode.seasonEpisodeKey()?.let { episodeRatings[it] } ?: episode.rating,
                                     isWatched = progressByVideoId[episodeVideoId]?.isEffectivelyCompleted == true ||
                                         WatchingState.isEpisodeWatched(
                                             watchedKeys = watchedKeys,
@@ -655,7 +655,7 @@ private fun EpisodeHorizontalRow(
                 video = episode,
                 fallbackImage = fallbackImage,
                 progressEntry = progressByVideoId[episodeVideoId],
-                imdbRating = episode.seasonEpisodeKey()?.let { episodeRatings[it] },
+                imdbRating = episode.seasonEpisodeKey()?.let { episodeRatings[it] } ?: episode.rating,
                 isWatched = progressByVideoId[episodeVideoId]?.isEffectivelyCompleted == true ||
                     WatchingState.isEpisodeWatched(
                         watchedKeys = watchedKeys,


### PR DESCRIPTION
## Summary

`MetaDetailsParser.videos()` builds every `MetaVideo` without reading `rating`, so a per-episode rating supplied by a metadata addon is discarded. This adds the field, parses it, and falls back to it on the episode cards when the episode-ratings repository has no entry.

## PR type

- [x] Reproducible bug fix

## Why

`rating` is the field the Stremio meta object uses for per-episode ratings, and Cinemeta populates it — all 67 videos on Breaking Bad (`tt0903747`) carry one. The parser reads `runtime`, `overview`, `thumbnail` and the rest of the video object but not `rating`, so the value arrives and is dropped.

Episode ratings can then only come from `ImdbEpisodeRatingsRepository`, which needs an IMDb or TMDB id. That covers most series, so the gap only shows up with addons that use their own ids: `MetaDetailsScreen` resolves neither id, `getEpisodeRatings` returns an empty map, and the cards stay blank even though the addon sent a rating for every episode.

It is also total in a build from source — `composeApp/build.gradle.kts:162-163` defaults both rating API URLs to an empty string, so the repository returns nothing for every series.

## Desktop scope

Windows, macOS and Linux equally. The change is in `composeApp/src/commonMain`, which is shared, but it only touches series detail metadata parsing and the episode card in `DetailSeriesContent` — both desktop UI paths. No platform-specific code.

## Issue or approval

Fixes #392

## UI / behavior impact

- [x] Behavior changed only to fix a documented bug/regression

The rating badge already exists and already renders whenever the repository has a value. This only fills it when the repository has none, so nothing about the layout changes.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Three files, four lines. Deliberately not included:

- No change to `ImdbEpisodeRatingsRepository` or to how the external service is called. It keeps priority everywhere it returns a value.
- No new UI, no layout or styling changes.
- No change to the season/episode ratings shown anywhere other than the episode cards.
- The same defect exists on NuvioTV (NuvioMedia/NuvioTV#3129), NuvioWeb (NuvioMedia/NuvioWeb#690) and NuvioMobile. I have the equivalent change for each and can open them separately if you want them; nothing here depends on those.

## Testing

Built and run on Windows 10 with `:composeApp:run`, on a source build so both rating API URLs are empty and the repository returns nothing.

- Breaking Bad, season 1 — no ratings before the change, ratings from Cinemeta after.
- Stranger Things — no ratings before or after. Cinemeta sends `"rating": "0"` for all 70 of its videos, and the existing `imdbRating?.takeIf { it > 0.0 }` in both card composables keeps them blank, so unrated series are unaffected.
- An addon using its own ids — ratings shown where none could appear before from any source.
- `:composeApp:compileKotlinDesktop` passes with no new warnings.

I checked metadata display only, not playback.

## Screenshots / Video

All from a source build on Windows 10, where both rating API URLs are empty so the ratings repository returns nothing. Same images as on #392.

Breaking Bad season 1 before the change - no rating on any card, though Cinemeta sends one for all 67 videos:

<img width="1975" height="1320" alt="Before" src="https://github.com/user-attachments/assets/d2e2785a-20b5-4e1c-882a-b3e16a56de54" />

After, same screen:

<img width="1975" height="1320" alt="After" src="https://github.com/user-attachments/assets/77c58f0a-1498-4079-af60-9824df4d8543" />

Stranger Things on the patched build. Cinemeta sends `"rating": "0"` for all 70 of its videos and the existing `takeIf { it > 0.0 }` keeps them blank, so series without ratings are unchanged:

<img width="1975" height="1320" alt="Unrated series unaffected" src="https://github.com/user-attachments/assets/fe64c5c5-31cd-4ed2-9777-751f56fcb166" />

## Breaking changes

None. `rating` is a new nullable field with a default, `MetaVideo` is constructed in one place, and the addon value is only read where the repository returned nothing.

## Linked issues

Fixes #392
