### PR TITLE
feat(library): add a Watchlist view for saved titles you have not finished

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -1859,6 +1859,9 @@
     <string name="library_sort_provider_order">Tracker order</string>
     <string name="library_source_cloud">Cloud</string>
     <string name="library_source_saved">Saved</string>
+    <string name="library_source_watchlist">Watchlist</string>
+    <string name="library_watchlist_empty_message">Titles you save stay here until you finish watching them.</string>
+    <string name="library_watchlist_empty_title">Nothing left to watch</string>
     <string name="library_title">Library</string>
     <string name="library_trakt_empty_message">Connect Trakt and save titles to your watchlist or personal lists.</string>
     <string name="library_trakt_empty_title">Your Trakt library is empty</string>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryDisplaySettings.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryDisplaySettings.kt
@@ -1,5 +1,6 @@
 package com.nuvio.app.features.library
 
+import com.nuvio.app.features.watching.application.WatchingState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -25,6 +26,7 @@ enum class LibrarySortOption {
 data class LibraryDisplaySettingsUiState(
     val layoutMode: LibraryLayoutMode = LibraryLayoutMode.HORIZONTAL,
     val sortOption: LibrarySortOption = LibrarySortOption.DEFAULT,
+    val watchlistSelected: Boolean = false,
 )
 
 object LibraryDisplaySettingsRepository {
@@ -58,6 +60,17 @@ object LibraryDisplaySettingsRepository {
         ensureLoaded()
         if (_uiState.value.sortOption == sortOption) return
         _uiState.value = _uiState.value.copy(sortOption = sortOption)
+        persist()
+    }
+
+    /**
+     * Remembers whether the library opens on Saved or on Watchlist. The Cloud
+     * view is deliberately not remembered here: it stays a per-session choice.
+     */
+    fun setWatchlistSelected(selected: Boolean) {
+        ensureLoaded()
+        if (_uiState.value.watchlistSelected == selected) return
+        _uiState.value = _uiState.value.copy(watchlistSelected = selected)
         persist()
     }
 
@@ -142,6 +155,30 @@ internal fun sortLibrarySections(
         section.copy(items = sortLibraryItems(section.items, selected, sourceMode))
     }
 
+/**
+ * Watchlist view: keeps only the saved items that do not carry a watched badge.
+ * Uses the same predicate the poster badges use, so the two can never disagree —
+ * watched movies and fully watched series drop out, partially watched series stay.
+ * Sections left with nothing in them are dropped rather than rendered empty.
+ */
+internal fun filterLibrarySectionsToUnwatched(
+    sections: List<LibrarySection>,
+    watchedKeys: Set<String>,
+    fullyWatchedSeriesKeys: Set<String>,
+): List<LibrarySection> {
+    if (watchedKeys.isEmpty() && fullyWatchedSeriesKeys.isEmpty()) return sections
+    return sections.mapNotNull { section ->
+        val unwatchedItems = section.items.filterNot { item ->
+            WatchingState.isPosterWatched(
+                watchedKeys = watchedKeys,
+                item = item.toMetaPreview(),
+                fullyWatchedSeriesKeys = fullyWatchedSeriesKeys,
+            )
+        }
+        if (unwatchedItems.isEmpty()) null else section.copy(items = unwatchedItems)
+    }
+}
+
 internal fun buildLibraryVerticalProjection(
     sections: List<LibrarySection>,
     sourceMode: LibrarySourceMode,
@@ -201,6 +238,7 @@ internal fun encodeLibraryDisplaySettings(state: LibraryDisplaySettingsUiState):
         StoredLibraryDisplaySettings(
             layoutMode = state.layoutMode.name,
             sortOption = state.sortOption.name,
+            watchlistSelected = state.watchlistSelected,
         ),
     )
 
@@ -219,6 +257,7 @@ internal fun decodeLibraryDisplaySettings(payload: String?): LibraryDisplaySetti
         sortOption = stored?.sortOption
             ?.let { value -> LibrarySortOption.entries.firstOrNull { it.name == value } }
             ?: LibrarySortOption.DEFAULT,
+        watchlistSelected = stored?.watchlistSelected ?: false,
     )
 }
 
@@ -251,4 +290,5 @@ internal val LibrarySourceMode.isRemoteTrackingSource: Boolean
 private data class StoredLibraryDisplaySettings(
     @SerialName("layout_mode") val layoutMode: String = LibraryLayoutMode.HORIZONTAL.name,
     @SerialName("sort_option") val sortOption: String = LibrarySortOption.DEFAULT.name,
+    @SerialName("watchlist_selected") val watchlistSelected: Boolean = false,
 )

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryScreen.kt
@@ -129,7 +129,14 @@ fun LibraryScreen(
     }.collectAsStateWithLifecycle()
     val networkStatusUiState by NetworkStatusRepository.uiState.collectAsStateWithLifecycle()
     var observedOfflineState by remember { mutableStateOf(false) }
