### PR TITLE
feat(discover): hide watched content from the discover feed

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -824,6 +824,7 @@
     <string name="settings_continue_watching_up_next_title">Next Up From Furthest Episode</string>
     <string name="settings_continue_watching_use_episode_thumbnails_description">Prefer episode thumbnails when available.</string>
     <string name="settings_continue_watching_use_episode_thumbnails_title">Prefer Episode Thumbnails in Continue Watching</string>
+    <string name="settings_content_discovery_section_discover">DISCOVER</string>
     <string name="settings_content_discovery_section_home">HOME</string>
     <string name="settings_content_discovery_section_sources">SOURCES</string>
     <string name="settings_content_discovery_addons_description">Install, remove, refresh, and sort your content sources.</string>
@@ -1501,6 +1502,8 @@
     <string name="discover_empty_no_results_message">The selected catalog and filters did not return any items.</string>
     <string name="discover_empty_no_results_title">No titles found</string>
     <string name="discover_empty_no_active_addons_message">Install and validate at least one addon before browsing discover catalogs.</string>
+    <string name="discover_hide_watched">Hide Watched Content</string>
+    <string name="discover_hide_watched_sub">Hide watched movies and finished shows from the Discover feed. Search results are never filtered.</string>
     <string name="discover_select_catalog">Select Catalog</string>
     <string name="discover_select_genre">Select Genre</string>
     <string name="discover_select_type">Select Type</string>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeCatalogSettingsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeCatalogSettingsRepository.kt
@@ -17,6 +17,12 @@ import kotlinx.serialization.json.Json
 import nuvio.composeapp.generated.resources.*
 import org.jetbrains.compose.resources.getString
 
