### PR TITLE
fix(linux): make the mouse back and forward buttons work

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/LinuxExtendedMouseButtons.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/LinuxExtendedMouseButtons.kt
@@ -1,0 +1,69 @@
+package com.nuvio.app
+
+import java.awt.AWTEvent
+import java.awt.Toolkit
+import java.awt.event.MouseEvent
+
+// X11 numbers the mouse thumb buttons 8 and 9. Java's XToolkit reports the
+// vertical wheel as MouseWheelEvent and keeps the horizontal wheel as buttons 4
+// and 5, so the thumb buttons arrive as AWT buttons 6 and 7. Compose derives
+// PointerButton.Back from the 4th button, so the back navigation in
+// MainAppContent never matched and the button did nothing on Linux.
+//
+// Re-post the press and release under the button number Compose expects. The
+// shared code stays untouched and keeps working unchanged on Windows and macOS,
+// where the toolkit already numbers these buttons the way Compose reads them.
+//
+// Only Back is mapped. Nothing acts on PointerButton.Forward: there is no
+// forward navigation anywhere in the app, and the player's own seek arrives
+// through the native bridge rather than through AWT, so mapping the second
+// thumb button would post events that no handler consumes.
+//
+// Install this only once the window peer exists. Reaching for the AWT toolkit
+// during main() forces it up before GTK has finished initializing, which is the
+// ordering main() opens by warning about, and it leaves the window unable to
+// close.
+private const val X11_THUMB_BACK = 6
+private const val COMPOSE_BACK = 4
+
+@Volatile
+private var extendedMouseButtonsInstalled = false
+
+fun installLinuxExtendedMouseButtons() {
+    if (!System.getProperty("os.name", "").lowercase().contains("linux")) return
+    synchronized(LinuxExtendedMouseButtonsLock) {
+        if (extendedMouseButtonsInstalled) return
+        extendedMouseButtonsInstalled = true
+    }
+    // Never let an input convenience take the app down with it.
+    runCatching {
+        val toolkit = Toolkit.getDefaultToolkit()
+        toolkit.addAWTEventListener({ event ->
+            val source = event as? MouseEvent ?: return@addAWTEventListener
+            if (source.id != MouseEvent.MOUSE_PRESSED && source.id != MouseEvent.MOUSE_RELEASED) {
+                return@addAWTEventListener
+            }
+            if (source.button != X11_THUMB_BACK) return@addAWTEventListener
+            val component = source.component ?: return@addAWTEventListener
+            // The replacement carries the mapped button, so this listener sees
+            // it, fails the check above, and returns -- it cannot feed itself.
+            runCatching {
+                toolkit.systemEventQueue.postEvent(
+                    MouseEvent(
+                        component,
+                        source.id,
+                        source.getWhen(),
+                        source.modifiersEx,
+                        source.x,
+                        source.y,
+                        source.clickCount,
+                        source.isPopupTrigger,
+                        COMPOSE_BACK,
+                    ),
+                )
+            }
+        }, AWTEvent.MOUSE_EVENT_MASK)
+    }
+}
+
+private object LinuxExtendedMouseButtonsLock

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
@@ -143,6 +143,7 @@ fun main(args: Array<String>) {
 
             LaunchedEffect(window) {
                 applyNativeDesktopWindowChrome(window)
+                installLinuxExtendedMouseButtons()
                 // Windows fullscreen is emulated natively and isn't reflected by
                 // WindowPlacement, so it must be re-applied once the window peer exists.
                 fullscreenController.applyRestoredFullscreenState(window, windowState, wasFullscreenOnLastExit)

--- a/composeApp/src/desktopMain/native/linux/player_bridge.cpp
+++ b/composeApp/src/desktopMain/native/linux/player_bridge.cpp
@@ -1064,6 +1064,37 @@ gboolean createWebviewOnGtk(gpointer data) {
                                     gpointer) -> gboolean { return TRUE; }),
                      nullptr);
 
