### PR TITLE
fix(desktop): stop parsing an empty TorrServer response as JSON

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/p2p/P2pStreamingEngine.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/p2p/P2pStreamingEngine.desktop.kt
@@ -672,7 +672,12 @@ actual object P2pStreamingEngine {
                 .build()
             val response = client.send(request, HttpResponse.BodyHandlers.ofString())
             if (response.statusCode() !in 200..299) return null
-            return json.parseToJsonElement(response.body().orEmpty()).jsonObject
+            // TorrServer answers some actions -- "drop" among them -- with 2xx and an
+            // empty body, which is not a JSON document. Parsing it threw on every
+            // dropTorrent call. No body means no object to return.
+            val raw = response.body().orEmpty()
+            if (raw.isBlank()) return null
+            return json.parseToJsonElement(raw).jsonObject
         }
     }
 


### PR DESCRIPTION
## Summary

Return `null` from `postJson` when TorrServer replies 2xx with an empty body, instead of handing the empty string to the JSON parser.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

TorrServer answers some `/torrents` actions with 2xx and an empty body. `drop` is one of them, so every `dropTorrent` call threw:

```
JsonDecodingException: Cannot read Json element because of unexpected
end of the input at path: $
```

It is caught and logged as a warning, so nothing breaks, but it fires on every torrent teardown — ten times in one viewing session here — and buries real problems in the log.

Not a regression: the unconditional parse has been there since `660b9be6`, and no commit has touched that line since.

An empty body is not a JSON document and there is no object to return, so `null` is the correct result. `postJson` already returns `JsonObject?` and already returns `null` for a non-2xx status.

## Desktop scope

Desktop shared code: `composeApp/src/desktopMain/kotlin/com/nuvio/app/features/p2p/P2pStreamingEngine.desktop.kt`. Not platform specific — any desktop platform running the bundled TorrServer hits it.

## Issue or approval

Fixes #465

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the blank-body case in `postJson` is changed. Status handling, timeouts, headers and every caller are untouched. The warning log in `dropTorrent` is left as it is, so a genuine failure still surfaces.

All three `postJson` callers already handle `null`: `addTorrent` checks it explicitly and logs a failure, one reader uses an elvis return, and `dropTorrent` ignores the result. So no caller changes behavior except by no longer seeing an exception.

## Testing

Linux, NixOS 25.11, OpenJDK 17.0.18.

- Confirmed the failing path in a real session log: ten `dropTorrent error` warnings, each with an empty `JSON input:`.
- `:composeApp:compileKotlinDesktop` passes.
- Read all three `postJson` call sites to confirm each already handles a `null` return.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #465
