### PR TITLE
fix(player): restore current episode streams on back

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/PlayerDestination.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/PlayerDestination.kt
@@ -84,6 +84,7 @@ internal fun PlayerDestination(
         torrentTrackers = launch.torrentTrackers,
         initialPositionMs = launch.initialPositionMs,
         initialProgressFraction = launch.initialProgressFraction,
+        streamLaunchId = launch.streamLaunchId,
         contentLanguage = launch.contentLanguage,
         onBack = onBack,
         onSystemBackHandlerChanged = registerSystemBack,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/StreamDestination.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/StreamDestination.kt
@@ -62,9 +62,7 @@ internal fun StreamDestination(
     openExternalStreamUrl: (String) -> Boolean,
 ) {
     val onBack = rememberGuardedPopBackStack(navController, route)
-    val launch = remember(route.launchId) {
-        StreamLaunchStore.get(route.launchId)
-    }
+    val launch = StreamLaunchStore.get(route.launchId)
     if (launch == null) {
         LaunchedEffect(route.launchId) {
             onBack()
@@ -195,6 +193,7 @@ internal fun StreamDestination(
             torrentTrackers = stream.p2pTrackers,
             initialPositionMs = resolvedResumePositionMs ?: 0L,
             initialProgressFraction = resolvedResumeProgressFraction,
+            streamLaunchId = route.launchId.takeUnless { replaceStreamRoute },
         )
 
         val launchId = PlayerLaunchStore.put(playerLaunch)
@@ -584,6 +583,7 @@ internal fun StreamDestination(
             parentMetaType = launch.parentMetaType ?: launch.type,
             initialPositionMs = resolvedResumePositionMs ?: 0L,
             initialProgressFraction = resolvedResumeProgressFraction,
+            streamLaunchId = route.launchId,
         )
 
         if (!forceInternal && externalPlayerSupported && (forceExternal || playerSettings.externalPlayerEnabled)) {
@@ -625,6 +625,7 @@ internal fun StreamDestination(
             resumeProgressFraction = launch.resumeProgressFraction,
             manualSelection = launch.manualSelection,
             startFromBeginning = launch.startFromBeginning,
+            initialStreamsSnapshot = launch.streamsSnapshot,
             onStreamSelected = { stream, resolvedResumePositionMs, resolvedResumeProgressFraction ->
                 openSelectedStream(
                     stream = stream,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerModels.kt
@@ -45,6 +45,7 @@ data class PlayerLaunch(
     val torrentTrackers: List<String> = emptyList(),
     val initialPositionMs: Long = 0L,
     val initialProgressFraction: Float? = null,
+    val streamLaunchId: Long? = null,
     val contentLanguage: String? = null,
 )
 

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreen.kt
@@ -41,6 +41,7 @@ internal fun PlayerScreen(
     torrentTrackers: List<String> = emptyList(),
     initialPositionMs: Long = 0L,
     initialProgressFraction: Float? = null,
+    streamLaunchId: Long? = null,
     contentLanguage: String? = null,
 ) {
     PlayerScreenContent(
@@ -81,6 +82,7 @@ internal fun PlayerScreen(
             torrentTrackers = torrentTrackers,
             initialPositionMs = initialPositionMs,
             initialProgressFraction = initialProgressFraction,
+            streamLaunchId = streamLaunchId,
             contentLanguage = contentLanguage,
         )
     )

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenArgs.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenArgs.kt
@@ -45,5 +45,6 @@ internal data class PlayerScreenArgs(
     val torrentTrackers: List<String>,
     val initialPositionMs: Long,
     val initialProgressFraction: Float?,
+    val streamLaunchId: Long? = null,
     val contentLanguage: String? = null,
 )

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeSourceActions.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeSourceActions.kt
@@ -11,7 +11,9 @@ import com.nuvio.app.features.downloads.DownloadsRepository
 import com.nuvio.app.features.p2p.P2pSettingsRepository
 import com.nuvio.app.features.p2p.P2pStreamingEngine
 import com.nuvio.app.features.streams.StreamItem
+import com.nuvio.app.features.streams.StreamLaunchStore
 import com.nuvio.app.features.streams.StreamLinkCacheRepository
+import com.nuvio.app.features.streams.StreamsUiState
 import com.nuvio.app.features.watchprogress.WatchProgressRepository
 import com.nuvio.app.features.watchprogress.buildPlaybackVideoId
 import kotlinx.coroutines.launch
@@ -203,6 +205,7 @@ internal fun PlayerScreenRuntime.switchToP2pEpisodeStream(
         pendingP2pSwitch = PendingPlayerP2pSwitch(stream = stream, episode = episode, isAutoPlay = isAutoPlay)
         return
     }
+    val episodeStreamsSnapshot = PlayerStreamsRepository.episodeStreamsState.value
     resetEpisodePanelAndNextEpisodeState()
     flushWatchProgress()
     stopActiveP2pStream()
@@ -223,7 +226,7 @@ internal fun PlayerScreenRuntime.switchToP2pEpisodeStream(
     activeTorrentFileIdx = stream.p2pFileIdx
     activeTorrentFilename = stream.behaviorHints.filename
     activeTorrentTrackers = stream.p2pTrackers
-    applyEpisodeStreamMetadata(stream, episode, resume)
+    applyEpisodeStreamMetadata(stream, episode, resume, episodeStreamsSnapshot)
 }
 
 internal fun PlayerScreenRuntime.switchToSource(stream: StreamItem) {
@@ -306,6 +309,7 @@ internal fun PlayerScreenRuntime.switchToEpisodeStream(stream: StreamItem, episo
     }
     if (openExternalSourceUrl(stream)) return
     val url = stream.playableDirectUrl ?: return
+    val episodeStreamsSnapshot = PlayerStreamsRepository.episodeStreamsState.value
     resetEpisodePanelAndNextEpisodeState()
     flushWatchProgress()
     stopActiveP2pStream()
@@ -319,7 +323,7 @@ internal fun PlayerScreenRuntime.switchToEpisodeStream(stream: StreamItem, episo
     activeSourceHeaders = sanitizePlaybackHeaders(stream.behaviorHints.proxyHeaders?.request)
     activeSourceResponseHeaders = sanitizePlaybackResponseHeaders(stream.behaviorHints.proxyHeaders?.response)
     activeStreamType = stream.streamType
-    applyEpisodeStreamMetadata(stream, episode, resume)
+    applyEpisodeStreamMetadata(stream, episode, resume, episodeStreamsSnapshot)
 }
 
 internal fun PlayerScreenRuntime.switchToDownloadedEpisode(downloadItem: DownloadItem, episode: MetaVideo) {
@@ -369,6 +373,7 @@ internal fun PlayerScreenRuntime.switchToDownloadedEpisode(downloadItem: Downloa
     activeInitialPositionMs = epResumePositionMs
     activeInitialProgressFraction = epResumeFraction
     controlsVisible = true
+    updateStreamReturnEpisode(episode = episode, videoId = resolvedVideoId)
 }
 
 internal fun PlayerScreenRuntime.playNextEpisode() {
@@ -461,6 +466,7 @@ private fun PlayerScreenRuntime.applyEpisodeStreamMetadata(
     stream: StreamItem,
     episode: MetaVideo,
     resume: EpisodeResume,
+    episodeStreamsSnapshot: StreamsUiState,
 ) {
     activeSourceIdentityKey = stream.playerSourceIdentityKey()
     activeStreamTitle = stream.streamLabel
@@ -477,6 +483,29 @@ private fun PlayerScreenRuntime.applyEpisodeStreamMetadata(
     activeInitialPositionMs = resume.positionMs
     activeInitialProgressFraction = resume.fraction
     controlsVisible = true
+    updateStreamReturnEpisode(
+        episode = episode,
+        videoId = episode.id,
+        streamsSnapshot = episodeStreamsSnapshot,
+    )
+}
+
+private fun PlayerScreenRuntime.updateStreamReturnEpisode(
+    episode: MetaVideo,
+    videoId: String,
+    streamsSnapshot: StreamsUiState? = null,
+) {
+    val streamLaunchId = args.streamLaunchId ?: return
+    StreamLaunchStore.updateEpisode(
+        launchId = streamLaunchId,
+        videoId = videoId,
+        seasonNumber = episode.season,
+        episodeNumber = episode.episode,
+        episodeTitle = episode.title,
+        episodeThumbnail = episode.thumbnail,
+        pauseDescription = episode.overview,
+        streamsSnapshot = streamsSnapshot,
+    )
 }
 
 private fun PlayerScreenRuntime.saveDirectStreamForReuse(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamLaunchStore.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamLaunchStore.kt
@@ -1,5 +1,7 @@
 package com.nuvio.app.features.streams
 
+import androidx.compose.runtime.mutableStateMapOf
+
 data class StreamLaunch(
     val profileId: Int,
     val type: String,
@@ -19,11 +21,12 @@ data class StreamLaunch(
     val resumeProgressFraction: Float? = null,
     val manualSelection: Boolean = false,
     val startFromBeginning: Boolean = false,
+    val streamsSnapshot: StreamsUiState? = null,
 )
 
 object StreamLaunchStore {
     private var nextLaunchId = 1L
-    private val launches = mutableMapOf<Long, StreamLaunch>()
+    private val launches = mutableStateMapOf<Long, StreamLaunch>()
 
     fun put(launch: StreamLaunch): Long {
         val launchId = nextLaunchId++
@@ -32,6 +35,33 @@ object StreamLaunchStore {
     }
 
     fun get(launchId: Long): StreamLaunch? = launches[launchId]
+
+    fun updateEpisode(
+        launchId: Long?,
+        videoId: String,
+        seasonNumber: Int?,
+        episodeNumber: Int?,
+        episodeTitle: String?,
+        episodeThumbnail: String?,
+        pauseDescription: String?,
+        streamsSnapshot: StreamsUiState? = null,
+    ) {
+        if (launchId == null) return
+        val current = launches[launchId] ?: return
+        launches[launchId] = current.copy(
+            videoId = videoId,
+            seasonNumber = seasonNumber,
+            episodeNumber = episodeNumber,
+            episodeTitle = episodeTitle,
+            episodeThumbnail = episodeThumbnail,
+            pauseDescription = pauseDescription,
+            resumePositionMs = null,
+            resumeProgressFraction = null,
+            manualSelection = true,
+            startFromBeginning = false,
+            streamsSnapshot = streamsSnapshot,
+        )
+    }
 
     fun remove(launchId: Long) {
         launches.remove(launchId)

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamsRepository.kt
@@ -71,13 +71,48 @@ object StreamsRepository {
         )
     }
 
-    private fun load(type: String, videoId: String, parentMetaId: String?, season: Int?, episode: Int?, manualSelection: Boolean, forceRefresh: Boolean) {
-        val pluginUiState = if (AppFeaturePolicy.pluginsEnabled) {
-            PluginRepository.initialize()
-            PluginRepository.uiState.value
-        } else {
-            PluginsUiState(pluginsEnabled = false)
+    fun restorePlayerEpisodeSnapshot(
+        type: String,
+        videoId: String,
+        season: Int?,
+        episode: Int?,
+        snapshot: StreamsUiState,
+    ) {
+        val completedGroups = snapshot.groups.map { group ->
+            if (group.isLoading) group.copy(isLoading = false) else group
         }
+        val emptyStateReason = if (completedGroups.isEmpty()) {
+            snapshot.emptyStateReason
+        } else {
+            completedGroups.toEmptyStateReason(anyLoading = false)
+        }
+        if (completedGroups.isEmpty() && emptyStateReason == null) return
+
+        val pluginUiState = currentPluginUiState()
+        val requestToken = requestToken(
+            type = type,
+            videoId = videoId,
+            season = season,
+            episode = episode,
+            manualSelection = true,
+        )
+        activeJob?.cancel()
+        activeJob = null
+        activeRequestKey = requestKey(requestToken, pluginUiState)
+        _uiState.value = StreamsUiState(
+            requestToken = requestToken,
+            groups = completedGroups,
+            activeAddonIds = completedGroups.map { it.addonId }.toSet(),
+            selectedFilter = snapshot.selectedFilter?.takeIf { selected ->
+                completedGroups.any { it.addonId == selected }
+            },
+            isAnyLoading = false,
+            emptyStateReason = emptyStateReason,
+        )
+    }
+
+    private fun load(type: String, videoId: String, parentMetaId: String?, season: Int?, episode: Int?, manualSelection: Boolean, forceRefresh: Boolean) {
+        val pluginUiState = currentPluginUiState()
         val requestToken = requestToken(
             type = type,
             videoId = videoId,
@@ -85,7 +120,7 @@ object StreamsRepository {
             episode = episode,
             manualSelection = manualSelection,
         )
-        val requestKey = "$requestToken::pluginsGrouped=${pluginUiState.groupStreamsByRepository}"
+        val requestKey = requestKey(requestToken, pluginUiState)
         val currentState = _uiState.value
         if (
             !forceRefresh &&
@@ -803,4 +838,15 @@ object StreamsRepository {
     fun setOverlayVisible(visible: Boolean, message: String? = null) {
         _uiState.update { it.copy(showDirectAutoPlayOverlay = visible, overlayMessage = message) }
     }
+
+    private fun currentPluginUiState(): PluginsUiState =
+        if (AppFeaturePolicy.pluginsEnabled) {
+            PluginRepository.initialize()
+            PluginRepository.uiState.value
+        } else {
+            PluginsUiState(pluginsEnabled = false)
+        }
+
+    private fun requestKey(requestToken: String, pluginUiState: PluginsUiState): String =
+        "$requestToken::pluginsGrouped=${pluginUiState.groupStreamsByRepository}"
 }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamsScreen.kt
@@ -124,6 +124,7 @@ fun StreamsScreen(
     resumeProgressFraction: Float? = null,
     manualSelection: Boolean = false,
     startFromBeginning: Boolean = false,
+    initialStreamsSnapshot: StreamsUiState? = null,
     onStreamSelected: (stream: StreamItem, resumePositionMs: Long?, resumeProgressFraction: Float?) -> Unit = { _, _, _ -> },
     onStreamActionOpen: (
         stream: StreamItem,
@@ -203,7 +204,16 @@ fun StreamsScreen(
         }
     }
 
-    LaunchedEffect(type, videoId, seasonNumber, episodeNumber, manualSelection) {
+    LaunchedEffect(type, videoId, seasonNumber, episodeNumber, manualSelection, initialStreamsSnapshot) {
+        initialStreamsSnapshot?.let { snapshot ->
+            StreamsRepository.restorePlayerEpisodeSnapshot(
+                type = type,
+                videoId = videoId,
+                season = seasonNumber,
+                episode = episodeNumber,
+                snapshot = snapshot,
+            )
+        }
         StreamsRepository.load(
             type = type,
             videoId = videoId,

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/streams/StreamLaunchStoreTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/streams/StreamLaunchStoreTest.kt
@@ -1,0 +1,71 @@
+package com.nuvio.app.features.streams
+
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class StreamLaunchStoreTest {
+    @AfterTest
+    fun tearDown() {
+        StreamLaunchStore.clear()
+    }
+
+    @Test
+    fun repeatedUpdatesKeepLatestEpisodeAndStreamsSnapshot() {
+        val launchId = StreamLaunchStore.put(
+            StreamLaunch(
+                profileId = 1,
+                type = "series",
+                videoId = "episode-1",
+                parentMetaId = "series-id",
+                parentMetaType = "series",
+                title = "Series",
+                seasonNumber = 1,
+                episodeNumber = 1,
+                episodeTitle = "Episode 1",
+                pauseDescription = "First episode",
+                resumePositionMs = 120_000L,
+                resumeProgressFraction = 0.5f,
+                startFromBeginning = true,
+            ),
+        )
+
+        for (episodeNumber in 2..20) {
+            val streamsSnapshot = StreamsUiState(
+                groups = listOf(
+                    AddonStreamGroup(
+                        addonName = "Addon $episodeNumber",
+                        addonId = "addon-$episodeNumber",
+                        streams = emptyList(),
+                    ),
+                ),
+            )
+            StreamLaunchStore.updateEpisode(
+                launchId = launchId,
+                videoId = "episode-$episodeNumber",
+                seasonNumber = 1,
+                episodeNumber = episodeNumber,
+                episodeTitle = "Episode $episodeNumber",
+                episodeThumbnail = "thumbnail-$episodeNumber",
+                pauseDescription = "Description $episodeNumber",
+                streamsSnapshot = streamsSnapshot,
+            )
+        }
+
+        val updated = StreamLaunchStore.get(launchId)!!
+        assertEquals("episode-20", updated.videoId)
+        assertEquals(1, updated.seasonNumber)
+        assertEquals(20, updated.episodeNumber)
+        assertEquals("Episode 20", updated.episodeTitle)
+        assertEquals("thumbnail-20", updated.episodeThumbnail)
+        assertEquals("Description 20", updated.pauseDescription)
+        assertEquals("addon-20", updated.streamsSnapshot?.groups?.single()?.addonId)
+        assertNull(updated.resumePositionMs)
+        assertNull(updated.resumeProgressFraction)
+        assertTrue(updated.manualSelection)
+        assertFalse(updated.startFromBeginning)
+    }
+}


### PR DESCRIPTION
## Summary

- Keep the Streams back-stack entry synchronized with the latest episode selected inside the player.
- Retain the latest episode's already-fetched addon stream snapshot on that entry.
- Restore the snapshot before the Streams screen performs its normal load check, avoiding a duplicate addon request after Back.
- Add regression coverage for repeated episode-context replacement.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Old behavior: pressing Back without changing episodes returned to the existing Streams screen and retained its already-loaded addon results.

Broken behavior: after selecting a later episode and stream inside the player, the player updated its active episode but the Streams back-stack entry still referenced the original episode. Returning therefore showed stale episode results. Merely updating the episode caused the separate main Streams repository to fetch the same addon results again.

New behavior: every successful in-player episode switch replaces the return entry's episode metadata and single latest stream snapshot. Back now returns to the current episode and immediately restores the results that the player already fetched.

## Desktop scope

This fixes player-to-Streams navigation and result reuse on desktop. The affected implementation is shared/common Compose code because the Desktop player and Streams destinations use that code path.

Manually verified on Windows 11 using a build from source.

## Issue or approval

Fixes #498

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

- Stores only the latest episode's return snapshot; this does not add a shared multi-episode cache.
- Does not merge or change the ownership of `PlayerStreamsRepository` and `StreamsRepository`.
- Does not change stream selection, autoplay policy, addon fetching, UI layout, styling, dependencies, or public navigation routes.
- Does not include unrelated cleanup or changes from the earlier experimental WIP branch.

## Testing

Tested locally on Windows 11:

- Verified that exiting the original episode returns to its existing stream results without fetching addons again.
- Verified that advancing through multiple episodes returns to the latest episode and restores its already-fetched stream results without another addon request.
- Verified the same behavior across a season boundary and multiple shows.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #498