### PR TITLE
Fix resize mode not being applied when stream starts

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
@@ -65,6 +65,9 @@ internal class NativePlayerController(
 
         @Volatile
         var rememberedVolumeLevel: Float = DesktopPlayerVolumeStorage.loadVolumeLevel() ?: 1f
+
+        @Volatile
+        var rememberedResizeMode: PlayerResizeMode = PlayerResizeMode.Fit
     }
 
     private data class ReleaseCallback(
@@ -332,11 +335,7 @@ internal class NativePlayerController(
                         }
                         applyRememberedVolume()
                         updateControls(controlsState)
-                        try {
-                            setResizeMode(PlayerResizeMode.valueOf(controlsState.resizeModeLabel))
-                        } catch(_: IllegalArgumentException) {
-                            setResizeMode(PlayerResizeMode.Fit)
-                        }
+                        setResizeMode(rememberedResizeMode)
                         applyPendingSubtitleSettings()
                     }
                 }.onFailure { error ->
@@ -453,6 +452,7 @@ internal class NativePlayerController(
     }
 
     fun setResizeMode(mode: PlayerResizeMode) {
+        rememberedResizeMode = mode
         handle.takeIf { it != 0L }?.let { current ->
             NativePlayerBridge.setResizeMode(
                 handle = current,

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
@@ -332,6 +332,11 @@ internal class NativePlayerController(
                         }
                         applyRememberedVolume()
                         updateControls(controlsState)
+                        try {
+                            setResizeMode(PlayerResizeMode.valueOf(controlsState.resizeModeLabel))
+                        } catch(_: IllegalArgumentException) {
+                            setResizeMode(PlayerResizeMode.Fit)
+                        }
                         applyPendingSubtitleSettings()
                     }
                 }.onFailure { error ->


### PR DESCRIPTION
## Summary

- Call `setResizeMode` directly from function `createPlayer` (it will only be called once per stream and when player is created)
- Grab resize mode from `controlsState`
- If `controlsState` is corrupted in any way, set resize mode to default value Fit

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Controls always keep value of previous resize mode that user selected, so player should set its mode accordingly.

## Desktop scope

This change is related to shared desktop code.

## Issue or approval

Fixes issue [#481](https://github.com/NuvioMedia/NuvioDesktop/issues/481)

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

Only `createPlayer` in `NativePlayerController` is changed. There might be a way to grab `PlayerResizeMode` value from storage, similarly like `applyRememberedVolume` does it. Except `applyRememberedVolume` has its own separate storage.
Another way this could be done is when `PlayerEngine` calls `setResizeMode` for the first time with value from storage and that call gets ignored because player doesn't exist yet, specific mode could be saved in random value in `NativePlayerController`, which would then be accessed only once by `setResizeMode` in `createPlayer`.

## Testing

Tested by changing resize mode to either Zoom or Stretch. Then I tried:

- Closing and opening same stream
- Closing and opening different source for same episode
- Closing and opening different series
- Changing source mid stream
- Changing episode mid stream
- Closing and opening application before opening stream

Tested with basic `println()` and confirmed that `setResizeMode` in `createPlayer` gets called only once when stream starts.

## Screenshots / Video

Not a UI change

## Breaking changes

None

## Linked issues

Fixes issue [#481](https://github.com/NuvioMedia/NuvioDesktop/issues/481)
