### PR TITLE
fix(player): treat the next-episode auto play timeout as a cap

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerNextEpisodeAutoPlay.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerNextEpisodeAutoPlay.kt
@@ -194,8 +194,13 @@ internal fun CoroutineScope.launchPlayerNextEpisodeAutoPlay(
         val timeoutMs = timeoutSeconds * 1_000L
         val isBoundedTimeout = timeoutSeconds in 1..30
 
+        // The timeout caps how long to wait for a stream to become selectable, so
+        // it must be raced against the selection rather than served in full. The
+        // unconditional sleep made every transition cost the whole setting even
+        // when the collector above had already picked a source in the first few
+        // hundred milliseconds.
         if (isBoundedTimeout) {
-            delay(timeoutMs)
+            withTimeoutOrNull(timeoutMs) { autoSelectSettled.await() }
         }
         applySelectionDecision(
             selectionCoordinator.onSelectionDelayElapsed(PlayerStreamsRepository.episodeStreamsState.value),


### PR DESCRIPTION
## Summary

- Race the next-episode stream selection timeout against the selection instead of sleeping through it.
- A transition now proceeds as soon as a source is picked, and the setting behaves as the ceiling it is described as.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

"Stream Selection Timeout" is described as the wait for addons before selecting, but `launchPlayerNextEpisodeAutoPlay` served it as a fixed delay:

```kotlin
if (isBoundedTimeout) {
    delay(timeoutMs)
}
```

The collector started just above already settles the selection as soon as a usable stream arrives, so on a fast source the decision was made in a few hundred milliseconds and the transition then sat idle for the rest of the setting. At the default of 3 seconds that is roughly three wasted seconds on every episode, on top of the countdown that follows, and it makes the higher values on the slider unusable: choosing 20s to accommodate a slow addon costs 20s on every transition, including the ones where a source was ready immediately.

Waiting for the selection with the timeout as a bound gives the same protection for slow addons without charging fast ones for it.

## Desktop scope

`commonMain`, and required for desktop behavior: `PlayerNextEpisodeAutoPlay.kt` is the auto-play path the desktop player runs on every episode transition, and the delay is served identically on Linux, Windows and macOS. The change is one statement in that shared function, with no platform-specific branch.

## Issue or approval

Fixes #454.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

The next episode starts once a source is selected rather than once the timeout expires. Nothing changes when no source settles in time.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

The timeout path itself is unchanged when nothing settles: the wait still expires after `timeoutMs` and the delay-elapsed decision is applied exactly as before, followed by the same hard timeout and the same manual-selection fallback. Values outside 1..30, which never waited, are untouched.

Not changed: the three-second countdown that runs after a source is picked, the selection rules in `NextEpisodeStreamSelectionCoordinator`, the settings UI, the stored setting and its allowed values, and every other platform's player. The issue also mentions the fixed countdown; that is a separate behavior change and is deliberately not bundled here.

## Testing

Built from source on NixOS 25.11 (kernel 6.12.93, KDE Plasma on Wayland), on `Dev` at `24f63e42`.

Desktop test suite: 133 suites, 790 tests, 0 failures, 0 skipped.

Manual, on Linux desktop:

- Stream Selection Timeout set to 20s, with addons that answer quickly: the next-episode countdown started about three seconds after the episode ended, which is the countdown alone. Before this change the same setting held the transition for the full 20s first.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #454.
