### PR TITLE
Fall back to an entry's other known IDs when no addon serves its canonical ID

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsRepository.kt
@@ -10,6 +10,8 @@ import com.nuvio.app.features.home.HomeCatalogSettingsRepository
 import com.nuvio.app.features.home.filterReleasedItems
 import com.nuvio.app.features.mdblist.MdbListMetadataService
 import com.nuvio.app.features.mdblist.MdbListSettingsRepository
+import com.nuvio.app.features.simkl.SimklSyncRepository
+import com.nuvio.app.features.simkl.alternateContentIdsFor
 import com.nuvio.app.features.tmdb.TmdbMetadataService
 import com.nuvio.app.features.tmdb.TmdbService
 import com.nuvio.app.features.tmdb.TmdbSettingsRepository
@@ -168,6 +170,21 @@ object MetaDetailsRepository {
                 return@launch
             }
 
+            val alternate = withContext(Dispatchers.Default) {
+                tryFetchMetaByAlternateId(type = type, id = metaLookupId)
+            }
+            if (alternate != null) {
+                publishLoadedMeta(
+                    requestKey = requestKey,
+                    meta = alternate.meta,
+                    fallbackItemId = alternate.id,
+                    fallbackItemType = type,
+                    mdbListSettings = mdbListSettings,
+                    metaScreenSettingsFingerprint = metaScreenSettingsFingerprint,
+                )
+                return@launch
+            }
+
             _uiState.value = MetaDetailsUiState(
                 errorMessage = getString(Res.string.details_load_failed_all_addons),
             )
@@ -212,7 +229,14 @@ object MetaDetailsRepository {
             }
         }
 