-    var sourceModeName by rememberSaveable { mutableStateOf(LibraryViewMode.Saved.name) }
+    var sourceModeName by rememberSaveable {
+        val initialMode = if (displaySettings.watchlistSelected) {
+            LibraryViewMode.Watchlist
+        } else {
+            LibraryViewMode.Saved
+        }
+        mutableStateOf(initialMode.name)
+    }
     val sourceMode = remember(sourceModeName) {
         runCatching { LibraryViewMode.valueOf(sourceModeName) }.getOrDefault(LibraryViewMode.Saved)
     }
@@ -149,22 +156,39 @@ fun LibraryScreen(
         selected = displaySettings.sortOption,
         sourceMode = uiState.sourceMode,
     )
-    val sortedSections = remember(uiState.sections, displaySettings.sortOption, uiState.sourceMode) {
+    val watchlistOnly = sourceMode == LibraryViewMode.Watchlist
+    val visibleSections = remember(
+        uiState.sections,
+        watchlistOnly,
+        watchedUiState.watchedKeys,
+        fullyWatchedSeriesKeys,
+    ) {
+        if (watchlistOnly) {
+            filterLibrarySectionsToUnwatched(
+                sections = uiState.sections,
+                watchedKeys = watchedUiState.watchedKeys,
+                fullyWatchedSeriesKeys = fullyWatchedSeriesKeys,
+            )
+        } else {
+            uiState.sections
+        }
+    }
+    val sortedSections = remember(visibleSections, displaySettings.sortOption, uiState.sourceMode) {
         sortLibrarySections(
-            sections = uiState.sections,
+            sections = visibleSections,
             selected = displaySettings.sortOption,
             sourceMode = uiState.sourceMode,
         )
     }
     val verticalProjection = remember(
-        uiState.sections,
+        visibleSections,
         uiState.sourceMode,
         selectedLibrarySectionKey,
         selectedLibraryType,
         displaySettings.sortOption,
     ) {
         buildLibraryVerticalProjection(
-            sections = uiState.sections,
+            sections = visibleSections,
             sourceMode = uiState.sourceMode,
             selectedSectionKey = selectedLibrarySectionKey,
             selectedType = selectedLibraryType,
@@ -269,7 +293,7 @@ fun LibraryScreen(
                             modifier = Modifier.padding(horizontal = 16.dp),
                             topPadding = topChromePadding,
                             actions = {
-                                if (sourceMode == LibraryViewMode.Saved) {
+                                if (sourceMode != LibraryViewMode.Cloud) {
                                     val targetLayout = if (displaySettings.layoutMode == LibraryLayoutMode.HORIZONTAL) {
                                         LibraryLayoutMode.VERTICAL
                                     } else {
@@ -307,6 +331,11 @@ fun LibraryScreen(
                             selectedMode = sourceMode,
                             onModeSelected = { mode ->
                                 sourceModeName = mode.name
+                                if (mode != LibraryViewMode.Cloud) {
+                                    LibraryDisplaySettingsRepository.setWatchlistSelected(
+                                        mode == LibraryViewMode.Watchlist,
+                                    )
+                                }
                             },
                             modifier = Modifier.padding(horizontal = 16.dp),
                         )
@@ -385,7 +414,7 @@ fun LibraryScreen(
                         }
                     }
 
-                    uiState.sections.isEmpty() -> {
+                    visibleSections.isEmpty() -> {
                         item {
                             if (networkStatusUiState.isOfflineLike && isRemoteSource) {
                                 NuvioNetworkOfflineCard(
@@ -396,15 +425,23 @@ fun LibraryScreen(
                             } else {
                                 HomeEmptyStateCard(
                                     modifier = Modifier.padding(horizontal = 16.dp),
-                                    title = when (uiState.sourceMode) {
-                                        LibrarySourceMode.LOCAL -> stringResource(Res.string.library_empty_title)
-                                        LibrarySourceMode.TRAKT -> stringResource(Res.string.library_trakt_empty_title)
-                                        LibrarySourceMode.SIMKL -> stringResource(Res.string.library_simkl_empty_title)
+                                    title = if (watchlistOnly) {
+                                        stringResource(Res.string.library_watchlist_empty_title)
+                                    } else {
+                                        when (uiState.sourceMode) {
+                                            LibrarySourceMode.LOCAL -> stringResource(Res.string.library_empty_title)
+                                            LibrarySourceMode.TRAKT -> stringResource(Res.string.library_trakt_empty_title)
+                                            LibrarySourceMode.SIMKL -> stringResource(Res.string.library_simkl_empty_title)
+                                        }
                                     },
-                                    message = when (uiState.sourceMode) {
-                                        LibrarySourceMode.LOCAL -> stringResource(Res.string.library_empty_message)
-                                        LibrarySourceMode.TRAKT -> stringResource(Res.string.library_trakt_empty_message)
-                                        LibrarySourceMode.SIMKL -> stringResource(Res.string.library_simkl_empty_message)
+                                    message = if (watchlistOnly) {
+                                        stringResource(Res.string.library_watchlist_empty_message)
+                                    } else {
+                                        when (uiState.sourceMode) {
+                                            LibrarySourceMode.LOCAL -> stringResource(Res.string.library_empty_message)
+                                            LibrarySourceMode.TRAKT -> stringResource(Res.string.library_trakt_empty_message)
+                                            LibrarySourceMode.SIMKL -> stringResource(Res.string.library_simkl_empty_message)
+                                        }
                                     },
                                 )
                             }
@@ -655,6 +692,11 @@ private fun LibrarySourceSwitch(
             label = stringResource(Res.string.library_source_saved),
             selected = selectedMode == LibraryViewMode.Saved,
             onClick = { onModeSelected(LibraryViewMode.Saved) },
+        )
+        LibraryChip(
+            label = stringResource(Res.string.library_source_watchlist),
+            selected = selectedMode == LibraryViewMode.Watchlist,
+            onClick = { onModeSelected(LibraryViewMode.Watchlist) },
         )
         LibraryChip(
             label = stringResource(Res.string.library_source_cloud),
@@ -1180,6 +1222,7 @@ private fun CloudSkeletonBlock(
 
 private enum class LibraryViewMode {
     Saved,
+    Watchlist,
     Cloud,
 }
 

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/library/LibraryWatchlistFilterTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/library/LibraryWatchlistFilterTest.kt
@@ -1,0 +1,88 @@
+package com.nuvio.app.features.library
+
+import com.nuvio.app.features.watched.watchedItemKey
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class LibraryWatchlistFilterTest {
+    private fun item(id: String, type: String, name: String) = LibraryItem(
+        id = id,
+        type = type,
+        name = name,
+        savedAtEpochMs = 0L,
+    )
+
+    private fun section(type: String, vararg items: LibraryItem) = LibrarySection(
+        type = type,
+        displayTitle = type,
+        items = items.toList(),
+    )
+
+    @Test
+    fun `keeps everything when nothing is watched`() {
+        val sections = listOf(
+            section("movie", item("tt1", "movie", "Movie One")),
+            section("series", item("tmdb:1", "series", "Show One")),
+        )
+
+        val result = filterLibrarySectionsToUnwatched(
+            sections = sections,
+            watchedKeys = emptySet(),
+            fullyWatchedSeriesKeys = emptySet(),
+        )
+
+        assertEquals(sections, result)
+    }
+
+    @Test
+    fun `drops watched movies and keeps the rest of the section`() {
+        val watched = item("tt1", "movie", "Watched Movie")
+        val unwatched = item("tt2", "movie", "Unwatched Movie")
+
+        val result = filterLibrarySectionsToUnwatched(
+            sections = listOf(section("movie", watched, unwatched)),
+            watchedKeys = setOf(watchedItemKey("movie", watched.id)),
+            fullyWatchedSeriesKeys = emptySet(),
+        )
+
+        assertEquals(1, result.size)
+        assertEquals(listOf(unwatched), result.single().items)
+    }
+
+    @Test
+    fun `drops fully watched series and keeps partially watched ones`() {
+        val finished = item("tmdb:1", "series", "Finished Show")
+        val inProgress = item("tmdb:2", "series", "In Progress Show")
+
+        val result = filterLibrarySectionsToUnwatched(
+            sections = listOf(section("series", finished, inProgress)),
+            watchedKeys = setOf(
+                // A single watched episode must not hide the show.
+                watchedItemKey("series", inProgress.id, season = 1, episode = 1),
+            ),
+            fullyWatchedSeriesKeys = setOf(watchedItemKey("series", finished.id)),
+        )
+
+        assertEquals(listOf(inProgress), result.single().items)
+    }
+
+    @Test
+    fun `drops sections that end up empty`() {
+        val watched = item("tt1", "movie", "Watched Movie")
+        val unwatchedShow = item("tmdb:1", "series", "Show One")
+
+        val result = filterLibrarySectionsToUnwatched(
+            sections = listOf(
+                section("movie", watched),
+                section("series", unwatchedShow),
+            ),
+            watchedKeys = setOf(watchedItemKey("movie", watched.id)),
+            fullyWatchedSeriesKeys = emptySet(),
+        )
+
+        assertEquals(1, result.size)
+        assertEquals("series", result.single().type)
+        assertTrue(result.none { it.type == "movie" })
+    }
+}


### PR DESCRIPTION
## Summary

Adds a Watchlist view of the saved library: a third pill next to Saved and Cloud that shows the saved titles which do not carry a watched badge. Watched movies and fully watched series drop out, partially watched series stay. Nothing is added to or removed from the library itself — it is a view over what is already saved.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [x] Approved larger or directional change

## Why

A saved library accumulates titles the user has already finished, and there is no way to see only the ones still waiting. The app already knows which is which, because it draws the watched badge, but that knowledge is not usable as a view. The only watchlist-shaped alternative today is connecting a third-party account and switching the library source to it, which is a lot to ask for organising titles Nuvio already tracks itself.

## Desktop scope

The change is in `commonMain`, so it affects the desktop app on Windows, macOS and Linux equally, and Android and iOS get the same behaviour. It touches the Library screen, the library display settings, and the library strings. Shared code is required because the library sections, the watched state and the display settings are all shared; there is no desktop-specific copy of any of them.

## Issue or approval

Feature request #504, opened alongside this PR. It is not approved yet. I am submitting the implementation with the proposal so the change can be judged as code rather than as a description. If the feature is not wanted, close both and I will drop it; if it is wanted in a different shape, tell me and I will rework it.

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [x] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

Both boxes are checked because they are the only ones that describe a deliberate UI and behavior change, but to be accurate: the linked feature request is not approved yet. See the Issue or approval section.

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

Deliberately not changed:

- The library itself. Saving and removing are untouched; the Watchlist is a view over the saved items, not a second list with its own membership.
- The watched model. The filter reuses `WatchingState.isPosterWatched`, the predicate that already decides whether a poster shows the watched badge, so the view and the badges cannot disagree. Nothing new computes watched state.
- The Cloud view. It keeps its current per-session behaviour and is not persisted, so this PR does not change how it behaves today.
- Storage schema. The remembered choice rides in the existing local library display settings file next to the layout mode and sort order. No new storage, no server change, no sync change.
- Sorting and type filtering. Both keep working inside the Watchlist view rather than being replaced by it.
- No refactors, renames or formatting beyond the lines this feature needs.

## Testing

Built and run on Linux (NixOS, KDE Wayland session, X11 Xwayland surface), desktop target, JDK 17.

- `./gradlew :composeApp:desktopJar` — green.
- `./gradlew :composeApp:desktopTest` — 134 suites, 818 tests, 0 failures on this branch. The only tests this PR adds are the four in `LibraryWatchlistFilterTest`, covering nothing watched, a watched movie whose section survives, a fully watched series alongside a partially watched one, and a section that empties out entirely.

Manual flows on the running desktop app:

- Watchlist pill: watched movies and finished series are gone, a series I am part-way through is still listed.
- Both layouts: the same items are filtered in the rows layout and the grid layout, switching between them with the layout toggle.
- Type and sort chips still apply inside the Watchlist view.
- A type whose saved titles are all watched loses its whole section instead of showing an empty header.
- Restarting the app while on Watchlist reopens on Watchlist; restarting while on Cloud reopens on the last of Saved or Watchlist, since Cloud is deliberately not remembered.
- Saved and Cloud behave as they did before.

## Screenshots / Video

The **Saved** pill, today's behaviour. Every poster on these rows carries the watched check, because these are all titles I have already finished:

![Library with the Saved pill selected](https://github.com/user-attachments/assets/004ee9e3-c352-48da-82d5-ef04324121ce)

The **Watchlist** pill on the same library. The finished titles are gone and what is left is what I still have to watch. No poster in this view carries a watched check:

![Library with the Watchlist pill selected](https://github.com/user-attachments/assets/d9629f6e-e783-42e7-9f55-22d99bcee7f7)

## Breaking changes

None. Nothing is removed from the Library, the new view is opt-in by tapping the pill, and the remembered choice defaults to Saved, so an existing install opens exactly as it does today.

## Linked issues

Feature request #504
