### PR TITLE
fix(linux): copy native video frames atomically

### DIFF
--- a/vendor/compose-media-player/mediaplayer/build.gradle.kts
+++ b/vendor/compose-media-player/mediaplayer/build.gradle.kts
@@ -65,9 +65,14 @@ val buildNativeWindows by tasks.registering(Exec::class) {
     commandLine("cmd", "/c", nativeDir.file("build.bat").asFile.absolutePath)
 }
 
+val cleanLegacyLinuxNativeResource by tasks.registering(Delete::class) {
+    delete(layout.projectDirectory.dir("src/jvmMain/resources/composemediaplayer/native/linux-x86-64"))
+}
+
 val buildNativeLinux by tasks.registering(Exec::class) {
     val nativeDir = layout.projectDirectory.dir("src/jvmMain/native/linux")
     enabled = Os.isFamily(Os.FAMILY_UNIX) && !Os.isFamily(Os.FAMILY_MAC)
+    dependsOn(cleanLegacyLinuxNativeResource)
     inputs.dir(nativeDir)
     outputs.dir(generatedNativeLibraryDir)
     workingDir(nativeDir)
@@ -75,6 +80,12 @@ val buildNativeLinux by tasks.registering(Exec::class) {
     commandLine("bash", "build.sh")
 }
 
+val nativeBuildTasks = listOf(buildNativeMacOs, buildNativeWindows, buildNativeLinux)
+
+tasks.named("assembleJvmMainResources") {
+    dependsOn(nativeBuildTasks)
+}
+
 tasks.named("jvmProcessResources") {
-    dependsOn(buildNativeMacOs, buildNativeWindows, buildNativeLinux)
+    dependsOn(nativeBuildTasks)
 }

--- a/vendor/compose-media-player/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxFrameResourceGate.kt
+++ b/vendor/compose-media-player/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxFrameResourceGate.kt
@@ -1,0 +1,26 @@
+package io.github.kdroidfilter.composemediaplayer.linux
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.LockSupport
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/** Serializes native frame writes with closing their Skia-backed destinations. */
+internal class LinuxFrameResourceGate {
+    private val lock = ReentrantLock()
+
+    fun <T> withResources(block: () -> T): T = lock.withLock(block)
+
+    /** Test seam that observes an actual lock queue rather than inferring from elapsed time. */
+    internal fun waitUntilQueued(
+        thread: Thread,
+        timeoutMillis: Long,
+    ): Boolean {
+        val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis)
+        while (System.nanoTime() < deadline) {
+            if (lock.hasQueuedThread(thread)) return true
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(1))
+        }
+        return lock.hasQueuedThread(thread)
+    }
+}

--- a/vendor/compose-media-player/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxFrameUtils.kt
+++ b/vendor/compose-media-player/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxFrameUtils.kt
@@ -2,6 +2,19 @@ package io.github.kdroidfilter.composemediaplayer.linux
 
 import java.nio.ByteBuffer
 