-        return tryFetchTmdbFallbackMeta(type = type, id = id)?.also { result ->
+        tryFetchTmdbFallbackMeta(type = type, id = id)?.let { result ->
+            if (cacheResult) {
+                cachedMetaByRequestKey[requestKey] = CachedMetaEntry(baseMeta = result)
+            }
+            return result
+        }
+
+        return tryFetchMetaByAlternateId(type = type, id = metaLookupId)?.meta?.also { result ->
             if (cacheResult) {
                 cachedMetaByRequestKey[requestKey] = CachedMetaEntry(baseMeta = result)
             }
@@ -273,6 +297,33 @@ object MetaDetailsRepository {
             log.e(e) { "Failed to fetch/parse meta from $url (manifest=${manifest.transportUrl})" }
             null
         }
+    }
+
+    private data class AlternateMeta(val id: String, val meta: MetaDetails)
+
+    /**
+     * Last-resort lookup for items whose canonical ID no installed addon can serve.
+     *
+     * A Simkl anime season can carry a season-specific IMDB ID that no meta addon indexes, while
+     * the same entry's MAL/AniDB/AniList/Kitsu IDs resolve fine through an anime addon. Those IDs
+     * are already known, so try them instead of failing. Only runs once every addon and the TMDB
+     * fallback have already missed, so the normal path is unaffected.
+     */
+    private suspend fun tryFetchMetaByAlternateId(type: String, id: String): AlternateMeta? {
+        val alternateIds = SimklSyncRepository.state.value.snapshot.alternateContentIdsFor(id)
+        if (alternateIds.isEmpty()) return null
+
+        log.d { "Retrying meta for id=$id with alternate ids=$alternateIds" }
+        for (alternateId in alternateIds) {
+            for (manifest in findMetaManifests(AddonRepository.uiState.value, type, alternateId)) {
+                val result = tryFetchMeta(manifest, type, alternateId, includeMdbList = false)
+                if (result != null) {
+                    log.i { "Resolved meta for id=$id via alternate id=$alternateId" }
+                    return AlternateMeta(id = alternateId, meta = result)
+                }
+            }
+        }
+        return null
     }
 
     private suspend fun findReadyMetaManifests(type: String, id: String): List<AddonManifest> {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/SeriesPlaybackResolver.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/SeriesPlaybackResolver.kt
@@ -220,11 +220,13 @@ internal fun latestCompletedSeriesEpisode(
     parentMetaType: String,
     progressEntries: List<WatchProgressEntry>,
     watchedItems: List<WatchedItem>,
+    preferFurthestEpisode: Boolean = true,
 ): CompletedSeriesEpisode? =
     latestCompletedSeriesEpisode(
         content = WatchingContentRef(type = parentMetaType, id = parentMetaId),
         progressRecords = progressEntries.map(WatchProgressEntry::toDomainProgressRecord),
         watchedRecords = watchedItems.map(WatchedItem::toDomainWatchedRecord),
+        preferFurthestEpisode = preferFurthestEpisode,
     )?.toLegacyCompletedEpisode()
 
 private fun MetaVideo.toDomainReleasedEpisode(): WatchingReleasedEpisode =

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeScreen.kt
@@ -36,10 +36,12 @@ import com.nuvio.app.features.cloud.CloudLibraryContentType
 import com.nuvio.app.features.cloud.CloudLibraryRepository
 import com.nuvio.app.features.cloud.CloudLibraryUiState
 import com.nuvio.app.features.cloud.findPlaybackTargetForProgress
+import com.nuvio.app.features.details.CompletedSeriesEpisode
 import com.nuvio.app.features.details.MetaDetails
 import com.nuvio.app.features.details.MetaDetailsRepository
 import com.nuvio.app.features.details.MetaVideo
 import com.nuvio.app.features.details.SeriesPrimaryAction
+import com.nuvio.app.features.details.latestCompletedSeriesEpisode
 import com.nuvio.app.features.details.seriesPrimaryAction
 import com.nuvio.app.features.home.components.HomeCatalogRowSection
 import com.nuvio.app.features.home.components.HomeContinueWatchingSection
@@ -1275,6 +1277,43 @@ internal fun classifyHomeNextUpCandidateMetadata(
     )
 }
 
+/**
+ * Re-anchors a Next Up candidate onto the content ID its metadata actually came from.
+ *
+ * When no installed addon serves an entry's own ID, [MetaDetailsRepository] falls back to one of
+ * the entry's other IDs - for a Simkl anime season, the franchise IMDB ID it shares through TVDB.
+ * The episode list that comes back is then the whole franchise's, while the candidate's seed was
+ * computed from that one arc's watch history, because the sibling arcs are recorded under the
+ * franchise ID instead. Left unreconciled the seed is the arc's own finale, so Next Up offers the
+ * first episode of the following arc - an episode the user has usually already watched under a
+ * sibling entry.
+ *
+ * Recomputing the seed under [resolvedContentId] puts both halves back on one identity: the
+ * franchise episode list is now read against the franchise watch history. It also collapses the
+ * candidate onto the franchise's own candidate, so one series cannot produce two Next Up cards.
+ *
+ * Returns [candidate] unchanged when no fallback happened, and null when the resolved ID carries
+ * no usable completed episode - there is no seed to offer a next episode from. A season-zero seed
+ * is rejected for the same reason [buildHomeNextUpSeedCandidates] rejects one: specials do not
+ * establish where a viewer is in the run.
+ */
+internal fun reanchorHomeNextUpCandidate(
+    candidate: CompletedSeriesCandidate,
+    resolvedContentId: String?,
+    resolvedLatestCompleted: CompletedSeriesEpisode?,
+): CompletedSeriesCandidate? {
+    val normalizedResolvedId = resolvedContentId?.trim().orEmpty()
+    if (normalizedResolvedId.isEmpty()) return candidate
+    if (normalizedResolvedId.equals(candidate.content.id.trim(), ignoreCase = true)) return candidate
+    if (resolvedLatestCompleted == null || resolvedLatestCompleted.seasonNumber == 0) return null
+    return CompletedSeriesCandidate(
+        content = candidate.content.copy(id = normalizedResolvedId),
+        seasonNumber = resolvedLatestCompleted.seasonNumber,
+        episodeNumber = resolvedLatestCompleted.episodeNumber,
+        markedAtEpochMs = resolvedLatestCompleted.markedAtEpochMs,
+    )
+}
+
 private suspend fun resolveHomeNextUpCandidate(
     completedEntry: CompletedSeriesCandidate,
     watchProgressEntries: List<WatchProgressEntry>,
@@ -1300,11 +1339,24 @@ private suspend fun resolveHomeNextUpCandidate(
         return HomeNextUpResolutionAttempt.transientFailure()
     }
 
+    val resolvedContentId = meta.id.takeIf(String::isNotBlank) ?: contentId
     val resolvedProgressEntries = WatchProgressRepository.prepareNextUpProgressEntries(
         entries = watchProgressEntries,
-        contentId = contentId,
+        contentId = resolvedContentId,
     )
     val resolvedWatchedItems = watchedItems
+    val anchoredEntry = reanchorHomeNextUpCandidate(
+        candidate = completedEntry,
+        resolvedContentId = resolvedContentId,
+        resolvedLatestCompleted = latestCompletedSeriesEpisode(
+            parentMetaId = resolvedContentId,
+            parentMetaType = completedEntry.content.type,
+            progressEntries = resolvedProgressEntries,
+            watchedItems = resolvedWatchedItems,
+            preferFurthestEpisode = preferFurthestEpisode,
+        ),
+    ) ?: return HomeNextUpResolutionAttempt.conclusiveNone()
+    val anchoredContentId = anchoredEntry.content.id
     val resolvedWatchedKeys = resolvedWatchedItems.mapTo(linkedSetOf()) { item ->
         watchedItemKey(item.type, item.id, item.season, item.episode)
     }
@@ -1326,7 +1378,7 @@ private suspend fun resolveHomeNextUpCandidate(
     }
 
     val action = meta.seriesPrimaryAction(
-        content = completedEntry.content,
+        content = anchoredEntry.content,
         entries = resolvedProgressEntries,
         watchedItems = resolvedWatchedItems,
         todayIsoDate = todayIsoDate,
@@ -1345,7 +1397,7 @@ private suspend fun resolveHomeNextUpCandidate(
         return HomeNextUpResolutionAttempt.conclusiveNone()
     }
     val metadataDecision = classifyHomeNextUpCandidateMetadata(
-        freshItem = completedEntry.toContinueWatchingSeed(meta)
+        freshItem = anchoredEntry.toContinueWatchingSeed(meta)
             .toUpNextContinueWatchingItem(nextEpisode),
         cachedFallbackItem = cachedFallbackItem,
         dismissedNextUpKeys = dismissedNextUpKeys,
@@ -1359,12 +1411,12 @@ private suspend fun resolveHomeNextUpCandidate(
     }
 
     val sortTimestamp = if (item.isReleaseAlert) {
-        com.nuvio.app.features.watchprogress.parseReleaseDateToEpochMs(item.released) ?: completedEntry.markedAtEpochMs
+        com.nuvio.app.features.watchprogress.parseReleaseDateToEpochMs(item.released) ?: anchoredEntry.markedAtEpochMs
     } else {
-        completedEntry.markedAtEpochMs
+        anchoredEntry.markedAtEpochMs
     }
     return HomeNextUpResolutionAttempt.success(
-        contentId to (sortTimestamp to item),
+        anchoredContentId to (sortTimestamp to item),
     )
 }
 

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklProjections.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklProjections.kt
@@ -170,6 +170,45 @@ internal fun SimklSyncSnapshot.toSimklProgressEntries(): List<WatchProgressEntry
         .mapNotNull { (_, candidates) -> candidates.maxByOrNull(WatchProgressEntry::lastUpdatedEpochMs) }
         .sortedByDescending(WatchProgressEntry::lastUpdatedEpochMs)
 
+/**
+ * Returns the other content IDs the entry matching [contentId] is known under, in fallback order.
+ *
+ * Used as a last resort when no installed addon can serve meta for [contentId]. An anime season can
+ * carry a season-specific IMDB ID that no meta addon indexes, even though the rest of the franchise
+ * shares a parent IMDB ID that resolves fine.
+ *
+ * Sibling IMDB IDs come first so the franchise keeps its IMDB identity — that is what the
+ * "Prefer IMDB" option promises, and it keeps episode air dates coming from the same source as the
+ * rest of the library. The entry's own MAL/AniDB/AniList/Kitsu IDs follow as a last resort.
+ */
+internal fun SimklSyncSnapshot.alternateContentIdsFor(contentId: String): List<String> {
+    val media = entries.firstOrNull { entry -> entry.matchesContentId(contentId) }?.media ?: return emptyList()
+    return (siblingImdbIdsFor(media) + media.alternateContentIds())
+        .filterNot { it.equals(contentId, ignoreCase = true) }
+        .distinct()
+}
+
+/**
+ * IMDB IDs used by other entries that belong to the same TVDB series as [media], most common first.
+ *
+ * Simkl models each anime season as its own entry but keeps the franchise TVDB ID on all of them,
+ * so the seasons that share a parent IMDB ID identify that parent for the season that does not.
+ */
+private fun SimklSyncSnapshot.siblingImdbIdsFor(media: SimklMedia): List<String> {
+    val tvdbId = media.ids.idValue("tvdb") ?: return emptyList()
+    val ownImdbId = media.ids.idValue("imdb")
+    return entries
+        .mapNotNull { entry -> entry.media }
+        .filter { candidate -> tvdbId.equals(candidate.ids.idValue("tvdb"), ignoreCase = true) }
+        .mapNotNull { candidate -> candidate.ids.idValue("imdb") }
+        .filterNot { imdbId -> imdbId.equals(ownImdbId, ignoreCase = true) }
+        .groupingBy { imdbId -> imdbId }
+        .eachCount()
+        .entries
+        .sortedByDescending { (_, count) -> count }
+        .map { (imdbId, _) -> imdbId }
+}
+
 internal fun SimklSyncSnapshot.toSimklShowIdSiblings(): Map<String, Set<String>> {
     val siblingsMap = mutableMapOf<String, MutableSet<String>>()
     entries.forEach { entry ->
@@ -305,7 +344,7 @@ internal fun SimklMedia.canonicalContentId(animeIdPreference: SimklAnimeIdPrefer
  * When the user prefers MAL or Kitsu as the canonical anime ID, only the preferred ID type
  * is emitted to prevent duplicates in continue watching and watched badge resolution.
  */
-private fun SimklMedia.alternateContentIds(): Set<String> {
+internal fun SimklMedia.alternateContentIds(): Set<String> {
     val preference = TrackingSettingsRepository.uiState.value.simklAnimeIdPreference
     return when (preference) {
         SimklAnimeIdPreference.IMDB -> buildSet {

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/home/HomeScreenTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/home/HomeScreenTest.kt
@@ -7,6 +7,7 @@ import com.nuvio.app.features.cloud.CloudLibraryProviderState
 import com.nuvio.app.features.cloud.CloudLibraryUiState
 import com.nuvio.app.features.cloud.playbackVideoId
 import com.nuvio.app.features.debrid.DebridProviders
+import com.nuvio.app.features.details.CompletedSeriesEpisode
 import com.nuvio.app.features.watchprogress.CachedInProgressItem
 import com.nuvio.app.features.watchprogress.CachedNextUpItem
 import com.nuvio.app.features.watchprogress.ContinueWatchingItem
@@ -23,6 +24,7 @@ import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -593,6 +595,136 @@ class HomeScreenTest {
         )
 
         assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `next up candidate keeps its own id when the addon served that id`() {
+        val candidate = CompletedSeriesCandidate(
+            content = WatchingContentRef(type = "series", id = "tt9335498"),
+            seasonNumber = 5,
+            episodeNumber = 8,
+            markedAtEpochMs = 3_000L,
+        )
+
+        val result = reanchorHomeNextUpCandidate(
+            candidate = candidate,
+            resolvedContentId = "tt9335498",
+            resolvedLatestCompleted = CompletedSeriesEpisode(
+                seasonNumber = 5,
+                episodeNumber = 8,
+                markedAtEpochMs = 3_000L,
+            ),
+        )
+
+        assertEquals(candidate, result)
+    }
+
+    @Test
+    fun `next up candidate resolved through a sibling id reseeds from the franchise history`() {
+        // Simkl models each anime arc as its own entry: this one carries a season-specific IMDB ID
+        // no addon serves, so its metadata resolves through the franchise ID the arcs share. Its
+        // own history stops at the arc finale (S3E11) while the franchise history runs to S5E8.
+        val arcCandidate = CompletedSeriesCandidate(
+            content = WatchingContentRef(type = "series", id = "tt15757634"),
+            seasonNumber = 3,
+            episodeNumber = 11,
+            markedAtEpochMs = 1_000L,
+        )
+
+        val result = reanchorHomeNextUpCandidate(
+            candidate = arcCandidate,
+            resolvedContentId = "tt9335498",
+            resolvedLatestCompleted = CompletedSeriesEpisode(
+                seasonNumber = 5,
+                episodeNumber = 8,
+                markedAtEpochMs = 3_000L,
+            ),
+        )
+
+        assertEquals(
+            CompletedSeriesCandidate(
+                content = WatchingContentRef(type = "series", id = "tt9335498"),
+                seasonNumber = 5,
+                episodeNumber = 8,
+                markedAtEpochMs = 3_000L,
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `next up candidate resolved through a sibling id without franchise history is dropped`() {
+        val arcCandidate = CompletedSeriesCandidate(
+            content = WatchingContentRef(type = "series", id = "tt15757634"),
+            seasonNumber = 3,
+            episodeNumber = 11,
+            markedAtEpochMs = 1_000L,
+        )
+
+        assertNull(
+            reanchorHomeNextUpCandidate(
+                candidate = arcCandidate,
+                resolvedContentId = "tt9335498",
+                resolvedLatestCompleted = null,
+            ),
+        )
+        assertNull(
+            reanchorHomeNextUpCandidate(
+                candidate = arcCandidate,
+                resolvedContentId = "tt9335498",
+                resolvedLatestCompleted = CompletedSeriesEpisode(
+                    seasonNumber = 0,
+                    episodeNumber = 4,
+                    markedAtEpochMs = 3_000L,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `next up candidate keeps its own id when no resolved id is reported`() {
+        val candidate = CompletedSeriesCandidate(
+            content = WatchingContentRef(type = "series", id = "tt15757634"),
+            seasonNumber = 3,
+            episodeNumber = 11,
+            markedAtEpochMs = 1_000L,
+        )
+
+        assertEquals(candidate, reanchorHomeNextUpCandidate(candidate, resolvedContentId = null, resolvedLatestCompleted = null))
+        assertEquals(candidate, reanchorHomeNextUpCandidate(candidate, resolvedContentId = "  ", resolvedLatestCompleted = null))
+    }
+
+    @Test
+    fun `reseeded next up candidate collapses onto the franchise dismiss key`() {
+        // The arc entry and the franchise entry must not produce two cards for one series: after
+        // reseeding they share a content ID and a seed, so one dismissal covers both.
+        val arcCandidate = CompletedSeriesCandidate(
+            content = WatchingContentRef(type = "series", id = "tt3687376"),
+            seasonNumber = 2,
+            episodeNumber = 24,
+            markedAtEpochMs = 1_000L,
+        )
+        val franchiseCompleted = CompletedSeriesEpisode(
+            seasonNumber = 3,
+            episodeNumber = 39,
+            markedAtEpochMs = 2_000L,
+        )
+
+        val reanchored = reanchorHomeNextUpCandidate(
+            candidate = arcCandidate,
+            resolvedContentId = "tt2359704",
+            resolvedLatestCompleted = franchiseCompleted,
+        )
+
+        assertNotNull(reanchored)
+        assertEquals(
+            nextUpDismissKey("tt2359704", 3, 39),
+            nextUpDismissKey(
+                reanchored.content.id,
+                reanchored.seasonNumber,
+                reanchored.episodeNumber,
+            ),
+        )
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/simkl/SimklProjectionsTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/simkl/SimklProjectionsTest.kt
@@ -341,6 +341,101 @@ class SimklProjectionsTest {
         assertNull(parseSimklUtcEpochMs("2024-01-01T00:00:00+01:00"))
     }
 
+    @Test
+    fun `alternate content ids prefer the franchise imdb id over per season anime ids`() {
+        // Re:Zero season 4: Simkl gives that season its own IMDB id that meta addons do not index,
+        // while the other seasons of the same TVDB series share the parent IMDB id.
+        val snapshot = SimklSyncSnapshot(entries = listOf(
+            animeEntry(simkl = 509292, imdb = "tt5607616", tvdb = "305089", mal = "31240", kitsu = "11209"),
+            animeEntry(simkl = 1367345, imdb = "tt5607616", tvdb = "305089", mal = "42203", kitsu = "43247"),
+            animeEntry(simkl = 2125704, imdb = "tt5607616", tvdb = "305089", mal = "54857", kitsu = "47235"),
+            animeEntry(
+                simkl = 2743422,
+                imdb = "tt36501927",
+                tvdb = "305089",
+                mal = "61316",
+                kitsu = "49746",
+                anidb = "19242",
+                anilist = "189046",
+            ),
+        ))
+
+        val alternates = snapshot.alternateContentIdsFor("tt36501927")
+
+        assertFalse(alternates.contains("tt36501927"))
+        assertEquals("tt5607616", alternates.first())
+        assertEquals(1, alternates.count { it == "tt5607616" })
+        assertTrue(alternates.contains("mal:61316"))
+        assertTrue(alternates.contains("kitsu:49746"))
+        assertTrue(alternates.indexOf("tt5607616") < alternates.indexOf("mal:61316"))
+    }
+
+    @Test
+    fun `alternate content ids fall back to anime ids when no sibling shares the tvdb series`() {
+        val snapshot = SimklSyncSnapshot(entries = listOf(
+            animeEntry(
+                simkl = 2743422,
+                imdb = "tt36501927",
+                tvdb = "305089",
+                mal = "61316",
+                kitsu = "49746",
+                anidb = "19242",
+                anilist = "189046",
+            ),
+        ))
+
+        val alternates = snapshot.alternateContentIdsFor("tt36501927")
+
+        assertFalse(alternates.any { it.startsWith("tt") })
+        assertTrue(alternates.contains("mal:61316"))
+        assertTrue(alternates.contains("anidb:19242"))
+        assertTrue(alternates.contains("anilist:189046"))
+        assertTrue(alternates.contains("kitsu:49746"))
+    }
+
+    @Test
+    fun `alternate content ids are empty for an unknown content id`() {
+        val snapshot = SimklSyncSnapshot(
+            entries = listOf(
+                entry(
+                    type = SimklMediaType.SHOWS,
+                    status = SimklListStatus.WATCHING,
+                    id = 2090,
+                    imdb = "tt1520211",
+                ),
+            ),
+        )
+
+        assertEquals(emptyList(), snapshot.alternateContentIdsFor("tt0000000"))
+    }
+
+    private fun animeEntry(
+        simkl: Long,
+        imdb: String,
+        tvdb: String,
+        mal: String? = null,
+        kitsu: String? = null,
+        anidb: String? = null,
+        anilist: String? = null,
+    ): SimklLibraryEntry = SimklLibraryEntry(
+        mediaType = SimklMediaType.ANIME,
+        status = SimklListStatus.WATCHING,
+        show = SimklMedia(
+            title = "Re:Zero - Starting Life in Another World",
+            poster = "20/poster",
+            year = 2026,
+            ids = buildJsonObject {
+                put("simkl", simkl)
+                put("imdb", imdb)
+                put("tvdb", tvdb)
+                mal?.let { put("mal", it) }
+                kitsu?.let { put("kitsu", it) }
+                anidb?.let { put("anidb", it) }
+                anilist?.let { put("anilist", it) }
+            },
+        ),
+    )
+
     private fun entry(
         type: SimklMediaType,
         status: SimklListStatus,


### PR DESCRIPTION
Fixes #483.

## Old behavior

`SimklMedia.canonicalContentId()` picks one ID and the meta lookup either resolves it or gives up.
For anime under `Prefer IMDB` that ID is whatever `imdb` value Simkl attached to *that entry*.

## Broken behavior

Simkl gives some anime seasons their own IMDB title. Re:Zero season 4 is reported as `tt36501927`,
and Cinemeta answers `GET /meta/series/tt36501927.json` with `200 {}`. The entry then cannot be
opened at all:

1. `resolveMetaLookupId` returns the ID unchanged — it only rewrites `tmdb:` IDs.
2. `findMetaManifests` offers only Cinemeta, since manifest `idPrefixes` filtering excludes every
   anime-ID addon for a `tt` ID.
3. Cinemeta's `{}` is correctly treated as a miss — `MetaDetailsParser` throws and `tryFetchMeta`
   returns null — but there is nothing left to try.
4. `tryFetchTmdbFallbackMeta` returns null immediately: `fetchStandaloneMeta` bails unless the ID
   starts with `tmdb:`.
5. The screen ends at `details_load_failed_all_addons`.

Meanwhile the same Simkl entry carries `mal:61316`, `anidb:19242`, `anilist:189046`, `kitsu:49746`,
and four sibling Re:Zero entries on the same TVDB series carry the parent `tt5607616` — which
Cinemeta serves with season 4 and correct air dates. None of it was consulted.

## New behavior

`SimklSyncSnapshot.alternateContentIdsFor(contentId)` returns the other IDs the matching entry is
known under. `MetaDetailsRepository` consults it **only after every addon and the TMDB fallback have
already missed**, so the normal path is unchanged and costs nothing.

Sibling IMDB IDs are tried first, most common first. Simkl models each anime season as its own entry
but keeps the franchise TVDB ID on all of them, so the seasons that do share a parent IMDB ID
identify that parent for the season that does not. Preferring them keeps Cinemeta as the metadata
source — and with it correct episode air dates — instead of silently moving one title to a different
metadata provider. That is also what the `Prefer IMDB` option already describes: *"Group anime
seasons under a shared IMDB ID"*. The entry's own MAL/AniDB/AniList/Kitsu IDs follow as a last resort.

Reuses the existing `alternateContentIds()`, which was already computed for watched-key emission; it
only changes from `private` to `internal`.

## How this was tested

**Unit:** three tests in `SimklProjectionsTest` covering the real Re:Zero ID set — that the franchise
IMDB ID is returned and ordered ahead of the anime IDs, that anime IDs are still used when no sibling
shares the TVDB series, and that an unknown content ID yields nothing. `SimklProjectionsTest` is
14/14.

**Full suite:** `:composeApp:desktopTest` — 790 tests, 1 failure in
`NativePlayerControllerTeardownTest.sourceGapsDisposeSuccessfulSupersededCreatesBeforeReplacementPublication`,
which reproduces identically on a clean checkout of `Dev` with these changes stashed. Unrelated to
this PR.

**Against a real library:** replayed the resolution logic over a 1283-entry Simkl library
(1099 unique `(id, type)` pairs) with Cinemeta and AIOStreams installed. 43 entries could not be
opened before; 38 resolve after — 12 via the franchise IMDB ID, 26 via an anime ID. Full per-title
breakdown in #483. The 5 remaining are movies carrying only a TMDB ID, which need a configured TMDB
key rather than a code change.

Manually verified on Windows with a patched local build: the Re:Zero season 4 Library entry opens on
the parent title, which is also where Continue Watching already points and where that show's watch
history is stored.

## Scope

Three files, +187/-2, no dependency, UI, or architecture changes. The new lookup runs only on the
path that previously ended in an error.


---

## Second commit: reseed Next Up when an entry resolves through a sibling ID

Found by running this branch on Windows for a day. The fallback above turns a dead meta lookup into
a live one, and Home's Next Up was not ready for a candidate whose metadata belongs to a different
ID than its watch history. Two finished shows started offering episodes already watched:

| Card | Seed | Entry |
|---|---|---|
| Demon Slayer: Kimetsu no Yaiba — S4E1 "Someone's Dream" | S3E11 | `tt15757634` — *Entertainment District Arc* |
| JoJo's Bizarre Adventure — S2E25 | S2E24 | `tt3687376` — *Stardust Crusaders* |

Both entries are Cinemeta misses — `tt15757634` answers `200 {}`, `tt3687376` answers `200` with no
`name` field, which `MetaDetailsParser` requires — so both reach the new fallback and resolve through
the franchise IMDB ID their TVDB siblings carry. They come back with the whole franchise's episode
list, while `latestCompletedSeriesEpisode` still filters watch history by the candidate's own content
ID, where only that arc's episodes are recorded:

```
tt15757634 history: S3E1-11          → next after S3E11 = S4E1  (watched, under tt9335498)
tt9335498  history: S1, S2, S4, S5   → next after S5E8  = nothing
```

`reanchorHomeNextUpCandidate()` moves the candidate onto the ID the metadata actually came from and
recomputes the seed from that ID's history, so both halves are read on one identity. It also
collapses the arc candidate onto the franchise's own candidate, so one series cannot produce two
cards. A candidate that reseeds onto nothing, or onto a season-zero special, is dropped rather than
guessed at — the same rule `buildHomeNextUpSeedCandidates` already applies to its seeds. Nothing
changes when the addon serves the requested ID, which is every entry that resolved before this PR.

Tested by replaying the Next Up pipeline over the same 1284-entry library with the live Cinemeta
responses: the "before" run reproduces both cards exactly as they appeared on the Home screen, down
to the episode titles, and the "after" run produces neither. Five tests in `HomeScreenTest` cover the
reseeding, the untouched path, both drop conditions, and the dismiss-key collapse. Manually verified
on Windows 11 with a local build installed over 1.1.20 — both cards are gone from Continue Watching
and the rest of the rail is unchanged. Full reasoning and the replay output are in
[this comment](https://github.com/NuvioMedia/NuvioDesktop/pull/459#issuecomment-5415876144).

`:composeApp:desktopTest` for the branch as a whole is now 796 tests, 0 failures — the
`NativePlayerControllerTeardownTest` flake noted above did not reproduce.

Three files, +192/-6, two of which this PR already touches.