+/**
+ * Default for the Discover watched filter. Off, so existing installs keep the
+ * current Discover behaviour until the user turns the setting on.
+ */
+const val DEFAULT_HIDE_WATCHED_IN_DISCOVER = false
+
 data class HomeCatalogSettingsItem(
     val key: String,
     val defaultTitle: String,
@@ -37,6 +43,7 @@ data class HomeCatalogSettingsUiState(
     val heroEnabled: Boolean = true,
     val showCatalogType: Boolean = true,
     val hideUnreleasedContent: Boolean = false,
+    val hideWatchedInDiscover: Boolean = DEFAULT_HIDE_WATCHED_IN_DISCOVER,
     val items: List<HomeCatalogSettingsItem> = emptyList(),
 ) {
     val signature: String
@@ -46,6 +53,8 @@ data class HomeCatalogSettingsUiState(
             append(showCatalogType)
             append('|')
             append(hideUnreleasedContent)
+            append('|')
+            append(hideWatchedInDiscover)
             append('|')
             append(
                 items.joinToString(separator = "|") { item ->
@@ -66,6 +75,7 @@ internal data class HomeCatalogSettingsSnapshot(
     val heroEnabled: Boolean,
     val showCatalogType: Boolean,
     val hideUnreleasedContent: Boolean,
+    val hideWatchedInDiscover: Boolean,
     val preferences: Map<String, HomeCatalogPreference>,
 )
 
@@ -83,6 +93,7 @@ private data class StoredHomeCatalogSettingsPayload(
     val heroEnabled: Boolean = true,
     val showCatalogType: Boolean = true,
     val hideUnreleasedContent: Boolean = false,
+    val hideWatchedInDiscover: Boolean = DEFAULT_HIDE_WATCHED_IN_DISCOVER,
     val items: List<StoredHomeCatalogPreference> = emptyList(),
 )
 
@@ -109,6 +120,7 @@ object HomeCatalogSettingsRepository {
     private var heroEnabled = true
     private var showCatalogType = true
     private var hideUnreleasedContent = false
+    private var hideWatchedInDiscover = DEFAULT_HIDE_WATCHED_IN_DISCOVER
 
     fun onProfileChanged() {
         hasLoaded = false
@@ -116,6 +128,7 @@ object HomeCatalogSettingsRepository {
         heroEnabled = true
         showCatalogType = true
         hideUnreleasedContent = false
+        hideWatchedInDiscover = DEFAULT_HIDE_WATCHED_IN_DISCOVER
         definitions = emptyList()
         collectionDefinitions = emptyList()
         _uiState.value = HomeCatalogSettingsUiState()
@@ -129,6 +142,7 @@ object HomeCatalogSettingsRepository {
         heroEnabled = true
         showCatalogType = true
         hideUnreleasedContent = false
+        hideWatchedInDiscover = DEFAULT_HIDE_WATCHED_IN_DISCOVER
         _uiState.value = HomeCatalogSettingsUiState()
     }
 
@@ -168,6 +182,7 @@ object HomeCatalogSettingsRepository {
             heroEnabled = heroEnabled,
             showCatalogType = showCatalogType,
             hideUnreleasedContent = hideUnreleasedContent,
+            hideWatchedInDiscover = hideWatchedInDiscover,
             preferences = preferences.mapValues { (_, value) ->
                 HomeCatalogPreference(
                     customTitle = value.customTitle,
@@ -207,6 +222,17 @@ object HomeCatalogSettingsRepository {
         HomeCatalogSettingsSyncService.triggerPush()
     }
 
+    fun setHideWatchedInDiscover(enabled: Boolean) {
+        ensureLoaded()
+        if (hideWatchedInDiscover == enabled) return
+        hideWatchedInDiscover = enabled
+        publish()
+        persist()
+        // Discover-only: the home catalogs never consult this flag, so there is
+        // nothing to recompute there.
+        HomeCatalogSettingsSyncService.triggerPush()
+    }
+
     fun setHeroSourceEnabled(key: String, enabled: Boolean) {
         updatePreference(key, pushRemote = false) { preference ->
             if (!enabled) {
@@ -236,6 +262,7 @@ object HomeCatalogSettingsRepository {
         heroEnabled = true
         showCatalogType = true
         hideUnreleasedContent = false
+        hideWatchedInDiscover = DEFAULT_HIDE_WATCHED_IN_DISCOVER
         preferences = emptyMap()
         normalizePreferences()
         publish()
@@ -287,6 +314,7 @@ object HomeCatalogSettingsRepository {
             heroEnabled = parsedPayload.heroEnabled
             showCatalogType = parsedPayload.showCatalogType
             hideUnreleasedContent = parsedPayload.hideUnreleasedContent
+            hideWatchedInDiscover = parsedPayload.hideWatchedInDiscover
             preferences = parsedPayload.items.associateBy { it.key }
             publish()
             return
@@ -387,6 +415,7 @@ object HomeCatalogSettingsRepository {
             heroEnabled = heroEnabled,
             showCatalogType = showCatalogType,
             hideUnreleasedContent = hideUnreleasedContent,
+            hideWatchedInDiscover = hideWatchedInDiscover,
             items = items,
         )
     }
@@ -398,6 +427,7 @@ object HomeCatalogSettingsRepository {
                     heroEnabled = heroEnabled,
                     showCatalogType = showCatalogType,
                     hideUnreleasedContent = hideUnreleasedContent,
+                    hideWatchedInDiscover = hideWatchedInDiscover,
                     items = preferences.values.sortedBy { it.order },
                 ),
             ),
@@ -496,6 +526,7 @@ object HomeCatalogSettingsRepository {
         return SyncHomeCatalogPayload(
             showCatalogType = showCatalogType,
             hideUnreleasedContent = hideUnreleasedContent,
+            hideWatchedInDiscover = hideWatchedInDiscover,
             items = items,
         )
     }
@@ -504,6 +535,7 @@ object HomeCatalogSettingsRepository {
         ensureLoaded()
         showCatalogType = payload.showCatalogType
         hideUnreleasedContent = payload.hideUnreleasedContent
+        hideWatchedInDiscover = payload.hideWatchedInDiscover
         if (payload.items.isNotEmpty()) {
             val existingHeroState = preferences.mapValues { it.value.heroSourceEnabled }
             val remotePreferences = payload.items.associate { item ->

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeCatalogSettingsSyncService.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeCatalogSettingsSyncService.kt
@@ -41,6 +41,7 @@ data class SyncCatalogItem(
 data class SyncHomeCatalogPayload(
     @SerialName("show_catalog_type") val showCatalogType: Boolean = true,
     @SerialName("hide_unreleased_content") val hideUnreleasedContent: Boolean = false,
+    @SerialName("hide_watched_in_discover") val hideWatchedInDiscover: Boolean = DEFAULT_HIDE_WATCHED_IN_DISCOVER,
     val items: List<SyncCatalogItem> = emptyList(),
 )
 
@@ -77,6 +78,7 @@ object HomeCatalogSettingsSyncService {
     }
 
     private const val HIDE_UNRELEASED_CONTENT_KEY = "hide_unreleased_content"
+    private const val HIDE_WATCHED_IN_DISCOVER_KEY = "hide_watched_in_discover"
     private const val SHOW_CATALOG_TYPE_KEY = "show_catalog_type"
 
     @Volatile
@@ -218,6 +220,11 @@ object HomeCatalogSettingsSyncService {
                 decoded.hideUnreleasedContent
             } else {
                 localPayload.hideUnreleasedContent
+            },
+            hideWatchedInDiscover = if (settingsJson.containsKey(HIDE_WATCHED_IN_DISCOVER_KEY)) {
+                decoded.hideWatchedInDiscover
+            } else {
+                localPayload.hideWatchedInDiscover
             },
         )
     }.getOrNull()

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/search/SearchRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/search/SearchRepository.kt
@@ -18,6 +18,8 @@ import com.nuvio.app.features.home.HomeCatalogSettingsRepository
 import com.nuvio.app.features.home.HomeCatalogSection
 import com.nuvio.app.features.home.MetaPreview
 import com.nuvio.app.features.home.filterReleasedItems
+import com.nuvio.app.features.watched.WatchedRepository
+import com.nuvio.app.features.watching.application.WatchingState
 import com.nuvio.app.features.watchprogress.CurrentDateProvider
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -51,6 +53,7 @@ internal fun resolveDiscoverCatalog(
 private data class DiscoverRequestKey(
     val sources: List<DiscoverCatalogOption>,
     val hideUnreleasedContent: Boolean,
+    val hideWatchedInDiscover: Boolean,
 )
 
 object SearchRepository {
@@ -218,10 +221,11 @@ object SearchRepository {
 
         val sources = buildDiscoverSources(activeAddons)
         val current = _discoverUiState.value
-        val hideUnreleasedContent = HomeCatalogSettingsRepository.snapshot().hideUnreleasedContent
+        val settingsSnapshot = HomeCatalogSettingsRepository.snapshot()
         val requestKey = DiscoverRequestKey(
             sources = sources,
-            hideUnreleasedContent = hideUnreleasedContent,
+            hideUnreleasedContent = settingsSnapshot.hideUnreleasedContent,
+            hideWatchedInDiscover = settingsSnapshot.hideWatchedInDiscover,
         )
         if (canReuseRequestState(forceRefresh, requestKey, lastDiscoverRequestKey)) {
             log.d {
@@ -486,7 +490,7 @@ object SearchRepository {
                     genre = current.selectedGenre,
                     skip = requestedSkip.takeIf { it > 0 },
                     forceRefresh = forceRefresh,
-                ).withUnreleasedFilter()
+                ).withUnreleasedFilter().withWatchedFilter()
             }.fold(
                 onSuccess = { page ->
                     val latest = _discoverUiState.value
@@ -566,6 +570,38 @@ private fun CatalogPage.withUnreleasedFilter(): CatalogPage {
     if (!HomeCatalogSettingsRepository.snapshot().hideUnreleasedContent) return this
     val filteredItems = items.filterReleasedItems(CurrentDateProvider.todayIsoDate())
     return if (filteredItems.size == items.size) this else copy(items = filteredItems)
+}
+
+/**
+ * Drops items the user has already finished from the discover feed. Uses the
+ * same predicate that decides whether a poster shows the watched badge, so the
+ * feed can never disagree with the badges: watched movies and fully watched
+ * series are hidden, partially watched series are kept.
+ *
+ * `rawItemCount` and `nextSkip` are deliberately left untouched so pagination
+ * keeps advancing through the catalog exactly as it would unfiltered.
+ */
+private fun CatalogPage.withWatchedFilter(): CatalogPage {
+    if (!HomeCatalogSettingsRepository.snapshot().hideWatchedInDiscover) return this
+    val filteredItems = items.filterUnwatchedPosters(
+        watchedKeys = WatchedRepository.uiState.value.watchedKeys,
+        fullyWatchedSeriesKeys = WatchedRepository.fullyWatchedSeriesKeys.value,
+    )
+    return if (filteredItems.size == items.size) this else copy(items = filteredItems)
+}
+
+internal fun List<MetaPreview>.filterUnwatchedPosters(
+    watchedKeys: Set<String>,
+    fullyWatchedSeriesKeys: Set<String>,
+): List<MetaPreview> {
+    if (watchedKeys.isEmpty() && fullyWatchedSeriesKeys.isEmpty()) return this
+    return filterNot { item ->
+        WatchingState.isPosterWatched(
+            watchedKeys = watchedKeys,
+            item = item,
+            fullyWatchedSeriesKeys = fullyWatchedSeriesKeys,
+        )
+    }
 }
 
 private data class SearchCatalogRequest(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/search/SearchScreen.kt
@@ -153,7 +153,11 @@ fun SearchScreen(
         }
     }
 
-    LaunchedEffect(addonRefreshKey, homeCatalogSettingsUiState.hideUnreleasedContent) {
+    LaunchedEffect(
+        addonRefreshKey,
+        homeCatalogSettingsUiState.hideUnreleasedContent,
+        homeCatalogSettingsUiState.hideWatchedInDiscover,
+    ) {
         SearchRepository.refreshDiscover(addonsUiState.addons)
     }
 

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/ContentDiscoverySettingsPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/ContentDiscoverySettingsPage.kt
@@ -2,21 +2,42 @@ package com.nuvio.app.features.settings
 
 import androidx.compose.foundation.lazy.LazyListScope
 import com.nuvio.app.core.build.AppFeaturePolicy
+import com.nuvio.app.features.home.HomeCatalogSettingsRepository
 import nuvio.composeapp.generated.resources.Res
 import nuvio.composeapp.generated.resources.compose_settings_page_addons
 import nuvio.composeapp.generated.resources.compose_settings_page_plugins
+import nuvio.composeapp.generated.resources.discover_hide_watched
+import nuvio.composeapp.generated.resources.discover_hide_watched_sub
 import nuvio.composeapp.generated.resources.settings_content_discovery_addons_description
 import nuvio.composeapp.generated.resources.settings_content_discovery_addons_description_appstore
 import nuvio.composeapp.generated.resources.settings_content_discovery_plugins_description
+import nuvio.composeapp.generated.resources.settings_content_discovery_section_discover
 import nuvio.composeapp.generated.resources.settings_content_discovery_section_sources
 import org.jetbrains.compose.resources.stringResource
 
 internal fun LazyListScope.contentDiscoveryContent(
     isTablet: Boolean,
     showPluginsEntry: Boolean,
+    hideWatchedInDiscover: Boolean,
     onAddonsClick: () -> Unit,
     onPluginsClick: () -> Unit,
 ) {
+    item {
+        SettingsSection(
+            title = stringResource(Res.string.settings_content_discovery_section_discover),
+            isTablet = isTablet,
+        ) {
+            SettingsGroup(isTablet = isTablet) {
+                SettingsSwitchRow(
+                    title = stringResource(Res.string.discover_hide_watched),
+                    description = stringResource(Res.string.discover_hide_watched_sub),
+                    checked = hideWatchedInDiscover,
+                    isTablet = isTablet,
+                    onCheckedChange = HomeCatalogSettingsRepository::setHideWatchedInDiscover,
+                )
+            }
+        }
+    }
     item {
         SettingsSection(
             title = stringResource(Res.string.settings_content_discovery_section_sources),

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/SettingsScreen.kt
@@ -336,6 +336,7 @@ fun SettingsScreen(
                 homescreenHeroEnabled = homescreenSettingsUiState.heroEnabled,
                 homescreenShowCatalogType = homescreenSettingsUiState.showCatalogType,
                 homescreenHideUnreleasedContent = homescreenSettingsUiState.hideUnreleasedContent,
+                discoverHideWatched = homescreenSettingsUiState.hideWatchedInDiscover,
                 homescreenItems = homescreenSettingsUiState.items,
                 metaScreenSettingsUiState = metaScreenSettingsUiState,
                 continueWatchingPreferencesUiState = continueWatchingPreferencesUiState,
@@ -398,6 +399,7 @@ fun SettingsScreen(
                 homescreenHeroEnabled = homescreenSettingsUiState.heroEnabled,
                 homescreenShowCatalogType = homescreenSettingsUiState.showCatalogType,
                 homescreenHideUnreleasedContent = homescreenSettingsUiState.hideUnreleasedContent,
+                discoverHideWatched = homescreenSettingsUiState.hideWatchedInDiscover,
                 homescreenItems = homescreenSettingsUiState.items,
                 metaScreenSettingsUiState = metaScreenSettingsUiState,
                 continueWatchingPreferencesUiState = continueWatchingPreferencesUiState,
@@ -470,6 +472,7 @@ private fun MobileSettingsScreen(
     homescreenHeroEnabled: Boolean,
     homescreenShowCatalogType: Boolean,
     homescreenHideUnreleasedContent: Boolean,
+    discoverHideWatched: Boolean,
     homescreenItems: List<HomeCatalogSettingsItem>,
     metaScreenSettingsUiState: MetaScreenSettingsUiState,
     continueWatchingPreferencesUiState: ContinueWatchingPreferencesUiState,
@@ -705,6 +708,7 @@ private fun MobileSettingsScreen(
                 SettingsPage.ContentDiscovery -> contentDiscoveryContent(
                     isTablet = false,
                     showPluginsEntry = AppFeaturePolicy.pluginsEnabled,
+                    hideWatchedInDiscover = discoverHideWatched,
                     onAddonsClick = onAddonsClick,
                     onPluginsClick = onPluginsClick,
                 )
@@ -844,6 +848,7 @@ private fun TabletSettingsScreen(
     homescreenHeroEnabled: Boolean,
     homescreenShowCatalogType: Boolean,
     homescreenHideUnreleasedContent: Boolean,
+    discoverHideWatched: Boolean,
     homescreenItems: List<HomeCatalogSettingsItem>,
     metaScreenSettingsUiState: MetaScreenSettingsUiState,
     continueWatchingPreferencesUiState: ContinueWatchingPreferencesUiState,
@@ -1138,6 +1143,7 @@ private fun TabletSettingsScreen(
                         SettingsPage.ContentDiscovery -> contentDiscoveryContent(
                             isTablet = true,
                             showPluginsEntry = AppFeaturePolicy.pluginsEnabled,
+                            hideWatchedInDiscover = discoverHideWatched,
                             onAddonsClick = { openInlinePage(SettingsPage.Addons) },
                             onPluginsClick = { openInlinePage(SettingsPage.Plugins) },
                         )

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/search/DiscoverWatchedFilterTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/search/DiscoverWatchedFilterTest.kt
@@ -1,0 +1,46 @@
+package com.nuvio.app.features.search
+
+import com.nuvio.app.features.home.MetaPreview
+import com.nuvio.app.features.watched.watchedItemKey
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DiscoverWatchedFilterTest {
+    private val movie = MetaPreview(id = "tt1234567", type = "movie", name = "Movie")
+    private val series = MetaPreview(id = "tmdb:123", type = "series", name = "Show")
+
+    @Test
+    fun `keeps every item when nothing is watched`() {
+        val result = listOf(movie, series).filterUnwatchedPosters(
+            watchedKeys = emptySet(),
+            fullyWatchedSeriesKeys = emptySet(),
+        )
+
+        assertEquals(listOf(movie, series), result)
+    }
+
+    @Test
+    fun `drops watched movies`() {
+        val result = listOf(movie, series).filterUnwatchedPosters(
+            watchedKeys = setOf(watchedItemKey("movie", movie.id)),
+            fullyWatchedSeriesKeys = emptySet(),
+        )
+
+        assertEquals(listOf(series), result)
+    }
+
+    @Test
+    fun `drops fully watched series but keeps partially watched ones`() {
+        val partiallyWatchedSeries = MetaPreview(id = "tmdb:456", type = "series", name = "Other Show")
+
+        val result = listOf(series, partiallyWatchedSeries).filterUnwatchedPosters(
+            watchedKeys = setOf(
+                // A single watched episode of the second show must not hide it.
+                watchedItemKey("series", partiallyWatchedSeries.id, season = 1, episode = 1),
+            ),
+            fullyWatchedSeriesKeys = setOf(watchedItemKey("series", series.id)),
+        )
+
+        assertEquals(listOf(partiallyWatchedSeries), result)
+    }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in setting that hides watched titles from the Discover feed under Search. Watched movies and fully watched series are removed from the feed; partially watched series stay. Typed search results, the home screen, catalog pages and meta screens are unchanged. The setting is off by default.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [x] Approved larger or directional change

## Why

Discover is where users look for something they have not seen, so titles they already finished are the one class of result that cannot help there. The watched badge already marks them, and they still occupy the grid on every page. Search results are deliberately left alone, because looking up a title you already know is a normal reason to search.

## Desktop scope

The change is in `commonMain`, so it affects the desktop app on Windows, macOS and Linux equally, and Android and iOS get the same behaviour. It touches the Discover assembly in `SearchRepository`, the Search screen's refresh trigger, the home catalog settings repository and its sync payload, and the Content & Discovery settings page. Shared code is required here because the Discover feed, the watched state and the settings store are all shared; there is no desktop-specific copy of any of them.

## Issue or approval

Feature request #502, opened alongside this PR. It is not approved yet. I am submitting the implementation with the proposal so the change can be judged as code rather than as a description. If the feature is not wanted, close both and I will drop it; if it is wanted in a different shape, tell me and I will rework it.

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [x] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

Both boxes are checked because they are the only ones that describe a deliberate UI and behavior change, but to be accurate: the linked feature request is not approved yet. See the Issue or approval section.

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

Deliberately not changed:

- Typed search results. They still return watched titles.
- The home screen, catalog pages and meta screens. The flag is read only by the Discover feed.
- The watched model. The filter reuses `WatchingState.isPosterWatched`, the predicate that already decides whether a poster shows the watched badge, so the feed and the badges cannot disagree. Nothing new computes watched state.
- Pagination. The filter drops items from a page but leaves `rawItemCount` and `nextSkip` untouched, so the feed advances through a catalog exactly as it does today. This follows the existing `withUnreleasedFilter` precedent.
- Storage and sync schema. The preference rides in the existing home catalog settings blob and its free-form `settings_json` sync payload. No new storage key, no server change; clients without this build ignore the extra key.
- No refactors, renames or formatting beyond the lines this feature needs.

## Testing

Built and run on Linux (NixOS, KDE Wayland session, X11 Xwayland surface), desktop target, JDK 17.

- `./gradlew :composeApp:desktopJar` — green.
- `./gradlew :composeApp:desktopTest` — 134 suites, 817 tests, 0 failures on this branch. The only tests this PR adds are the three in `DiscoverWatchedFilterTest`, covering nothing watched, a watched movie, and a fully watched series alongside a partially watched one.

Manual flows on the running desktop app:

- Discover with the setting on: watched movies and finished series no longer appear; a series I am part-way through still does.
- Typing a query: search results still return watched titles, including the ones Discover hides.
- Toggling the setting off in Settings → Content & Discovery: Discover refreshes and the watched titles come back. Toggling it on again removes them.
- Home screen: unchanged, watched titles and their badges still show.
- Scrolling Discover well past the first page: paging keeps loading and the grid keeps filling.

## Screenshots / Video

The new setting, in Settings → Content & Discovery:

![Settings, Content & Discovery, Discover section](https://github.com/user-attachments/assets/dd91ba2c-1615-4dfc-bdfa-dc21ff41de38)

Same catalog, same position. With the setting **off**, which is today's behaviour, five posters carry the watched check: Obsession, Project Hail Mary, Backrooms, Masters of the Universe and The Sheep Detectives.

![Discover with the setting off](https://github.com/user-attachments/assets/72fd2de6-af5d-4a2a-8dc2-2569fa254cab)

With the setting **on**, those five are gone and nothing else moves: the order runs The Invite, Don't Say Good Luck, Facing El Chapo, Disclosure Day, Michael, Toy Story 5, Normal, exactly as before minus the watched titles. No poster in the feed carries a watched check. Bleach: Thousand-Year Blood War is still there, which is the intended behaviour for a series I am part-way through.

![Discover with the setting on](https://github.com/user-attachments/assets/f54dee1a-3ede-49ac-9a02-dbd04cc0ac9e)

## Breaking changes

None. The setting defaults to off, so existing installs see no change until they turn it on. The new key is additive in both the local settings blob and the sync payload, and is ignored by clients that do not have it.

## Linked issues

Feature request #502