+internal fun checkedFrameBufferSize(
+    width: Int,
+    height: Int,
+    rowBytes: Int,
+): Long? {
+    if (width <= 0 || height <= 0 || rowBytes <= 0) return null
+    val minimumRowBytes = width.toLong() * 4L
+    if (minimumRowBytes > Int.MAX_VALUE || rowBytes.toLong() < minimumRowBytes) return null
+    val totalBytes = rowBytes.toLong() * height.toLong()
+    if (totalBytes > Int.MAX_VALUE) return null
+    return totalBytes
+}
+
 internal fun copyBgraFrame(
     src: ByteBuffer,
     dst: ByteBuffer,

--- a/vendor/compose-media-player/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxNativeBridge.kt
+++ b/vendor/compose-media-player/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxNativeBridge.kt
@@ -8,6 +8,12 @@ import java.nio.ByteBuffer
  * Handles are opaque Long values (native pointer cast to jlong, 0 = null).
  */
 internal object LinuxNativeBridge {
+    const val FRAME_COPY_INVALID = -1
+    const val FRAME_COPY_DEST_TOO_SMALL = -2
+    const val FRAME_COPY_SIZE_CHANGED = -3
+    const val FRAME_COPY_NOT_READY = 0
+    const val FRAME_COPY_OK = 1
+
     init {
         NativeLibraryLoader.load("NativeVideoPlayer", LinuxNativeBridge::class.java)
     }
@@ -46,7 +52,14 @@ internal object LinuxNativeBridge {
     @JvmStatic external fun nGetPlaybackSpeed(handle: Long): Float
 
     // Frame access
-    @JvmStatic external fun nGetLatestFrameAddress(handle: Long): Long
+    @JvmStatic external fun nCopyLatestFrame(
+        handle: Long,
+        destination: ByteBuffer,
+        expectedWidth: Int,
+        expectedHeight: Int,
+        destinationStride: Int,
+        outInfo: IntArray,
+    ): Int
 
     @JvmStatic external fun nWrapPointer(
         address: Long,

--- a/vendor/compose-media-player/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxVideoPlayerState.kt
+++ b/vendor/compose-media-player/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxVideoPlayerState.kt
@@ -24,6 +24,7 @@ import org.jetbrains.skia.ColorAlphaType
 import org.jetbrains.skia.ColorType
 import org.jetbrains.skia.ImageInfo
 import java.io.File
+import java.nio.ByteBuffer
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.math.abs
@@ -52,6 +53,10 @@ class LinuxVideoPlayerState : VideoPlayerState {
     private var skiaBitmapHeight: Int = 0
     private var skiaBitmapA: Bitmap? = null
     private var skiaBitmapB: Bitmap? = null
+    private var skiaBitmapABuffer: ByteBuffer? = null
+    private var skiaBitmapBBuffer: ByteBuffer? = null
+    private val frameCopyInfo = IntArray(3)
+    private val frameResourceGate = LinuxFrameResourceGate()
     private var nextSkiaBitmapA: Boolean = true
 
     // Surface display size (pixels) for output scaling
@@ -472,66 +477,111 @@ class LinuxVideoPlayerState : VideoPlayerState {
         bufferingCheckJob = null
     }
 
+    private fun allocateFrameTargets(
+        width: Int,
+        height: Int,
+    ): Boolean {
+        val imageInfo = ImageInfo(width, height, ColorType.BGRA_8888, ColorAlphaType.OPAQUE)
+        val newBitmapA = Bitmap().apply { allocPixels(imageInfo) }
+        val newBitmapB = Bitmap().apply { allocPixels(imageInfo) }
+        val pixmapA = newBitmapA.peekPixels()
+        val pixmapB = newBitmapB.peekPixels()
+        if (pixmapA == null || pixmapB == null || pixmapA.addr == 0L || pixmapB.addr == 0L) {
+            newBitmapA.close()
+            newBitmapB.close()
+            return false
+        }
+
+        val sizeA = checkedFrameBufferSize(width, height, pixmapA.rowBytes)
+        val sizeB = checkedFrameBufferSize(width, height, pixmapB.rowBytes)
+        if (sizeA == null || sizeB == null) {
+            newBitmapA.close()
+            newBitmapB.close()
+            return false
+        }
+
+        val newBufferA = LinuxNativeBridge.nWrapPointer(pixmapA.addr, sizeA)
+        val newBufferB = LinuxNativeBridge.nWrapPointer(pixmapB.addr, sizeB)
+        if (newBufferA == null || newBufferB == null) {
+            newBitmapA.close()
+            newBitmapB.close()
+            return false
+        }
+
+        skiaBitmapA?.close()
+        skiaBitmapB?.close()
+        skiaBitmapA = newBitmapA
+        skiaBitmapB = newBitmapB
+        skiaBitmapABuffer = newBufferA
+        skiaBitmapBBuffer = newBufferB
+        skiaBitmapWidth = width
+        skiaBitmapHeight = height
+        nextSkiaBitmapA = true
+        return true
+    }
+
     private suspend fun updateFrameAsync() {
         withContext(frameDispatcher) {
             try {
-                val ptr = playerPtr
-                if (ptr == 0L) return@withContext
+                val copied =
+                    frameResourceGate.withResources resources@{
+                        val ptr = playerPtr
+                        if (ptr == 0L) return@resources false
 
-                val width = LinuxNativeBridge.nGetFrameWidth(ptr)
-                val height = LinuxNativeBridge.nGetFrameHeight(ptr)
-                if (width <= 0 || height <= 0) return@withContext
+                        val width = LinuxNativeBridge.nGetFrameWidth(ptr)
+                        val height = LinuxNativeBridge.nGetFrameHeight(ptr)
+                        if (width <= 0 || height <= 0) return@resources false
 
-                val frameAddress = LinuxNativeBridge.nGetLatestFrameAddress(ptr)
-                if (frameAddress == 0L) return@withContext
+                        if (
+                            skiaBitmapA == null ||
+                            skiaBitmapWidth != width ||
+                            skiaBitmapHeight != height
+                        ) {
+                            if (!allocateFrameTargets(width, height)) return@resources false
+                        }
 
-                val pixelCount = width * height
-                val frameSizeBytes = pixelCount.toLong() * 4L
-                var framePublished = false
+                        val useBitmapA = nextSkiaBitmapA
+                        val targetBitmap = if (useBitmapA) skiaBitmapA else skiaBitmapB
+                        val destination = if (useBitmapA) skiaBitmapABuffer else skiaBitmapBBuffer
+                        if (targetBitmap == null || destination == null) return@resources false
+                        val pixmap = targetBitmap.peekPixels() ?: return@resources false
+                        val destinationSize =
+                            checkedFrameBufferSize(width, height, pixmap.rowBytes)
+                                ?: return@resources false
+                        if (destination.capacity().toLong() < destinationSize) return@resources false
 
-                withContext(Dispatchers.Default) {
-                    val srcBuf =
-                        LinuxNativeBridge.nWrapPointer(frameAddress, frameSizeBytes)
-                            ?: return@withContext
+                        val status =
+                            LinuxNativeBridge.nCopyLatestFrame(
+                                handle = ptr,
+                                destination = destination,
+                                expectedWidth = width,
+                                expectedHeight = height,
+                                destinationStride = pixmap.rowBytes,
+                                outInfo = frameCopyInfo,
+                            )
 
-                    // Allocate/reuse double-buffered bitmaps
-                    if (skiaBitmapA == null || skiaBitmapWidth != width || skiaBitmapHeight != height) {
-                        skiaBitmapA?.close()
-                        skiaBitmapB?.close()
+                        if (status != LinuxNativeBridge.FRAME_COPY_OK) {
+                            when (status) {
+                                LinuxNativeBridge.FRAME_COPY_SIZE_CHANGED ->
+                                    linuxLogger.d {
+                                        "Frame size changed during copy to ${frameCopyInfo[0]}x${frameCopyInfo[1]}"
+                                    }
 
-                        val imageInfo = ImageInfo(width, height, ColorType.BGRA_8888, ColorAlphaType.OPAQUE)
-                        skiaBitmapA = Bitmap().apply { allocPixels(imageInfo) }
-                        skiaBitmapB = Bitmap().apply { allocPixels(imageInfo) }
-                        skiaBitmapWidth = width
-                        skiaBitmapHeight = height
-                        nextSkiaBitmapA = true
+                                LinuxNativeBridge.FRAME_COPY_DEST_TOO_SMALL,
+                                LinuxNativeBridge.FRAME_COPY_INVALID,
+                                -> linuxLogger.e { "Native frame copy rejected layout (status=$status)" }
+                            }
+                            return@resources false
+                        }
+
+                        nextSkiaBitmapA = !useBitmapA
+                        _currentFrameState.value = targetBitmap.asComposeImageBitmap()
+                        lastFrameUpdateTime = System.currentTimeMillis()
+                        true
                     }
 
-                    val targetBitmap = if (nextSkiaBitmapA) skiaBitmapA!! else skiaBitmapB!!
-                    nextSkiaBitmapA = !nextSkiaBitmapA
-
-                    val pixmap = targetBitmap.peekPixels() ?: return@withContext
-                    val pixelsAddr = pixmap.addr
-                    if (pixelsAddr == 0L) return@withContext
-
-                    // Native-to-native copy: frame buffer -> Skia bitmap pixels
-                    srcBuf.rewind()
-                    val destRowBytes = pixmap.rowBytes
-                    val destSizeBytes = destRowBytes.toLong() * height.toLong()
-                    val destBuf =
-                        LinuxNativeBridge.nWrapPointer(pixelsAddr, destSizeBytes)
-                            ?: return@withContext
-                    copyBgraFrame(srcBuf, destBuf, width, height, destRowBytes)
-
-                    _currentFrameState.value = targetBitmap.asComposeImageBitmap()
-                    framePublished = true
-                }
-
-                if (framePublished) {
-                    lastFrameUpdateTime = System.currentTimeMillis()
-                    if (isLoading && !seekInProgress) {
-                        withContext(Dispatchers.Main) { isLoading = false }
-                    }
+                if (copied && isLoading && !seekInProgress) {
+                    withContext(Dispatchers.Main) { isLoading = false }
                 }
             } catch (e: Exception) {
                 if (e is CancellationException) throw e
@@ -763,20 +813,29 @@ class LinuxVideoPlayerState : VideoPlayerState {
         stopBufferingCheck()
         uiUpdateJob?.cancel()
         playerScope.cancel()
+        ioScope.cancel()
 
-        // Clear the pointer atomically so no background task can use it
+        // Prevent new copies first, then wait for any copy already writing into a
+        // Skia allocation before detaching the resources that own those pixels.
         val ptrToDispose = playerPtrAtomic.getAndSet(0L)
-
-        // Native cleanup on a background thread to avoid blocking the UI.
-        Thread {
-            try {
-                skiaBitmapA?.close()
-                skiaBitmapB?.close()
+        val bitmapsToClose =
+            frameResourceGate.withResources {
+                val detached = skiaBitmapA to skiaBitmapB
+                skiaBitmapABuffer = null
+                skiaBitmapBBuffer = null
                 skiaBitmapA = null
                 skiaBitmapB = null
                 skiaBitmapWidth = 0
                 skiaBitmapHeight = 0
                 nextSkiaBitmapA = true
+                detached
+            }
+
+        // Native cleanup on a background thread to avoid blocking the UI.
+        Thread {
+            try {
+                bitmapsToClose.first?.close()
+                bitmapsToClose.second?.close()
             } catch (e: Exception) {
                 linuxLogger.e { "Error releasing bitmaps: ${e.message}" }
             }
@@ -790,8 +849,6 @@ class LinuxVideoPlayerState : VideoPlayerState {
                 }
             }
         }.start()
-
-        ioScope.cancel()
     }
 
     // --- Subtitle stubs ---

--- a/vendor/compose-media-player/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/util/NativeLibraryLoader.kt
+++ b/vendor/compose-media-player/mediaplayer/src/jvmMain/kotlin/io/github/kdroidfilter/composemediaplayer/util/NativeLibraryLoader.kt
@@ -1,15 +1,17 @@
 package io.github.kdroidfilter.composemediaplayer.util
 
 import java.io.File
+import java.nio.file.AtomicMoveNotSupportedException
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
+import java.security.MessageDigest
 
 /**
  * Loads native libraries following a two-stage strategy:
  * 1. Try [System.loadLibrary] (works for packaged apps / GraalVM native-image
  *    where the lib sits on `java.library.path`).
  * 2. Fallback: extract from the classpath (`composemediaplayer/native/<platform>/`)
- *    into a persistent cache and load from there.
+ *    into a content-addressed persistent cache and load from there.
  */
 internal object NativeLibraryLoader {
     private const val RESOURCE_PREFIX = "composemediaplayer/native"
@@ -20,18 +22,17 @@ internal object NativeLibraryLoader {
         libraryName: String,
         callerClass: Class<*>,
     ): Boolean {
+        validateNativePathSegment(libraryName)
         if (libraryName in loadedLibraries) return true
 
-        // 1. Try system library path (packaged app / GraalVM native-image)
         try {
             System.loadLibrary(libraryName)
             loadedLibraries += libraryName
             return true
         } catch (_: UnsatisfiedLinkError) {
-            // Not on java.library.path, try classpath extraction
+            // Not on java.library.path, try classpath extraction.
         }
 
-        // 2. Extract from classpath to persistent cache
         val file = extractToCache(libraryName, callerClass) ?: return false
         System.load(file.absolutePath)
         loadedLibraries += libraryName
@@ -43,28 +44,35 @@ internal object NativeLibraryLoader {
         callerClass: Class<*>,
     ): File? {
         val platform = detectPlatform()
-        val fileName = mapLibraryName(libraryName)
+        val fileName = validateNativePathSegment(mapLibraryName(libraryName))
         val resourcePath = "$RESOURCE_PREFIX/$platform/$fileName"
-
         val resourceUrl = callerClass.classLoader?.getResource(resourcePath) ?: return null
+        val resourceBytes = resourceUrl.openStream().use { it.readBytes() }
 
         val cacheDir = resolveCacheDir(platform)
         cacheDir.mkdirs()
-        val cachedFile = File(cacheDir, fileName)
-
-        // Validate cache: re-extract if size differs or file is missing
-        val resourceSize = resourceUrl.openConnection().contentLengthLong
-        if (cachedFile.exists() && cachedFile.length() == resourceSize) {
+        val cachedFile = File(cacheDir, contentAddressedNativeFileName(fileName, resourceBytes))
+        if (cachedFile.exists() && cachedFile.readBytes().contentEquals(resourceBytes)) {
             return cachedFile
         }
 
-        // Atomic extract: write to temp then move
-        val tmpFile = File(cacheDir, "$fileName.tmp")
+        val tmpFile = Files.createTempFile(cacheDir.toPath(), "$fileName.", ".tmp").toFile()
         try {
-            resourceUrl.openStream().use { input ->
-                Files.copy(input, tmpFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
+            Files.write(tmpFile.toPath(), resourceBytes)
+            try {
+                Files.move(
+                    tmpFile.toPath(),
+                    cachedFile.toPath(),
+                    StandardCopyOption.ATOMIC_MOVE,
+                    StandardCopyOption.REPLACE_EXISTING,
+                )
+            } catch (_: AtomicMoveNotSupportedException) {
+                Files.move(
+                    tmpFile.toPath(),
+                    cachedFile.toPath(),
+                    StandardCopyOption.REPLACE_EXISTING,
+                )
             }
-            Files.move(tmpFile.toPath(), cachedFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
             cachedFile.setExecutable(true)
         } finally {
             tmpFile.delete()
@@ -107,4 +115,25 @@ internal object NativeLibraryLoader {
             else -> "lib$name.so"
         }
     }
+}
+
+internal fun contentAddressedNativeFileName(
+    fileName: String,
+    bytes: ByteArray,
+): String {
+    validateNativePathSegment(fileName)
+    val digest = MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
+    val extensionIndex = fileName.lastIndexOf('.')
+    val stem = if (extensionIndex > 0) fileName.substring(0, extensionIndex) else fileName
+    val extension = if (extensionIndex > 0) fileName.substring(extensionIndex) else ""
+    return "$stem-$digest$extension"
+}
+
+internal fun validateNativePathSegment(value: String): String {
+    require(value.isNotBlank()) { "Native library name must not be blank" }
+    require(value != "." && value != "..") { "Native library name must not be a dot segment" }
+    require(value.all { it.isLetterOrDigit() || it == '.' || it == '_' || it == '-' }) {
+        "Native library name must be a single safe path segment"
+    }
+    return value
 }

--- a/vendor/compose-media-player/mediaplayer/src/jvmMain/native/linux/CMakeLists.txt
+++ b/vendor/compose-media-player/mediaplayer/src/jvmMain/native/linux/CMakeLists.txt
@@ -40,6 +40,31 @@ target_compile_options(NativeVideoPlayer PRIVATE
     -fPIC
 )
 
+include(CTest)
+if(BUILD_TESTING)
+    add_executable(frame_copy_test
+        tests/frame_copy_test.c
+        NativeVideoPlayer.c
+    )
+    target_compile_definitions(frame_copy_test PRIVATE NVP_TESTING)
+    target_include_directories(frame_copy_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${GST_INCLUDE_DIRS}
+    )
+    target_link_libraries(frame_copy_test PRIVATE
+        ${GST_LIBRARIES}
+        m
+        pthread
+    )
+    target_compile_options(frame_copy_test PRIVATE
+        ${GST_CFLAGS_OTHER}
+        -Wall -Wextra -Werror
+        -O2
+    )
+    add_test(NAME frame_copy_test COMMAND frame_copy_test)
+    set_tests_properties(frame_copy_test PROPERTIES TIMEOUT 30)
+endif()
+
 # Determine output directory based on architecture
 if(DEFINED ENV{NATIVE_LIBS_OUTPUT_DIR})
     set(BASE_OUTPUT_DIR "$ENV{NATIVE_LIBS_OUTPUT_DIR}")

--- a/vendor/compose-media-player/mediaplayer/src/jvmMain/native/linux/NativeVideoPlayer.c
+++ b/vendor/compose-media-player/mediaplayer/src/jvmMain/native/linux/NativeVideoPlayer.c
@@ -6,7 +6,7 @@
 
 #include <gst/gst.h>
 #include <gst/app/gstappsink.h>
-#include <gst/video/video-info.h>
+#include <gst/video/video.h>
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
@@ -27,6 +27,7 @@ struct VideoPlayer {
     uint8_t* frame_buffer;
     int32_t  frame_width;
     int32_t  frame_height;
+    int32_t  frame_stride;
     size_t   frame_size;
 
     // Output scaling
@@ -50,6 +51,17 @@ struct VideoPlayer {
     // Bus polling thread
     pthread_t bus_thread;
     volatile int bus_thread_running;
+
+#ifdef NVP_TESTING
+    pthread_mutex_t test_copy_hook_lock;
+    pthread_cond_t test_copy_hook_condition;
+    int test_pause_next_copy;
+    int test_copy_paused;
+    int test_resume_copy;
+    int test_publish_attempt_armed;
+    int test_publish_attempted;
+    int test_publish_lock_result;
+#endif
 };
 
 // ---------------------------------------------------------------------------
@@ -71,6 +83,36 @@ static pthread_once_t gst_init_once = PTHREAD_ONCE_INIT;
 static void gst_init_func(void) {
     gst_init(NULL, NULL);
 }
+
+#ifdef NVP_TESTING
+static void init_copy_test_hooks(VideoPlayer* p) {
+    pthread_mutex_init(&p->test_copy_hook_lock, NULL);
+    pthread_cond_init(&p->test_copy_hook_condition, NULL);
+}
+
+static void destroy_copy_test_hooks(VideoPlayer* p) {
+    pthread_cond_destroy(&p->test_copy_hook_condition);
+    pthread_mutex_destroy(&p->test_copy_hook_lock);
+}
+
+static void pause_copy_for_test_if_requested(VideoPlayer* p) {
+    pthread_mutex_lock(&p->test_copy_hook_lock);
+    if (p->test_pause_next_copy) {
+        p->test_copy_paused = 1;
+        pthread_cond_broadcast(&p->test_copy_hook_condition);
+        while (!p->test_resume_copy) {
+            pthread_cond_wait(
+                &p->test_copy_hook_condition,
+                &p->test_copy_hook_lock
+            );
+        }
+        p->test_pause_next_copy = 0;
+        p->test_copy_paused = 0;
+        p->test_resume_copy = 0;
+    }
+    pthread_mutex_unlock(&p->test_copy_hook_lock);
+}
+#endif
 
 // ---------------------------------------------------------------------------
 // Bus polling thread
@@ -161,6 +203,9 @@ VideoPlayer* nvp_create(void) {
 
     pthread_mutex_init(&p->frame_lock, NULL);
     pthread_mutex_init(&p->meta_lock, NULL);
+#ifdef NVP_TESTING
+    init_copy_test_hooks(p);
+#endif
     p->volume = 1.0f;
     p->playback_speed = 1.0f;
 
@@ -169,6 +214,9 @@ VideoPlayer* nvp_create(void) {
     if (!p->pipeline) {
         pthread_mutex_destroy(&p->frame_lock);
         pthread_mutex_destroy(&p->meta_lock);
+#ifdef NVP_TESTING
+        destroy_copy_test_hooks(p);
+#endif
         free(p);
         return NULL;
     }
@@ -180,6 +228,9 @@ VideoPlayer* nvp_create(void) {
         gst_object_unref(p->pipeline);
         pthread_mutex_destroy(&p->frame_lock);
         pthread_mutex_destroy(&p->meta_lock);
+#ifdef NVP_TESTING
+        destroy_copy_test_hooks(p);
+#endif
         free(p);
         return NULL;
     }
@@ -288,6 +339,9 @@ void nvp_destroy(VideoPlayer* p) {
     free(p->mime_type);
     pthread_mutex_unlock(&p->meta_lock);
     pthread_mutex_destroy(&p->meta_lock);
+#ifdef NVP_TESTING
+    destroy_copy_test_hooks(p);
+#endif
 
     free(p);
 }
@@ -309,6 +363,7 @@ int nvp_open_uri(VideoPlayer* p, const char* uri) {
     p->frame_buffer = NULL;
     p->frame_width = 0;
     p->frame_height = 0;
+    p->frame_stride = 0;
     p->frame_size = 0;
     pthread_mutex_unlock(&p->frame_lock);
 
@@ -409,18 +464,260 @@ float nvp_get_playback_speed(VideoPlayer* p) {
 // Frame access
 // ---------------------------------------------------------------------------
 
-void* nvp_get_latest_frame_address(VideoPlayer* p) {
-    if (!p) return NULL;
-    return p->frame_buffer;
+static int frame_layout_size(
+    int32_t width,
+    int32_t height,
+    int32_t stride,
+    size_t* row_bytes,
+    size_t* total_bytes
+) {
+    if (width <= 0 || height <= 0 || stride <= 0 ||
+        width > INT32_MAX / 4) {
+        return 0;
+    }
+
+    const size_t row = (size_t)width * 4u;
+    if ((size_t)stride < row || (size_t)height > SIZE_MAX / (size_t)stride) {
+        return 0;
+    }
+
+    if (row_bytes) *row_bytes = row;
+    if (total_bytes) *total_bytes = (size_t)stride * (size_t)height;
+    return 1;
+}
+
+static void lock_frame_for_publish(VideoPlayer* p) {
+#ifdef NVP_TESTING
+    int attempt_armed = 0;
+    pthread_mutex_lock(&p->test_copy_hook_lock);
+    if (p->test_publish_attempt_armed) {
+        p->test_publish_attempt_armed = 0;
+        attempt_armed = 1;
+    }
+    pthread_mutex_unlock(&p->test_copy_hook_lock);
+
+    if (attempt_armed) {
+        const int lock_result = pthread_mutex_trylock(&p->frame_lock);
+        pthread_mutex_lock(&p->test_copy_hook_lock);
+        p->test_publish_lock_result = lock_result;
+        p->test_publish_attempted = 1;
+        pthread_cond_broadcast(&p->test_copy_hook_condition);
+        pthread_mutex_unlock(&p->test_copy_hook_lock);
+        if (lock_result == 0) return;
+    }
+#endif
+    pthread_mutex_lock(&p->frame_lock);
+}
+
+static int32_t publish_bgra_frame(
+    VideoPlayer* p,
+    const uint8_t* source,
+    int32_t width,
+    int32_t height,
+    int32_t source_stride
+) {
+    size_t row_bytes = 0;
+    size_t source_size = 0;
+    if (!p || !source ||
+        !frame_layout_size(width, height, source_stride, &row_bytes, &source_size)) {
+        return 0;
+    }
+    (void)source_size;
+
+    if ((size_t)height > SIZE_MAX / row_bytes) return 0;
+    const size_t packed_size = row_bytes * (size_t)height;
+
+    lock_frame_for_publish(p);
+    if (!p->frame_buffer || p->frame_size != packed_size) {
+        uint8_t* replacement = (uint8_t*)malloc(packed_size);
+        if (!replacement) {
+            pthread_mutex_unlock(&p->frame_lock);
+            return 0;
+        }
+        free(p->frame_buffer);
+        p->frame_buffer = replacement;
+        p->frame_size = packed_size;
+    }
+
+    for (int32_t row = 0; row < height; ++row) {
+        memcpy(
+            p->frame_buffer + (size_t)row * row_bytes,
+            source + (size_t)row * (size_t)source_stride,
+            row_bytes
+        );
+    }
+    p->frame_width = width;
+    p->frame_height = height;
+    p->frame_stride = (int32_t)row_bytes;
+    pthread_mutex_unlock(&p->frame_lock);
+    return 1;
+}
+
+int32_t nvp_copy_latest_frame(
+    VideoPlayer* p,
+    void* destination,
+    size_t destination_capacity,
+    int32_t expected_width,
+    int32_t expected_height,
+    int32_t destination_stride,
+    NvpFrameInfo* out_info
+) {
+    if (out_info) memset(out_info, 0, sizeof(*out_info));
+
+    size_t destination_row_bytes = 0;
+    size_t destination_size = 0;
+    if (!p || !destination || !out_info ||
+        !frame_layout_size(
+            expected_width,
+            expected_height,
+            destination_stride,
+            &destination_row_bytes,
+            &destination_size
+        )) {
+        return NVP_FRAME_COPY_INVALID;
+    }
+
+    pthread_mutex_lock(&p->frame_lock);
+#ifdef NVP_TESTING
+    pause_copy_for_test_if_requested(p);
+#endif
+    out_info->width = p->frame_width;
+    out_info->height = p->frame_height;
+    out_info->source_stride = p->frame_stride;
+
+    if (!p->frame_buffer || p->frame_width <= 0 || p->frame_height <= 0 ||
+        p->frame_stride <= 0) {
+        pthread_mutex_unlock(&p->frame_lock);
+        return NVP_FRAME_COPY_NOT_READY;
+    }
+
+    if (p->frame_width != expected_width || p->frame_height != expected_height) {
+        pthread_mutex_unlock(&p->frame_lock);
+        return NVP_FRAME_COPY_SIZE_CHANGED;
+    }
+
+    size_t source_row_bytes = 0;
+    size_t source_size = 0;
+    if (!frame_layout_size(
+            p->frame_width,
+            p->frame_height,
+            p->frame_stride,
+            &source_row_bytes,
+            &source_size
+        ) || p->frame_size < source_size) {
+        pthread_mutex_unlock(&p->frame_lock);
+        return NVP_FRAME_COPY_INVALID;
+    }
+
+    if (destination_capacity < destination_size) {
+        pthread_mutex_unlock(&p->frame_lock);
+        return NVP_FRAME_COPY_DEST_TOO_SMALL;
+    }
+
+    for (int32_t row = 0; row < p->frame_height; ++row) {
+        memcpy(
+            (uint8_t*)destination + (size_t)row * (size_t)destination_stride,
+            p->frame_buffer + (size_t)row * (size_t)p->frame_stride,
+            source_row_bytes
+        );
+    }
+    pthread_mutex_unlock(&p->frame_lock);
+    return NVP_FRAME_COPY_OK;
 }
 
 int32_t nvp_get_frame_width(VideoPlayer* p) {
-    return p ? p->frame_width : 0;
+    if (!p) return 0;
+    pthread_mutex_lock(&p->frame_lock);
+    const int32_t width = p->frame_width;
+    pthread_mutex_unlock(&p->frame_lock);
+    return width;
 }
 
 int32_t nvp_get_frame_height(VideoPlayer* p) {
-    return p ? p->frame_height : 0;
+    if (!p) return 0;
+    pthread_mutex_lock(&p->frame_lock);
+    const int32_t height = p->frame_height;
+    pthread_mutex_unlock(&p->frame_lock);
+    return height;
 }
+
+#ifdef NVP_TESTING
+int32_t nvp_test_publish_bgra(
+    VideoPlayer* p,
+    const void* source,
+    int32_t width,
+    int32_t height,
+    int32_t source_stride
+) {
+    if (!p) return 0;
+    return publish_bgra_frame(
+        p,
+        (const uint8_t*)source,
+        width,
+        height,
+        source_stride
+    );
+}
+
+void nvp_test_pause_next_copy(VideoPlayer* p) {
+    if (!p) return;
+    pthread_mutex_lock(&p->test_copy_hook_lock);
+    p->test_pause_next_copy = 1;
+    p->test_copy_paused = 0;
+    p->test_resume_copy = 0;
+    pthread_mutex_unlock(&p->test_copy_hook_lock);
+}
+
+void nvp_test_wait_until_copy_paused(VideoPlayer* p) {
+    if (!p) return;
+    pthread_mutex_lock(&p->test_copy_hook_lock);
+    while (!p->test_copy_paused) {
+        pthread_cond_wait(
+            &p->test_copy_hook_condition,
+            &p->test_copy_hook_lock
+        );
+    }
+    pthread_mutex_unlock(&p->test_copy_hook_lock);
+}
+
+void nvp_test_resume_copy(VideoPlayer* p) {
+    if (!p) return;
+    pthread_mutex_lock(&p->test_copy_hook_lock);
+    p->test_resume_copy = 1;
+    pthread_cond_broadcast(&p->test_copy_hook_condition);
+    pthread_mutex_unlock(&p->test_copy_hook_lock);
+}
+
+void nvp_test_arm_publish_attempt(VideoPlayer* p) {
+    if (!p) return;
+    pthread_mutex_lock(&p->test_copy_hook_lock);
+    p->test_publish_attempted = 0;
+    p->test_publish_lock_result = -1;
+    p->test_publish_attempt_armed = 1;
+    pthread_mutex_unlock(&p->test_copy_hook_lock);
+}
+
+int32_t nvp_test_wait_until_publish_attempted(VideoPlayer* p) {
+    if (!p) return -1;
+    pthread_mutex_lock(&p->test_copy_hook_lock);
+    while (!p->test_publish_attempted) {
+        pthread_cond_wait(
+            &p->test_copy_hook_condition,
+            &p->test_copy_hook_lock
+        );
+    }
+    const int32_t result = p->test_publish_lock_result;
+    pthread_mutex_unlock(&p->test_copy_hook_lock);
+    return result;
+}
+
+int32_t nvp_test_try_frame_lock(VideoPlayer* p) {
+    if (!p) return 0;
+    if (pthread_mutex_trylock(&p->frame_lock) != 0) return 0;
+    pthread_mutex_unlock(&p->frame_lock);
+    return 1;
+}
+#endif
 
 int32_t nvp_set_output_size(VideoPlayer* p, int32_t width, int32_t height) {
     if (!p || width <= 0 || height <= 0) return 0;
@@ -516,70 +813,46 @@ static GstFlowReturn on_new_sample(GstAppSink* sink, gpointer data) {
     if (!sample) return GST_FLOW_OK;
 
     GstCaps* caps = gst_sample_get_caps(sample);
-    if (!caps) {
+    GstBuffer* buffer = gst_sample_get_buffer(sample);
+    if (!caps || !buffer) {
         gst_sample_unref(sample);
         return GST_FLOW_OK;
     }
 
-    GstStructure* s = gst_caps_get_structure(caps, 0);
-    gint width = 0, height = 0;
-    gst_structure_get_int(s, "width", &width);
-    gst_structure_get_int(s, "height", &height);
+    GstVideoInfo info;
+    if (!gst_video_info_from_caps(&info, caps)) {
+        gst_sample_unref(sample);
+        return GST_FLOW_OK;
+    }
 
+    const int32_t width = (int32_t)GST_VIDEO_INFO_WIDTH(&info);
+    const int32_t height = (int32_t)GST_VIDEO_INFO_HEIGHT(&info);
     if (width <= 0 || height <= 0) {
         gst_sample_unref(sample);
         return GST_FLOW_OK;
     }
 
-    // Extract frame rate from caps
-    gint fps_n = 0, fps_d = 1;
-    if (gst_structure_get_fraction(s, "framerate", &fps_n, &fps_d) && fps_d > 0) {
+    const gint fps_n = GST_VIDEO_INFO_FPS_N(&info);
+    const gint fps_d = GST_VIDEO_INFO_FPS_D(&info);
+    if (fps_d > 0) {
         p->frame_rate = (float)fps_n / (float)fps_d;
     }
 
-    GstBuffer* buffer = gst_sample_get_buffer(sample);
-    if (!buffer) {
+    GstVideoFrame frame;
+    if (!gst_video_frame_map(&frame, &info, buffer, GST_MAP_READ)) {
         gst_sample_unref(sample);
         return GST_FLOW_OK;
     }
 
-    GstMapInfo map;
-    if (!gst_buffer_map(buffer, &map, GST_MAP_READ)) {
-        gst_sample_unref(sample);
-        return GST_FLOW_OK;
+    const uint8_t* source =
+        (const uint8_t*)GST_VIDEO_FRAME_PLANE_DATA(&frame, 0);
+    const int32_t source_stride =
+        (int32_t)GST_VIDEO_FRAME_PLANE_STRIDE(&frame, 0);
+    if (source && source_stride > 0) {
+        publish_bgra_frame(p, source, width, height, source_stride);
     }
 
-    size_t expected = (size_t)width * (size_t)height * 4;
-    if (map.size < expected) {
-        gst_buffer_unmap(buffer, &map);
-        gst_sample_unref(sample);
-        return GST_FLOW_OK;
-    }
-
-    pthread_mutex_lock(&p->frame_lock);
-
-    if (p->frame_width != width || p->frame_height != height || !p->frame_buffer) {
-        free(p->frame_buffer);
-        p->frame_buffer = (uint8_t*)malloc(expected);
-        if (!p->frame_buffer) {
-            p->frame_width = 0;
-            p->frame_height = 0;
-            p->frame_size = 0;
-            pthread_mutex_unlock(&p->frame_lock);
-            gst_buffer_unmap(buffer, &map);
-            gst_sample_unref(sample);
-            return GST_FLOW_OK;
-        }
-        p->frame_width = width;
-        p->frame_height = height;
-        p->frame_size = expected;
-    }
-
-    memcpy(p->frame_buffer, map.data, expected);
-
-    pthread_mutex_unlock(&p->frame_lock);
-
-    gst_buffer_unmap(buffer, &map);
+    gst_video_frame_unmap(&frame);
     gst_sample_unref(sample);
     return GST_FLOW_OK;
 }
@@ -640,8 +913,8 @@ static void update_stream_metadata(VideoPlayer* p) {
             gst_structure_get_int(vs, "width", &w);
             gst_structure_get_int(vs, "height", &h);
 
-            // Only update dimensions if not already set by frame callback
-            if (w > 0 && h > 0 && (p->frame_width == 0 || p->frame_height == 0)) {
+            // Only update dimensions if not already set by frame callback.
+            if (w > 0 && h > 0) {
                 pthread_mutex_lock(&p->frame_lock);
                 if (p->frame_width == 0 || p->frame_height == 0) {
                     p->frame_width = w;

--- a/vendor/compose-media-player/mediaplayer/src/jvmMain/native/linux/NativeVideoPlayer.h
+++ b/vendor/compose-media-player/mediaplayer/src/jvmMain/native/linux/NativeVideoPlayer.h
@@ -4,6 +4,7 @@
 #ifndef NATIVE_VIDEO_PLAYER_H
 #define NATIVE_VIDEO_PLAYER_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -28,10 +29,48 @@ void nvp_set_playback_speed(VideoPlayer* p, float speed);
 float nvp_get_playback_speed(VideoPlayer* p);
 
 // Frame access
-void*   nvp_get_latest_frame_address(VideoPlayer* p);
+enum {
+    NVP_FRAME_COPY_INVALID = -1,
+    NVP_FRAME_COPY_DEST_TOO_SMALL = -2,
+    NVP_FRAME_COPY_SIZE_CHANGED = -3,
+    NVP_FRAME_COPY_NOT_READY = 0,
+    NVP_FRAME_COPY_OK = 1,
+};
+
+typedef struct NvpFrameInfo {
+    int32_t width;
+    int32_t height;
+    int32_t source_stride;
+} NvpFrameInfo;
+
+int32_t nvp_copy_latest_frame(
+    VideoPlayer* p,
+    void* destination,
+    size_t destination_capacity,
+    int32_t expected_width,
+    int32_t expected_height,
+    int32_t destination_stride,
+    NvpFrameInfo* out_info
+);
 int32_t nvp_get_frame_width(VideoPlayer* p);
 int32_t nvp_get_frame_height(VideoPlayer* p);
 int32_t nvp_set_output_size(VideoPlayer* p, int32_t width, int32_t height);
+
+#ifdef NVP_TESTING
+int32_t nvp_test_publish_bgra(
+    VideoPlayer* p,
+    const void* source,
+    int32_t width,
+    int32_t height,
+    int32_t source_stride
+);
+void nvp_test_pause_next_copy(VideoPlayer* p);
+void nvp_test_wait_until_copy_paused(VideoPlayer* p);
+void nvp_test_resume_copy(VideoPlayer* p);
+int32_t nvp_test_try_frame_lock(VideoPlayer* p);
+void nvp_test_arm_publish_attempt(VideoPlayer* p);
+int32_t nvp_test_wait_until_publish_attempted(VideoPlayer* p);
+#endif
 
 // Timing
 double nvp_get_duration(VideoPlayer* p);

--- a/vendor/compose-media-player/mediaplayer/src/jvmMain/native/linux/build.sh
+++ b/vendor/compose-media-player/mediaplayer/src/jvmMain/native/linux/build.sh
@@ -15,6 +15,7 @@ mkdir -p "$BUILD_DIR"
 cd "$BUILD_DIR"
 cmake "$SCRIPT_DIR" -DCMAKE_BUILD_TYPE=Release
 cmake --build . --parallel
+ctest --output-on-failure --no-tests=error
 
 echo "=== Build completed ==="
 

--- a/vendor/compose-media-player/mediaplayer/src/jvmMain/native/linux/jni_bridge.c
+++ b/vendor/compose-media-player/mediaplayer/src/jvmMain/native/linux/jni_bridge.c
@@ -14,6 +14,13 @@ static inline VideoPlayer* toCtx(jlong h) {
     return (VideoPlayer*)(uintptr_t)(uint64_t)h;
 }
 
+static void throwIllegalArgument(JNIEnv* env, const char* message) {
+    jclass type = (*env)->FindClass(env, "java/lang/IllegalArgumentException");
+    if (type) {
+        (*env)->ThrowNew(env, type, message);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // JNI implementations
 // ---------------------------------------------------------------------------
@@ -47,10 +54,76 @@ static jfloat JNICALL jni_GetVolume(JNIEnv* env, jclass cls, jlong handle) {
     return handle ? nvp_get_volume(toCtx(handle)) : 0.0f;
 }
 
-static jlong JNICALL jni_GetLatestFrameAddress(JNIEnv* env, jclass cls, jlong handle) {
-    if (!handle) return 0L;
-    void* ptr = nvp_get_latest_frame_address(toCtx(handle));
-    return ptr ? (jlong)(uintptr_t)ptr : 0L;
+static jint JNICALL jni_CopyLatestFrame(
+    JNIEnv* env,
+    jclass cls,
+    jlong handle,
+    jobject destination,
+    jint expected_width,
+    jint expected_height,
+    jint destination_stride,
+    jintArray out_info
+) {
+    (void)cls;
+    if (!handle) {
+        throwIllegalArgument(env, "handle must be non-zero");
+        return NVP_FRAME_COPY_INVALID;
+    }
+    if (!destination) {
+        throwIllegalArgument(env, "destination must not be null");
+        return NVP_FRAME_COPY_INVALID;
+    }
+    if (!out_info || (*env)->GetArrayLength(env, out_info) < 3) {
+        throwIllegalArgument(env, "outInfo must contain at least three integers");
+        return NVP_FRAME_COPY_INVALID;
+    }
+    if (expected_width <= 0 || expected_height <= 0 || destination_stride <= 0) {
+        throwIllegalArgument(env, "frame dimensions and stride must be positive");
+        return NVP_FRAME_COPY_INVALID;
+    }
+
+    jclass destination_class = (*env)->GetObjectClass(env, destination);
+    if (!destination_class) return NVP_FRAME_COPY_INVALID;
+    jmethodID is_read_only_method =
+        (*env)->GetMethodID(env, destination_class, "isReadOnly", "()Z");
+    if (!is_read_only_method) {
+        (*env)->DeleteLocalRef(env, destination_class);
+        return NVP_FRAME_COPY_INVALID;
+    }
+    const jboolean is_read_only =
+        (*env)->CallBooleanMethod(env, destination, is_read_only_method);
+    (*env)->DeleteLocalRef(env, destination_class);
+    if ((*env)->ExceptionCheck(env)) return NVP_FRAME_COPY_INVALID;
+    if (is_read_only == JNI_TRUE) {
+        throwIllegalArgument(env, "destination must be writable");
+        return NVP_FRAME_COPY_INVALID;
+    }
+
+    void* address = (*env)->GetDirectBufferAddress(env, destination);
+    const jlong capacity = (*env)->GetDirectBufferCapacity(env, destination);
+    if (!address || capacity < 0 || (uint64_t)capacity > (uint64_t)SIZE_MAX) {
+        throwIllegalArgument(env, "destination must be a direct ByteBuffer");
+        return NVP_FRAME_COPY_INVALID;
+    }
+
+    NvpFrameInfo info = {0};
+    const int32_t status = nvp_copy_latest_frame(
+        toCtx(handle),
+        address,
+        (size_t)capacity,
+        (int32_t)expected_width,
+        (int32_t)expected_height,
+        (int32_t)destination_stride,
+        &info
+    );
+    const jint metadata[3] = {
+        (jint)info.width,
+        (jint)info.height,
+        (jint)info.source_stride,
+    };
+    (*env)->SetIntArrayRegion(env, out_info, 0, 3, metadata);
+    if ((*env)->ExceptionCheck(env)) return NVP_FRAME_COPY_INVALID;
+    return (jint)status;
 }
 
 static jobject JNICALL jni_WrapPointer(JNIEnv* env, jclass cls, jlong address, jlong size) {
@@ -143,7 +216,7 @@ static const JNINativeMethod g_methods[] = {
     { "nPause",                  "(J)V",                        (void*)jni_Pause },
     { "nSetVolume",              "(JF)V",                       (void*)jni_SetVolume },
     { "nGetVolume",              "(J)F",                        (void*)jni_GetVolume },
-    { "nGetLatestFrameAddress",  "(J)J",                        (void*)jni_GetLatestFrameAddress },
+    { "nCopyLatestFrame",         "(JLjava/nio/ByteBuffer;III[I)I", (void*)jni_CopyLatestFrame },
     { "nWrapPointer",            "(JJ)Ljava/nio/ByteBuffer;",   (void*)jni_WrapPointer },
     { "nGetFrameWidth",          "(J)I",                        (void*)jni_GetFrameWidth },
     { "nGetFrameHeight",         "(J)I",                        (void*)jni_GetFrameHeight },

--- a/vendor/compose-media-player/mediaplayer/src/jvmMain/native/linux/tests/frame_copy_test.c
+++ b/vendor/compose-media-player/mediaplayer/src/jvmMain/native/linux/tests/frame_copy_test.c
@@ -1,0 +1,216 @@
+#include "NativeVideoPlayer.h"
+
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define CHECK(condition) \
+    do { \
+        if (!(condition)) { \
+            fprintf(stderr, "CHECK failed at %s:%d: %s\n", __FILE__, __LINE__, #condition); \
+            exit(EXIT_FAILURE); \
+        } \
+    } while (0)
+
+static void source_and_destination_padding_are_respected(void) {
+    enum {
+        WIDTH = 2,
+        HEIGHT = 2,
+        PIXEL_BYTES = 4,
+        SOURCE_STRIDE = 12,
+        DESTINATION_STRIDE = 16,
+    };
+
+    const uint8_t source[SOURCE_STRIDE * HEIGHT] = {
+        1, 2, 3, 4, 5, 6, 7, 8, 0xee, 0xee, 0xee, 0xee,
+        9, 10, 11, 12, 13, 14, 15, 16, 0xdd, 0xdd, 0xdd, 0xdd,
+    };
+    uint8_t destination[DESTINATION_STRIDE * HEIGHT];
+    memset(destination, 0xa5, sizeof(destination));
+
+    VideoPlayer* player = nvp_create();
+    CHECK(player != NULL);
+    CHECK(nvp_test_publish_bgra(
+        player,
+        source,
+        WIDTH,
+        HEIGHT,
+        SOURCE_STRIDE
+    ) == 1);
+
+    NvpFrameInfo info = {0};
+    const int32_t status = nvp_copy_latest_frame(
+        player,
+        destination,
+        sizeof(destination),
+        WIDTH,
+        HEIGHT,
+        DESTINATION_STRIDE,
+        &info
+    );
+
+    CHECK(status == NVP_FRAME_COPY_OK);
+    CHECK(info.width == WIDTH);
+    CHECK(info.height == HEIGHT);
+    CHECK(info.source_stride == WIDTH * PIXEL_BYTES);
+
+    for (int row = 0; row < HEIGHT; ++row) {
+        CHECK(memcmp(
+            destination + row * DESTINATION_STRIDE,
+            source + row * SOURCE_STRIDE,
+            WIDTH * PIXEL_BYTES
+        ) == 0);
+        for (int index = WIDTH * PIXEL_BYTES; index < DESTINATION_STRIDE; ++index) {
+            CHECK(destination[row * DESTINATION_STRIDE + index] == 0xa5);
+        }
+    }
+
+    nvp_destroy(player);
+}
+
+typedef struct CopyThreadArgs {
+    VideoPlayer* player;
+    uint8_t destination[16];
+    int32_t status;
+} CopyThreadArgs;
+
+static void* copy_thread(void* opaque) {
+    CopyThreadArgs* args = (CopyThreadArgs*)opaque;
+    NvpFrameInfo info = {0};
+    args->status = nvp_copy_latest_frame(
+        args->player,
+        args->destination,
+        sizeof(args->destination),
+        2,
+        2,
+        8,
+        &info
+    );
+    return NULL;
+}
+
+typedef struct PublishThreadArgs {
+    VideoPlayer* player;
+    atomic_int finished;
+} PublishThreadArgs;
+
+static void* publish_thread(void* opaque) {
+    PublishThreadArgs* args = (PublishThreadArgs*)opaque;
+    const uint8_t replacement[] = {21, 22, 23, 24};
+    CHECK(nvp_test_publish_bgra(args->player, replacement, 1, 1, 4) == 1);
+    atomic_store(&args->finished, 1);
+    return NULL;
+}
+
+static void copy_blocks_resize_publication(void) {
+    const uint8_t initial[] = {
+        1, 2, 3, 4, 5, 6, 7, 8,
+        9, 10, 11, 12, 13, 14, 15, 16,
+    };
+    VideoPlayer* player = nvp_create();
+    CHECK(player != NULL);
+    CHECK(nvp_test_publish_bgra(player, initial, 2, 2, 8) == 1);
+
+    nvp_test_pause_next_copy(player);
+    CopyThreadArgs copy_args = {
+        .player = player,
+        .destination = {0},
+        .status = NVP_FRAME_COPY_INVALID,
+    };
+    pthread_t copier;
+    CHECK(pthread_create(&copier, NULL, copy_thread, &copy_args) == 0);
+    nvp_test_wait_until_copy_paused(player);
+    CHECK(nvp_test_try_frame_lock(player) == 0);
+
+    PublishThreadArgs publish_args = {
+        .player = player,
+        .finished = ATOMIC_VAR_INIT(0),
+    };
+    nvp_test_arm_publish_attempt(player);
+    pthread_t publisher;
+    CHECK(pthread_create(&publisher, NULL, publish_thread, &publish_args) == 0);
+    CHECK(nvp_test_wait_until_publish_attempted(player) == EBUSY);
+    CHECK(atomic_load(&publish_args.finished) == 0);
+
+    nvp_test_resume_copy(player);
+    CHECK(pthread_join(copier, NULL) == 0);
+    CHECK(pthread_join(publisher, NULL) == 0);
+    CHECK(copy_args.status == NVP_FRAME_COPY_OK);
+    CHECK(memcmp(copy_args.destination, initial, sizeof(initial)) == 0);
+
+    uint8_t replacement_destination[4] = {0};
+    NvpFrameInfo replacement_info = {0};
+    CHECK(nvp_copy_latest_frame(
+        player,
+        replacement_destination,
+        sizeof(replacement_destination),
+        1,
+        1,
+        4,
+        &replacement_info
+    ) == NVP_FRAME_COPY_OK);
+    const uint8_t expected_replacement[] = {21, 22, 23, 24};
+    CHECK(memcmp(
+        replacement_destination,
+        expected_replacement,
+        sizeof(expected_replacement)
+    ) == 0);
+
+    nvp_destroy(player);
+}
+
+static void invalid_layouts_fail_without_writing_destination(void) {
+    const uint8_t source[16] = {
+        1, 2, 3, 4, 5, 6, 7, 8,
+        9, 10, 11, 12, 13, 14, 15, 16,
+    };
+    VideoPlayer* player = nvp_create();
+    CHECK(player != NULL);
+    CHECK(nvp_test_publish_bgra(player, source, 2, 2, 7) == 0);
+    CHECK(nvp_test_publish_bgra(player, source, 2, 2, 8) == 1);
+
+    uint8_t destination[16];
+    memset(destination, 0x5a, sizeof(destination));
+    NvpFrameInfo info = {0};
+    CHECK(nvp_copy_latest_frame(
+        player,
+        destination,
+        sizeof(destination),
+        1,
+        1,
+        4,
+        &info
+    ) == NVP_FRAME_COPY_SIZE_CHANGED);
+    CHECK(info.width == 2);
+    CHECK(info.height == 2);
+    for (size_t index = 0; index < sizeof(destination); ++index) {
+        CHECK(destination[index] == 0x5a);
+    }
+
+    CHECK(nvp_copy_latest_frame(
+        player,
+        destination,
+        sizeof(destination) - 1,
+        2,
+        2,
+        8,
+        &info
+    ) == NVP_FRAME_COPY_DEST_TOO_SMALL);
+    for (size_t index = 0; index < sizeof(destination); ++index) {
+        CHECK(destination[index] == 0x5a);
+    }
+
+    nvp_destroy(player);
+}
+
+int main(void) {
+    source_and_destination_padding_are_respected();
+    copy_blocks_resize_publication();
+    invalid_layouts_fail_without_writing_destination();
+    puts("frame_copy_test: passed");
+    return 0;
+}

--- a/vendor/compose-media-player/mediaplayer/src/jvmTest/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxFrameLayoutTest.kt
+++ b/vendor/compose-media-player/mediaplayer/src/jvmTest/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxFrameLayoutTest.kt
@@ -1,0 +1,30 @@
+package io.github.kdroidfilter.composemediaplayer.linux
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class LinuxFrameLayoutTest {
+    @Test
+    fun `valid padded layout returns total byte size`() {
+        assertEquals(32L, checkedFrameBufferSize(width = 2, height = 2, rowBytes = 16))
+    }
+
+    @Test
+    fun `invalid or undersized layout is rejected`() {
+        assertNull(checkedFrameBufferSize(width = 0, height = 2, rowBytes = 16))
+        assertNull(checkedFrameBufferSize(width = 2, height = 0, rowBytes = 16))
+        assertNull(checkedFrameBufferSize(width = 2, height = 2, rowBytes = 7))
+    }
+
+    @Test
+    fun `layout larger than JVM byte buffer capacity is rejected`() {
+        assertNull(
+            checkedFrameBufferSize(
+                width = 16_384,
+                height = 32_768,
+                rowBytes = 65_536,
+            ),
+        )
+    }
+}

--- a/vendor/compose-media-player/mediaplayer/src/jvmTest/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxFrameResourceGateTest.kt
+++ b/vendor/compose-media-player/mediaplayer/src/jvmTest/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxFrameResourceGateTest.kt
@@ -1,0 +1,44 @@
+package io.github.kdroidfilter.composemediaplayer.linux
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LinuxFrameResourceGateTest {
+    @Test
+    fun `close waits until active frame resource use completes`() {
+        val gate = LinuxFrameResourceGate()
+        val copyEntered = CountDownLatch(1)
+        val releaseCopy = CountDownLatch(1)
+        val closed = AtomicBoolean(false)
+
+        val copier =
+            thread(name = "frame-copy") {
+                gate.withResources {
+                    copyEntered.countDown()
+                    assertTrue(releaseCopy.await(5, TimeUnit.SECONDS))
+                }
+            }
+        assertTrue(copyEntered.await(5, TimeUnit.SECONDS))
+
+        lateinit var disposer: Thread
+        disposer =
+            thread(start = false, name = "frame-dispose") {
+                gate.withResources { closed.set(true) }
+            }
+        disposer.start()
+        assertTrue(gate.waitUntilQueued(disposer, 5_000))
+        assertFalse(closed.get())
+
+        releaseCopy.countDown()
+        copier.join(5_000)
+        disposer.join(5_000)
+        assertFalse(copier.isAlive)
+        assertFalse(disposer.isAlive)
+        assertTrue(closed.get())
+    }
+}

--- a/vendor/compose-media-player/mediaplayer/src/jvmTest/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxNativeFrameCopyTest.kt
+++ b/vendor/compose-media-player/mediaplayer/src/jvmTest/kotlin/io/github/kdroidfilter/composemediaplayer/linux/LinuxNativeFrameCopyTest.kt
@@ -1,0 +1,165 @@
+package io.github.kdroidfilter.composemediaplayer.linux
+
+import io.github.kdroidfilter.composemediaplayer.util.CurrentPlatform
+import org.junit.Assume
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class LinuxNativeFrameCopyTest {
+    private fun twoByTwoBmp(): ByteArray =
+        ByteBuffer
+            .allocate(70)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .apply {
+                put('B'.code.toByte())
+                put('M'.code.toByte())
+                putInt(70)
+                putShort(0)
+                putShort(0)
+                putInt(54)
+                putInt(40)
+                putInt(2)
+                putInt(2)
+                putShort(1)
+                putShort(24)
+                putInt(0)
+                putInt(16)
+                putInt(2835)
+                putInt(2835)
+                putInt(0)
+                putInt(0)
+                // Bottom-up BGR rows, padded to four-byte boundaries.
+                put(byteArrayOf(0, 0, -1, -1, -1, -1, 0, 0))
+                put(byteArrayOf(-1, 0, 0, 0, -1, 0, 0, 0))
+            }.array()
+
+    private fun createPlayerOrFail(): Long {
+        Assume.assumeTrue(CurrentPlatform.os == CurrentPlatform.OS.LINUX)
+        return LinuxNativeBridge.nCreatePlayer().also { player ->
+            assertNotEquals(0L, player, "Native Linux player creation failed")
+        }
+    }
+
+    @Test
+    fun `copy rejects heap byte buffer`() {
+        val player = createPlayerOrFail()
+
+        try {
+            assertFailsWith<IllegalArgumentException> {
+                LinuxNativeBridge.nCopyLatestFrame(
+                    handle = player,
+                    destination = ByteBuffer.allocate(16),
+                    expectedWidth = 2,
+                    expectedHeight = 2,
+                    destinationStride = 8,
+                    outInfo = IntArray(3),
+                )
+            }
+        } finally {
+            LinuxNativeBridge.nDisposePlayer(player)
+        }
+    }
+
+    @Test
+    fun `copy rejects read only direct byte buffer`() {
+        val player = createPlayerOrFail()
+
+        try {
+            assertFailsWith<IllegalArgumentException> {
+                LinuxNativeBridge.nCopyLatestFrame(
+                    handle = player,
+                    destination = ByteBuffer.allocateDirect(16).asReadOnlyBuffer(),
+                    expectedWidth = 2,
+                    expectedHeight = 2,
+                    destinationStride = 8,
+                    outInfo = IntArray(3),
+                )
+            }
+        } finally {
+            LinuxNativeBridge.nDisposePlayer(player)
+        }
+    }
+
+    @Test
+    fun `copy reports not ready through direct byte buffer`() {
+        val player = createPlayerOrFail()
+        val info = intArrayOf(7, 7, 7)
+
+        try {
+            val status =
+                LinuxNativeBridge.nCopyLatestFrame(
+                    handle = player,
+                    destination = ByteBuffer.allocateDirect(16),
+                    expectedWidth = 2,
+                    expectedHeight = 2,
+                    destinationStride = 8,
+                    outInfo = info,
+                )
+
+            assertEquals(LinuxNativeBridge.FRAME_COPY_NOT_READY, status)
+            assertContentEquals(intArrayOf(0, 0, 0), info)
+        } finally {
+            LinuxNativeBridge.nDisposePlayer(player)
+        }
+    }
+
+    @Test
+    fun `copy succeeds through real JNI and preserves destination padding`() {
+        val player = createPlayerOrFail()
+        var fixture: java.nio.file.Path? = null
+
+        try {
+            fixture = Files.createTempFile("compose-media-player-frame-", ".bmp")
+            Files.write(fixture, twoByTwoBmp())
+            LinuxNativeBridge.nOpenUri(player, fixture.toUri().toASCIIString())
+            LinuxNativeBridge.nPlay(player)
+
+            val destinationStride = 12
+            val destination = ByteBuffer.allocateDirect(destinationStride * 2)
+            repeat(destination.capacity()) { destination.put(it, 0x5a.toByte()) }
+            val info = IntArray(3)
+            var status = LinuxNativeBridge.FRAME_COPY_NOT_READY
+            val deadline = System.nanoTime() + 10_000_000_000L
+            while (System.nanoTime() < deadline) {
+                if (LinuxNativeBridge.nGetFrameWidth(player) == 2 &&
+                    LinuxNativeBridge.nGetFrameHeight(player) == 2
+                ) {
+                    status =
+                        LinuxNativeBridge.nCopyLatestFrame(
+                            handle = player,
+                            destination = destination,
+                            expectedWidth = 2,
+                            expectedHeight = 2,
+                            destinationStride = destinationStride,
+                            outInfo = info,
+                        )
+                    if (status == LinuxNativeBridge.FRAME_COPY_OK) break
+                }
+                Thread.sleep(10)
+            }
+
+            assertEquals(LinuxNativeBridge.FRAME_COPY_OK, status)
+            assertContentEquals(intArrayOf(2, 2, 8), info)
+            val copied = ByteArray(destination.capacity())
+            destination.position(0)
+            destination.get(copied)
+            assertTrue(copied.sliceArray(0 until 8).any { it != 0.toByte() })
+            assertTrue(copied.sliceArray(12 until 20).any { it != 0.toByte() })
+            assertTrue(copied.sliceArray(8 until 12).all { it == 0x5a.toByte() })
+            assertTrue(copied.sliceArray(20 until 24).all { it == 0x5a.toByte() })
+        } finally {
+            try {
+                LinuxNativeBridge.nDisposePlayer(player)
+            } finally {
+                fixture?.let { Files.deleteIfExists(it) }
+            }
+        }
+    }
+}

--- a/vendor/compose-media-player/mediaplayer/src/jvmTest/kotlin/io/github/kdroidfilter/composemediaplayer/util/NativeLibraryLoaderTest.kt
+++ b/vendor/compose-media-player/mediaplayer/src/jvmTest/kotlin/io/github/kdroidfilter/composemediaplayer/util/NativeLibraryLoaderTest.kt
@@ -1,0 +1,35 @@
+package io.github.kdroidfilter.composemediaplayer.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+
+class NativeLibraryLoaderTest {
+    @Test
+    fun `equal sized native libraries with different content use different cache files`() {
+        val first = contentAddressedNativeFileName("libNativeVideoPlayer.so", byteArrayOf(1, 2, 3, 4))
+        val second = contentAddressedNativeFileName("libNativeVideoPlayer.so", byteArrayOf(4, 3, 2, 1))
+
+        assertNotEquals(first, second)
+        assertEquals(first, contentAddressedNativeFileName("libNativeVideoPlayer.so", byteArrayOf(1, 2, 3, 4)))
+    }
+
+    @Test
+    fun `native library path segments reject traversal and separators`() {
+        listOf(
+            "../libNativeVideoPlayer.so",
+            "/tmp/libNativeVideoPlayer.so",
+            "nested/libNativeVideoPlayer.so",
+            "nested\\libNativeVideoPlayer.so",
+            "..",
+        ).forEach { unsafeName ->
+            assertFailsWith<IllegalArgumentException>(unsafeName) {
+                validateNativePathSegment(unsafeName)
+            }
+        }
+
+        assertEquals("NativeVideoPlayer", validateNativePathSegment("NativeVideoPlayer"))
+        assertEquals("libNativeVideoPlayer.so", validateNativePathSegment("libNativeVideoPlayer.so"))
+    }
+}


### PR DESCRIPTION
## Summary

- Replace Linux bare frame-address access with one atomic JNI copy operation.
- Map GStreamer samples through `GstVideoFrame` and honor actual plane stride.
- Hold `frame_lock` across coherent metadata validation and every destination row copy.
- Gate reusable direct-buffer/Skia destination lifetime during disposal.
- Reject null, heap, read-only, invalid-layout, and undersized JNI destinations.
- Harden native-library extraction and ensure Gradle packages freshly built native bytes.
- Add deterministic native concurrency/stride tests and successful real-GStreamer JNI coverage.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

The Linux bridge exposed a decoded-frame address while reading dimensions separately. Kotlin could retain and copy that address while GStreamer replaced, resized, or freed the frame. Source rows also assumed tight `width * 4` packing instead of the actual plane stride. This could produce incoherent frames, out-of-bounds reads, or use-after-free.

## Desktop scope

Linux desktop only. The changes are confined to the vendored compose-media-player Linux GStreamer/JNI implementation, its JVM resource build wiring, Linux player state, and focused native/JVM tests. No Windows, macOS, Android, iOS, or shared application behavior is changed.

## Issue or approval

Fixes #479.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

Decoded Linux frames are now copied coherently instead of exposing native storage across JNI.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

This PR does not change UI, playback controls, source selection, or non-Linux backends. Broader native player-object lifecycle leases, overlapping-open generation handling, and release workflow changes remain separate follow-up work. The loader/resource-order changes are limited to ensuring the Linux JNI tests and package use the current native bytes.

## Testing

Ubuntu Linux amd64:

- Native CTest passed with a 30-second timeout and `--no-tests=error`.
- Deterministic lock test proved the real publication helper receives `EBUSY` while copy owns `frame_lock`.
- ASan/UBSan frame-copy stress: 100/100 passed.
- Focused real-JNI frame-copy tests: 4/4 passed, zero skips.
- Full media-player JVM suite: 92/92 passed, zero skips.
- Desktop baseline: 787/788 passed; only the pre-existing `WatchedItemsStoreTest.concurrent updates publish coherent item snapshots` failed.
- Linux DEB tooling and metadata verifier passed.
- Exact DEB reinstall, package identity, `dpkg -V`, and packaged-native byte equality passed.
- Installed GStreamer/JNI probe successfully copied a decoded 2x2 BMP frame.
- Reviewed exact diff SHA-256: `0692cc617382ee6f44fd0f3580ddf191ae2703d593c69f27b2897e1ac43a35ef`.
- Commit: `ac93907446a21d36d3e6faf348dcc0f3c0e20a58`.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Closes #479.
