### PR TITLE
fix(linux): trap X errors while destroying the player overlay

### DIFF
--- a/composeApp/src/desktopMain/native/linux/player_bridge.cpp
+++ b/composeApp/src/desktopMain/native/linux/player_bridge.cpp
@@ -1287,7 +1287,19 @@ gboolean destroyWebviewOnGtk(gpointer data) {
             }
         }
         player->savedFocusXid = 0;
+        // WebKit's dispose resets the tooltip (WebPageProxy::close ->
+        // resetState -> setToolTip("")), and GTK answers that with a
+        // pointer-position query — gtk_tooltip_trigger_tooltip_query ->
+        // gdk_device_get_window_at_position -> XIQueryPointer — which walks the
+        // very X tree this destroy is dismantling. The reply comes back
+        // BadWindow, and GDK escalates an untrapped X error to a fatal g_log,
+        // i.e. G_BREAKPOINT: the process dies on int3 with no Java stack. Seen
+        // at every episode boundary, where the next-episode swap disposes the
+        // player. Trap the destroy the same way the focus handover above does.
+        GdkDisplay *destroyDisplay = gtk_widget_get_display(player->gtkWindow);
+        gdk_x11_display_error_trap_push(destroyDisplay);
         gtk_widget_destroy(player->gtkWindow);
+        gdk_x11_display_error_trap_pop_ignored(destroyDisplay);
         player->gtkWindow = nullptr;
         player->webview = nullptr;
         player->overlayXid = 0;
@@ -1919,7 +1931,15 @@ JNIEXPORT void JNICALL NP(shutdownWebView2Warmup)(JNIEnv *, jobject) {
     g_main_context_invoke(nullptr,
                           +[](gpointer) -> gboolean {
                               if (gWarmupWindow) {
+                                  // Same fatal-X-error exposure as the overlay
+                                  // teardown (see destroyWebviewOnGtk): the
+                                  // webview's dispose queries the pointer
+                                  // position while this window is dying.
+                                  GdkDisplay *d =
+                                      gtk_widget_get_display(gWarmupWindow);
+                                  gdk_x11_display_error_trap_push(d);
                                   gtk_widget_destroy(gWarmupWindow);
+                                  gdk_x11_display_error_trap_pop_ignored(d);
                                   // The view/ucm die with their window — null
                                   // them too or the adoption gate could later
                                   // read dangling pointers.


### PR DESCRIPTION
## Summary

Wrap the two `gtk_widget_destroy` calls in the Linux player bridge in a GDK X error trap, so an X error raised while the overlay window is being dismantled can no longer take the whole process down.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

On Linux the app could die during player teardown, with the window vanishing and no Java stack trace. The process dies on `int3` with SIGTRAP, which bypasses the JVM crash handler, so no `hs_err` file is written.

From the core dump, on the GTK thread:

```
Java_..._NativePlayerBridge_dispose
 -> gtk_widget_destroy(player->gtkWindow)
   -> g_object_run_dispose(WebKitWebViewBase)
     -> WebPageProxy::close -> resetState -> setToolTip("")
       -> webkitWebViewBaseSetTooltipText
         -> gtk_tooltip_trigger_tooltip_query
           -> gdk_device_get_window_at_position -> XIQueryPointer
             -> reply carries BadWindow
               -> gdk_x_error -> g_log (fatal) -> G_BREAKPOINT
```

WebKit's dispose resets its tooltip unconditionally, GTK answers that with a pointer-position query, and that query walks the X tree the destroy is dismantling. When it samples a window that has just died the reply is `BadWindow`, and GDK escalates an untrapped X error to a fatal log.

It depends on pointer position and destroy timing, so it is a race: it fired once in twelve episodes here, at an episode boundary, where the next-episode swap disposes the player.

Not a regression: the destroy has been untrapped since the Linux bridge was added in `a80c0235`, and no commit has touched that line since. It only surfaced now because the race is rare.

The focus handover a few lines above the destroy already uses `gdk_x11_display_error_trap_push`/`pop` for the same class of problem. The destroy itself was the one X call in that function left untrapped.

`pop_ignored` needs no `XSync`: GDK ignores by request-serial range, and the `XIQueryPointer` round-trip is issued inside the trap.

## Desktop scope

Linux only. `composeApp/src/desktopMain/native/linux/player_bridge.cpp`. No shared or common code changed.

## Issue or approval

Fixes #464

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the two `gtk_widget_destroy` call sites are touched. The teardown order, the focus handover, the release barrier and the surface lifecycle are all unchanged. No retry, no timeout, no logging changes.

The second call site, `shutdownWebView2Warmup`, destroys a `WebKitWebViewBase` the same way and so carries the same fatal exposure at app exit. It is included because it is the same defect, not as a drive-by.

## Testing

Linux, NixOS 25.11, KDE Plasma 6 on Wayland, Xwayland 24.1.12, WebKitGTK 2.52.4, GTK 3, GLib 2.86.3, OpenJDK 17.0.18.

- Confirmed the crash chain in the core dump before fixing: SIGTRAP, `int3` in libglib, and the full teardown stack above.
- Verified the patched `.so` contains the traps by disassembly (5 `error_trap_push`, 3 `error_trap_pop_ignored`, 2 `error_trap_pop` call sites, matching the source).
- Ran the patched build for roughly 16 hours across 10 episodes, which is about 9 teardowns of the kind that crashed. No crash, no core dump, no `X Window System error`, no GDK/GTK criticals, and no release-watchdog timeouts.
- The original failure took twelve episodes to appear once, so this is evidence rather than proof. The trap makes the outcome non-fatal however the race falls.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #464
