### PR TITLE
fix(details): retain sticky top bar when returning while scrolled

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
@@ -885,7 +886,7 @@ fun MetaDetailsScreen(
                         .calculateTopPadding()
                         .toPx()
                 }
-                val heroHeightPx = remember(meta.id) { mutableIntStateOf(0) }
+                val heroHeightPx = rememberSaveable(meta.id) { mutableIntStateOf(0) }
                 // Keep pixel-by-pixel list state reads out of this composition.
                 val detailScrollOffsetPx = remember(listState, heroHeightPx) {
                     {
@@ -901,10 +902,13 @@ fun MetaDetailsScreen(
                 }
                 val isHeroCollapsed = remember(listState, heroHeightPx, safeAreaTopPx) {
                     derivedStateOf {
-                        val measuredHeroHeightPx = heroHeightPx.intValue
-                        val thresholdPx = (measuredHeroHeightPx - safeAreaTopPx).coerceAtLeast(0f)
-                        measuredHeroHeightPx > 0 &&
-                            (listState.firstVisibleItemIndex > 0 || detailScrollOffsetPx() > thresholdPx)
+                        if (listState.firstVisibleItemIndex > 0) {
+                            true
+                        } else {
+                            val measuredHeroHeightPx = heroHeightPx.intValue
+                            val thresholdPx = (measuredHeroHeightPx - safeAreaTopPx).coerceAtLeast(0f)
+                            measuredHeroHeightPx > 0 && detailScrollOffsetPx() > thresholdPx
+                        }
                     }
                 }
                 val heroTrailerSourceUrl = heroTrailerPlaybackSource


### PR DESCRIPTION
## Summary

Fixes a UI state bug on the details screen where the sticky top header bar (containing the logo, list actions, and fullscreen button) disappeared when returning from playback while scrolled down.

## PR type

- [x] UI glitch/bug fix

## Why

When returning to `MetaDetailsScreen` from playback while scrolled down into the episodes list, `LazyColumn` restores its scroll position to item index > 0. Because Item 0 (the hero banner) is scrolled off-screen, `LazyColumn` does not compose it, leaving `heroHeightPx` initialized at `0`.

The `isHeroCollapsed` condition previously required `measuredHeroHeightPx > 0 && ...`, which evaluated to `false` when `heroHeightPx` was `0`, causing Compose to treat the hero as uncollapsed, hiding the sticky floating header bar and incorrectly showing the floating back button over episode content.

## Desktop scope

Shared multiplatform UI code (`composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsScreen.kt`). Resolves the header state restoration glitch on Desktop as well as all shared platforms.

## Issue or approval

Fixes #470

## UI / behavior impact

- [x] UI changed only to fix a documented glitch/bug

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only adjusts `heroHeightPx` retention (`rememberSaveable`) and ensures `isHeroCollapsed` evaluates to `true` when `firstVisibleItemIndex > 0`. Does not alter styling, header layout, or hero animations.

## Testing

Tested on Windows 11:
- Scrolled down to the episodes section on a series details screen until the sticky top header appeared.
- Selected an episode, started playback, and navigated back to the details screen.
- Verified that the restored scrolled-down position properly displays the sticky floating header bar instead of disappearing.
- Verified scrolling back to the top smoothly transitions between the floating header and the hero back button.

## Screenshots / Video

### Before (Sticky header missing on return)
<img width="1919" height="880" alt="Before - Header missing on return" src="https://github.com/user-attachments/assets/e0372a7a-3a60-4013-8d64-f5409f8ecdb6" />

### After (Sticky header retained on return)
<img width="1919" height="944" alt="After - Sticky header retained on return" src="https://github.com/user-attachments/assets/e8e2c1a9-9a8e-4d8f-87db-14afcaa77ae1" />

*Note: Both screenshots were taken immediately after exiting playback back to the details screen while remaining scrolled down at the episodes list.*

## Breaking changes

None.

## Linked issues

Fixes #470
