### PR TITLE
fix(linux): make hitting play at the end of playback seek to start on linux

### DIFF
--- a/composeApp/src/desktopMain/native/linux/player_bridge.cpp
+++ b/composeApp/src/desktopMain/native/linux/player_bridge.cpp
@@ -449,7 +449,16 @@ void onPlayerMessage(WebKitUserContentManager *, WebKitJavascriptResult *js, gpo
     // it is up. cursorActivity also arrives while hidden (mouse woke the UI) and
     // must re-activate compositing so the fade-in is actually shown.
     if (type) {
-        if (strncmp(type, "keyboard", 8) == 0) {
+        if (strcmp(type, "setPlaybackState") == 0 ||
+            strcmp(type, "setPlaybackStateQuiet") == 0) {
+            bool shouldPlay = value >= 0.5;
+            if (shouldPlay && (player->ended.load() || mpvGetFlag(player->mpv, "eof-reached"))) {
+                const char *cmd[] = {"seek", "0", "absolute", nullptr};
+                mpv_command(player->mpv, cmd);
+                player->ended.store(false);
+            }
+            mpvSetFlag(player->mpv, "pause", !shouldPlay);
+        } else if (strncmp(type, "keyboard", 8) == 0) {
             // Keyboard shortcuts (page keydown, real X focus): the page renders
             // its feedback toast without revealing the chrome, so neither latch
             // overlayActive (nothing would ever unlatch it — hideChrome only


### PR DESCRIPTION
## Summary

This change makes it so that toggling playback state at eof restarts the playback instead of doing nothing.
This is the equivalent of the bridge changes in https://github.com/NuvioMedia/NuvioDesktop/commit/a938caf5f73c5625f10d1763128ad24cfb699767 to Linux bridge to ensure behavior parity with the other bridges. This was missed/omitted in the initial PR.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [X] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

This change is needed to ensure behavioral parity between platforms.

## Desktop scope

Platform: Linux

## Issue or approval

Fixes https://github.com/NuvioMedia/NuvioDesktop/issues/477

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [X] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [X] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [X] I have read and understood `CONTRIBUTING.md`.
- [X] This PR is small, focused, and limited to one problem.
- [X] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [X] This PR is not cosmetic-only.
- [X] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [X] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [X] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [X] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [X] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

Scoped to Linux bridge only.

## Testing

Tested on Fedora 44 with Radeon RX9070 XT. Hitting the play button or space at the end of playback restarted it, doing those actions when not at eof paused/resumed the playback as expected.

## Screenshots / Video

Not a UI change

## Breaking changes

None

## Linked issues
Closes https://github.com/NuvioMedia/NuvioDesktop/issues/477
