### PR TITLE
fix(addons): skip cloud sync for guest sessions

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/addons/AddonRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/addons/AddonRepository.kt
@@ -1,6 +1,8 @@
 package com.nuvio.app.features.addons
 
 import co.touchlab.kermit.Logger
+import com.nuvio.app.core.auth.AuthRepository
+import com.nuvio.app.core.auth.AuthState
 import com.nuvio.app.core.network.SupabaseProvider
 import com.nuvio.app.core.sync.putSyncOriginClientId
 import com.nuvio.app.features.profiles.ProfileRepository
@@ -47,6 +49,9 @@ private data class AddonPushItem(
 )
 
 private const val ADDON_PUSH_DEBOUNCE_MS = 500L
+
+internal fun shouldPushAddonsToServer(authState: AuthState): Boolean =
+    authState is AuthState.Authenticated && !authState.isAnonymous
 
 object AddonRepository {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -403,6 +408,10 @@ object AddonRepository {
 
     private fun pushToServer() {
         if (isUsingPrimaryAddonsFromSecondaryProfile()) return
+        if (!shouldPushAddonsToServer(AuthRepository.state.value)) {
+            log.d { "pushToServer() — skipped: registered authenticated session required" }
+            return
+        }
         val profileId = currentProfileId
         val addons = _uiState.value.addons
             .distinctBy { it.manifestUrl }
@@ -419,6 +428,10 @@ object AddonRepository {
         pushJob = scope.launch {
             try {
                 delay(ADDON_PUSH_DEBOUNCE_MS)
+                if (!shouldPushAddonsToServer(AuthRepository.state.value)) {
+                    log.d { "pushToServer() — cancelled: registered authenticated session no longer active" }
+                    return@launch
+                }
                 log.d { "pushToServer() — profileId=$profileId, pushing ${addons.size} addons" }
                 val params = buildJsonObject {
                     put("p_profile_id", profileId)

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/addons/AddonSyncEligibilityTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/addons/AddonSyncEligibilityTest.kt
@@ -1,0 +1,44 @@
+package com.nuvio.app.features.addons
+
+import com.nuvio.app.core.auth.AuthState
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AddonSyncEligibilityTest {
+    @Test
+    fun `server push is disabled while authentication is loading`() {
+        assertFalse(shouldPushAddonsToServer(AuthState.Loading))
+    }
+
+    @Test
+    fun `server push is disabled when unauthenticated`() {
+        assertFalse(shouldPushAddonsToServer(AuthState.Unauthenticated))
+    }
+
+    @Test
+    fun `server push is disabled for local anonymous users`() {
+        assertFalse(
+            shouldPushAddonsToServer(
+                AuthState.Authenticated(
+                    userId = "guest-id",
+                    email = null,
+                    isAnonymous = true,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `server push is enabled for registered authenticated users`() {
+        assertTrue(
+            shouldPushAddonsToServer(
+                AuthState.Authenticated(
+                    userId = "member-id",
+                    email = "member@example.com",
+                    isAnonymous = false,
+                ),
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- prevent guest, anonymous, and unauthenticated addon mutations from scheduling authenticated cloud sync
- re-check authentication after the 500 ms debounce so an auth transition cannot race into the RPC
- add deterministic state-policy coverage for loading, unauthenticated, anonymous, and registered sessions

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Guest addon changes persist locally but currently attempt the authenticated `sync_push_addons` Supabase RPC afterward. That request is rejected as unauthorized and emits a background stack trace. Guest mode should remain local-only, matching the sync eligibility policy already used by LibraryRepository.

## Desktop scope

Shared desktop addon repository behavior. The fix is platform-neutral and affects only cloud-sync eligibility; local addon installation, persistence, enable/disable, removal, and registered-account sync remain in place.

## Issue or approval

Fixes #475.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

No UI changes, RPC schema changes, addon transport changes, auth-flow changes, retry changes, or unrelated synchronization refactors. The existing registered non-anonymous path remains eligible to push.

## Testing

TDD and local verification on x86_64 Linux / JDK 17:

- RED: the new policy regression failed before `shouldPushAddonsToServer` existed
- focused eligibility test: passed
- addon test group: passed
- exact clean upstream-based branch:
  - desktop: 134 suites / 792 tests / 0 failures
  - media player: 16 suites / 82 tests / 0 failures
- exact installed production-configured DEB runtime:
  - guest addon install and enable/disable persisted locally
  - log emitted only `pushToServer() — skipped: registered authenticated session required`
  - no `sync_push_addons` request and no unauthorized exception
- independent exact-diff review at SHA-256 `84a025c9f9ba83d4a21e2d487eca6a7fe74465d53772072bd851cd8d9e4b893a`: passed with no security or logic findings

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #475.
