### PR TITLE
fix(linux): make horizontal wheel and touchpad scrolling work

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/LinuxExtendedMouseButtons.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/LinuxExtendedMouseButtons.kt
@@ -1,30 +1,55 @@
 package com.nuvio.app
 
 import java.awt.AWTEvent
+import java.awt.Component
+import java.awt.EventQueue
 import java.awt.Toolkit
+import java.awt.event.InputEvent
 import java.awt.event.MouseEvent
+import java.awt.event.MouseWheelEvent
 
-// X11 numbers the mouse thumb buttons 8 and 9. Java's XToolkit reports the
-// vertical wheel as MouseWheelEvent and keeps the horizontal wheel as buttons 4
-// and 5, so the thumb buttons arrive as AWT buttons 6 and 7. Compose derives
-// PointerButton.Back from the 4th button, so the back navigation in
-// MainAppContent never matched and the button did nothing on Linux.
+// X11 numbers the buttons above the wheel differently from the other desktop
+// toolkits and Java's XToolkit passes that numbering straight through. The
+// vertical wheel becomes a MouseWheelEvent, but the horizontal wheel stays a
+// pair of button presses -- X11 buttons 6 and 7, reported as AWT buttons 4 and
+// 5 -- so the thumb buttons (X11 8 and 9) arrive as AWT buttons 6 and 7.
 //
-// Re-post the press and release under the button number Compose expects. The
-// shared code stays untouched and keeps working unchanged on Windows and macOS,
-// where the toolkit already numbers these buttons the way Compose reads them.
+// Compose derives its PointerButton from the AWT button number minus one, which
+// leaves two separate defects on Linux:
 //
-// Only Back is mapped. Nothing acts on PointerButton.Forward: there is no
-// forward navigation anywhere in the app, and the player's own seek arrives
-// through the native bridge rather than through AWT, so mapping the second
-// thumb button would post events that no handler consumes.
+//   * the thumb back button arrives as button 6, never matches
+//     PointerButton.Back, and back navigation does nothing;
+//   * a horizontal wheel tick arrives as button 4 or 5, which is exactly what
+//     Compose reads as Back and Forward, so scrolling a row sideways navigates
+//     the app backwards instead of moving the row.
+//
+// A horizontal scroll only reaches Compose as a MouseWheelEvent with shift held
+// -- ComposeSceneMediator builds Offset(rotation, 0) when isShiftDown and
+// Offset(0, rotation) otherwise -- so the wheel buttons have to be translated
+// into that shape rather than merely renumbered.
+//
+// Both fixes have to replace the original event instead of adding to it, which
+// an AWTEventListener cannot do: it observes and cannot consume. Pushing an
+// EventQueue hands us each event before dispatch, so the button press is swapped
+// for the event Compose understands and the original never reaches the app.
+// Shared code stays untouched, and Windows and macOS never see this -- their
+// toolkits already number these buttons the way Compose reads them.
 //
 // Install this only once the window peer exists. Reaching for the AWT toolkit
 // during main() forces it up before GTK has finished initializing, which is the
 // ordering main() opens by warning about, and it leaves the window unable to
 // close.
-private const val X11_THUMB_BACK = 6
+
+// AWT numbers, i.e. what MouseEvent.getButton() reports on X11.
+private const val AWT_WHEEL_LEFT = 4
+private const val AWT_WHEEL_RIGHT = 5
+private const val AWT_THUMB_BACK = 6
+
+// The AWT button Compose reads as PointerButton.Back.
 private const val COMPOSE_BACK = 4
+
+// One notch per press, matching what the toolkit sends for the vertical wheel.
+private const val WHEEL_SCROLL_AMOUNT = 3
 
 @Volatile
 private var extendedMouseButtonsInstalled = false
@@ -37,32 +62,76 @@ fun installLinuxExtendedMouseButtons() {
     }
     // Never let an input convenience take the app down with it.
     runCatching {
-        val toolkit = Toolkit.getDefaultToolkit()
-        toolkit.addAWTEventListener({ event ->
-            val source = event as? MouseEvent ?: return@addAWTEventListener
-            if (source.id != MouseEvent.MOUSE_PRESSED && source.id != MouseEvent.MOUSE_RELEASED) {
-                return@addAWTEventListener
-            }
-            if (source.button != X11_THUMB_BACK) return@addAWTEventListener
-            val component = source.component ?: return@addAWTEventListener
-            // The replacement carries the mapped button, so this listener sees
-            // it, fails the check above, and returns -- it cannot feed itself.
-            runCatching {
-                toolkit.systemEventQueue.postEvent(
-                    MouseEvent(
-                        component,
-                        source.id,
-                        source.getWhen(),
-                        source.modifiersEx,
-                        source.x,
-                        source.y,
-                        source.clickCount,
-                        source.isPopupTrigger,
-                        COMPOSE_BACK,
-                    ),
-                )
-            }
-        }, AWTEvent.MOUSE_EVENT_MASK)
+        Toolkit.getDefaultToolkit().systemEventQueue.push(LinuxExtendedMouseButtonQueue())
+    }
+}
+
+private class LinuxExtendedMouseButtonQueue : EventQueue() {
+    override fun dispatchEvent(event: AWTEvent) {
+        // A translation fault must not cost the app an event, so fall back to
+        // dispatching what the toolkit gave us.
+        val translated = runCatching { translate(event) }.getOrDefault(event)
+        if (translated != null) {
+            super.dispatchEvent(translated)
+        }
+    }
+
+    // Returns the event to dispatch, or null to drop it.
+    private fun translate(event: AWTEvent): AWTEvent? {
+        // Wheel events are already the shape Compose wants, and only pressed,
+        // released and clicked carry a button number.
+        if (event !is MouseEvent || event is MouseWheelEvent) return event
+        if (event.id != MouseEvent.MOUSE_PRESSED &&
+            event.id != MouseEvent.MOUSE_RELEASED &&
+            event.id != MouseEvent.MOUSE_CLICKED
+        ) {
+            return event
+        }
+        val component = event.component ?: return event
+        return when (event.button) {
+            AWT_THUMB_BACK -> withButton(event, component, COMPOSE_BACK)
+            AWT_WHEEL_LEFT -> horizontalScroll(event, component, rotation = -1)
+            AWT_WHEEL_RIGHT -> horizontalScroll(event, component, rotation = 1)
+            else -> event
+        }
+    }
+
+    private fun withButton(source: MouseEvent, component: Component, button: Int): MouseEvent =
+        MouseEvent(
+            component,
+            source.id,
+            source.getWhen(),
+            source.modifiersEx,
+            source.x,
+            source.y,
+            source.xOnScreen,
+            source.yOnScreen,
+            source.clickCount,
+            source.isPopupTrigger,
+            button,
+        )
+
+    private fun horizontalScroll(source: MouseEvent, component: Component, rotation: Int): AWTEvent? {
+        // The press is the tick. The release and click that follow it would
+        // scroll the row a second and third time, and passing them through
+        // instead would navigate back, which is the defect being fixed.
+        if (source.id != MouseEvent.MOUSE_PRESSED) return null
+        return MouseWheelEvent(
+            component,
+            MouseEvent.MOUSE_WHEEL,
+            source.getWhen(),
+            source.modifiersEx or InputEvent.SHIFT_DOWN_MASK,
+            source.x,
+            source.y,
+            source.xOnScreen,
+            source.yOnScreen,
+            0,
+            false,
+            MouseWheelEvent.WHEEL_UNIT_SCROLL,
+            WHEEL_SCROLL_AMOUNT,
+            rotation,
+            rotation.toDouble(),
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

- Translate the X11 horizontal wheel into the shift-modified `MouseWheelEvent` Compose reads as a horizontal scroll.
- Stop a horizontal tick from reaching the app as `PointerButton.Back`/`Forward`, which navigated instead of scrolling.
- Move the existing thumb-button remap onto the same pushed `EventQueue`, since an `AWTEventListener` cannot swallow the event it replaces.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

X11 delivers the horizontal wheel as buttons 6 and 7, and Java's XToolkit reports those as AWT buttons 4 and 5. Compose derives its `PointerButton` from the AWT button number minus one, so on Linux a horizontal tick arrives as `PointerButton.Back` or `PointerButton.Forward`. Scrolling a row sideways therefore moved nothing and, to the left, navigated the app back one screen.

The scroll path itself is fine — Shift + wheel already scrolls these rows on Linux. `ComposeSceneMediator` builds `Offset(rotation, 0)` when shift is held and `Offset(0, rotation)` otherwise, so a horizontal scroll only exists as a `MouseWheelEvent` with shift, and the horizontal wheel never becomes a `MouseWheelEvent` on X11. The fix is to build that event from the button press.

The press also has to be swallowed, or the back navigation stays. An `AWTEventListener` can only observe, so the translation moves to a pushed `EventQueue`, and the thumb-button remap added in #473 moves with it rather than living in a second mechanism.

## Desktop scope

Linux only. `LinuxExtendedMouseButtons.kt` is desktop code that returns immediately unless `os.name` is Linux, and the file is the only one touched. Windows and macOS toolkits already number these buttons the way Compose reads them and never reach the translation. No shared or common code is involved.

## Issue or approval

Fixes #495.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

A horizontal wheel tick now scrolls the row under the pointer instead of navigating backwards.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

The thumb back button keeps exactly the behaviour it has today: AWT button 6 is dispatched as button 4 so `PointerButton.Back` matches. `PointerButton.Forward` is still deliberately unmapped, because nothing in the app acts on it.

Not changed: the vertical wheel, `controls.js` and the in-player controls, the native player bridge, scroll speed or smooth-scrolling behaviour anywhere, and any shared or non-Linux code. No dependencies added.

## Testing

Built from source on NixOS 25.11 (kernel 6.12.93, KDE Plasma on Wayland, the app under Xwayland), on `Dev` at `24f63e42`.

Desktop test suite: 133 suites, 790 tests, 0 failures, 0 skipped.

Manual, on a laptop touchpad with two-finger horizontal scrolling:

- Home carousels, Continue Watching, and a series episode list in Horizontal card mode all scroll sideways now, in both directions, with the row moving the way the fingers move.
- Scrolling left no longer navigates back.
- Shift + vertical wheel still scrolls these rows, unchanged.
- Thumb back button still navigates back outside the player, and inside the player back and forward each still seek 10s per press through the native bridge, with no double step.
- Left and right clicks, drags on the seek and volume sliders, and vertical scrolling are all unchanged. Middle click does nothing, as before this change — there is no handler for it in the app.
- The window still closes normally from its own button, which is the failure mode to watch for when touching AWT startup on Linux.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #495.
