### PR TITLE
fix(player): use activePauseDescription for pause overlay metadata

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
@@ -250,7 +250,7 @@ internal fun PlayerScreenRuntime.RenderPlayerRuntimeUi() {
             activeProviderName
         },
         pauseOverlayEpisodeTitle = activeEpisodeTitle.orEmpty(),
-        pauseOverlayDescription = (pauseDescription ?: activeStreamSubtitle).orEmpty(),
+        pauseOverlayDescription = (activePauseDescription ?: activeStreamSubtitle).orEmpty(),
         resizeModeLabel = stringResource(resizeMode.labelRes),
         playbackSpeedLabel = formatPlaybackSpeedLabel(playbackSnapshot.playbackSpeed),
         subtitlesLabel = stringResource(Res.string.compose_player_subs),


### PR DESCRIPTION
## Summary

Fixes a bug where the desktop player's idle pause metadata overlay continued displaying the previous episode's synopsis after transitioning to a new episode in-player.

## PR type

- [x] Behavior bug/regression fix

## Why

In `PlayerScreenRuntimeUi.kt`, `playerControlsState` constructed `pauseOverlayDescription` using `pauseDescription` (the static argument passed at player launch) rather than `activePauseDescription`. When transitioning between episodes in-player (via next episode auto-play or stream selection), `activePauseDescription` was updated in state but ignored by `playerControlsState`, leaving the desktop pause overlay showing stale synopsis text from the initial episode.

## Desktop scope

Shared multiplatform player UI (`composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt`).

## Issue or approval

Fixes #471

## UI / behavior impact

- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only changes `pauseOverlayDescription` to reference `activePauseDescription`. Does not modify player controls layout, auto-play logic, or tracking session builders.

## Testing

Tested on Windows 11:
- Played an episode and advanced to the next episode in-player.
- Paused playback and waited for the pause metadata overlay to appear.
- Verified that the description updates to the active episode's synopsis instead of retaining the previous episode's text.

## Screenshots / Video

Not a UI change (metadata state propagation fix only).

## Breaking changes

None.

## Linked issues

Fixes #471