### PR TITLE
fix(player-ui): prevent click-to-pause from triggering inside bottom controls and metadata

### DIFF
--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -2855,9 +2855,47 @@ window.playerControls = nextState => {
   }
 };
 
+
+const isControlsSurfaceEvent = event => {
+  if (activeModal) return true;
+  if (event.target.closest("button, input, textarea, select, a, .action-pill, .volume-control, .modal-layer, .skip-prompt, .next-episode-card")) {
+    return true;
+  }
+
+  const seekEl = document.getElementById("seek");
+  if (seekEl && event.clientY >= seekEl.getBoundingClientRect().top - 6) {
+    return true;
+  }
+
+  const titleEl = document.getElementById("title");
+  const metaRow = document.querySelector(".meta-row");
+  if (titleEl && metaRow) {
+    const titleRect = titleEl.getBoundingClientRect();
+    const metaRect = metaRow.getBoundingClientRect();
+    const textTop = Math.min(titleRect.top, metaRect.top);
+    const textBottom = Math.max(titleRect.bottom, metaRect.bottom);
+    const textRight = titleRect.left + Math.max(titleEl.scrollWidth, metaRow.scrollWidth) + 16;
+
+    if (
+        event.clientX >= titleRect.left &&
+        event.clientX <= textRight &&
+        event.clientY >= textTop &&
+        event.clientY <= textBottom
+    ) {
+      return true;
+    }
+  }
+
+  const header = document.querySelector(".header");
+  if (header && event.clientY <= header.getBoundingClientRect().bottom + 10) {
+    return true;
+  }
+
+  return false;
+};
+
 root.addEventListener("click", event => {
-  if (playbackErrorText()) return;
-  if (event.target.closest("button,input")) return;
+  if (playbackErrorText() || isControlsSurfaceEvent(event)) return;
   window.clearTimeout(tapTimer);
   tapTimer = window.setTimeout(() => {
     requestPlaybackState("setPlaybackStateQuiet", false);
@@ -2865,8 +2903,7 @@ root.addEventListener("click", event => {
 });
 
 root.addEventListener("dblclick", event => {
-  if (playbackErrorText()) return;
-  if (event.target.closest("button,input")) return;
+  if (playbackErrorText() || isControlsSurfaceEvent(event)) return;
   event.preventDefault();
   window.clearTimeout(tapTimer);
   togglePlayerFullscreen();


### PR DESCRIPTION
## Summary

Prevents the root tap-to-pause and double-click fullscreen handlers in the desktop player UI from misfiring when clicking within the bottom controls, seekbar area, and metadata text bounding box.

## PR type

- [x] Behavior bug/regression fix

## Why

In `controls.js`, the root `click` and `dblclick` listeners previously only checked `event.target.closest("button,input")`. Because text elements and control bar padding are not `<button>` or `<input>`, clicking anywhere on the bottom controls bar (such as title text, metadata labels, time display, or empty padding around buttons) fell through to the root handler, unintentionally toggling play/pause or fullscreen.

## Desktop scope

Desktop shared player UI (`composeApp/src/desktopMain/resources/player-ui/controls.js`), affecting all desktop platforms (Windows, macOS, Linux).

## Issue or approval

Fixes #469

## UI / behavior impact

- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only adjusts click event filtering in `controls.js` for root `click` and `dblclick` events. Does not alter player styling, layout, or core player playback logic.

## Testing

Tested locally on Windows 11:
- Verified that clicking on the title text, metadata labels, time display, and empty space around bottom buttons does not toggle play/pause or fullscreen.
- Verified that clicking on the open video canvas smoothly toggles play/pause.
- Verified that all interactive controls (play/pause toggle, volume slider, seekbar, and modals) continue to function normally.

## Screenshots / Video

Not a UI change (interaction/behavior fix only).

## Breaking changes

None.

## Linked issues

Fixes #469