+    // Mouse thumb buttons never reach the controls page on Linux. X11 delivers
+    // them as buttons 8 and 9, but the DOM numbers them 3 and 4, and WebKitGTK
+    // does not translate between the two -- so the page's back/forward seek
+    // handler (which is shared with Windows, where WebView2 does translate)
+    // never fires here. Nothing reports it: the buttons are simply dead.
+    // Emit the same events the page would have sent, so both platforms end up
+    // in the same Kotlin handler.
+    g_signal_connect(wv, "button-press-event",
+                     G_CALLBACK(+[](GtkWidget *, GdkEventButton *ev,
+                                    gpointer data) -> gboolean {
+                         auto *p = static_cast<Player *>(data);
+                         if (!playerAlive(p)) return FALSE;
+                         const char *action = ev->button == 8   ? "seekBack"
+                                              : ev->button == 9 ? "seekForward"
+                                                                : nullptr;
+                         if (!action) return FALSE;
+                         // Consume it either way: letting a half-handled thumb
+                         // button fall through to WebKit gains nothing.
+                         if (!p->eventSink || !p->eventMethod) return TRUE;
+                         JNIEnv *env = attachGtkThread();
+                         if (env) {
+                             jstring jtype = env->NewStringUTF(action);
+                             env->CallVoidMethod(p->eventSink, p->eventMethod,
+                                                 jtype, (jdouble)0.0);
+                             env->DeleteLocalRef(jtype);
+                         }
+                         NUVIO_LOG("thumb button %u -> %s", ev->button, action);
+                         return TRUE;
+                     }),
+                     player);
+
     if (!adopted) gtk_container_add(GTK_CONTAINER(win), GTK_WIDGET(wv));
 
     // Make sure the overlay actually asks the X server for pointer/keyboard


### PR DESCRIPTION
## Summary

The mouse thumb buttons do nothing on Linux — neither seek in the player nor back navigation while browsing. Both are button-numbering mismatches, at two different layers, and both are fixed here.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

X11 numbers the thumb buttons **8 and 9**. Nothing on the desktop side expects those numbers, and they arrive differently depending on which toolkit is looking:

**In the player.** The controls page listens for DOM buttons 3 and 4:

```js
if (event.button === 3) { send("seekBack", 0); }
else if (event.button === 4) { send("seekForward", 0); }
```

WebKitGTK does not translate 8/9 into DOM 3/4, so that handler never fires. Windows works because WebView2 does translate — the Windows bridge has no side-button code at all, so both platforms depend entirely on this one DOM path.

**Outside the player.** Java's XToolkit reports the vertical wheel as `MouseWheelEvent` and keeps the horizontal wheel as buttons 4 and 5, so the thumb buttons reach AWT as buttons **6 and 7**. Compose derives `PointerButton.Back` from the 4th button, so `MainAppContent`'s back navigation never matched.

Neither can fix the other: even a corrected Compose mapping would not reach the player, because Compose receives no pointer events over the native video surface.

Nothing reported either failure. No error, no log — the buttons were simply inert in the app while working everywhere else on the system.

## Desktop scope

Linux only, three files: the native bridge handles buttons 8 and 9 on the player overlay, and a desktop-only listener re-posts the AWT back press under the number Compose expects. No shared or common code changed, and the controls page is untouched, so Windows and macOS behavior is unchanged.

## Issue or approval

Related to #294, the approved request this feature serves, implemented for desktop in #449.

Not using a closing keyword: #294 asks for more than this delivers, so it should stay open.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

One problem — the thumb buttons on Linux — at the two layers that each drop them. Only buttons 8 and 9 natively, and button 6 in AWT, are claimed; every other button falls through untouched.

Only Back is mapped in AWT. Nothing acts on `PointerButton.Forward` — there is no forward navigation anywhere in the app, and the player's seek arrives through the native bridge rather than AWT — so mapping the second thumb button would post events that no handler consumes.

The existing event names, seek step and toast are reused rather than replaced, so behavior matches Windows rather than diverging. No change to the controls page, to shared code, or to any other platform.

The AWT listener is installed from the window's `LaunchedEffect`, not `main()`. Touching the AWT toolkit during startup forces it up before GTK has finished initializing — the ordering `main()` opens by warning about — and leaves the window unable to close. It is installed once and its work is exception-guarded, so an input convenience cannot take the app down.

Forward still does nothing outside the player. `PointerButton.Forward` is handled only in `PlayerScreenContent`; there is no app-level forward navigation on any platform, so this matches Windows rather than adding something new.

## Testing

Linux, NixOS 25.11, KDE Plasma 6 on Wayland, WebKitGTK 2.52.4, GTK 3, OpenJDK 17.0.18, five-button mouse.

- Reproduced first: both thumb buttons inert throughout the app, working normally in other applications on the same machine.
- Confirmed with a standalone AWT probe that the buttons arrive as AWT 6 and 7, and that Java sees 8 buttons — so the hardware and X mapping were never in question.
- Confirmed the Windows bridge has no side-button handling, so the DOM path is the only mechanism there.
- With the patch: **in the player, back and forward each seek 10s**, matching a single `seekBy(10_000L)` step — one press, one seek, no double handling from the two paths.
- **Outside the player, back navigates to the previous screen.** Forward does nothing, as on Windows.
- Window opens and closes normally, repeatedly.
- Wheel-to-volume and click-to-mute from the same feature set verified unaffected.
- Builds clean against `Dev` with only these two commits applied.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Related to #294. Implemented for desktop in #449; this makes it work on Linux.
