### PR TITLE
fix(linux): run appimagetool without FUSE or pre-extracted

### DIFF
--- a/scripts/linux/build-appimage.sh
+++ b/scripts/linux/build-appimage.sh
@@ -104,7 +104,7 @@ if [[ -n "$update_information" ]]; then
     appimagetool_args=("-u" "$update_information" "${appimagetool_args[@]}")
 fi
 
-ARCH=x86_64 "$appimagetool_path" --appimage-extract-and-run "${appimagetool_args[@]}"
+APPIMAGE_EXTRACT_AND_RUN=1 ARCH=x86_64 "$appimagetool_path" "${appimagetool_args[@]}"
 
 if [[ ! -f "$output_appimage" ]]; then
     echo "Expected AppImage output was not produced: $output_appimage" >&2


### PR DESCRIPTION
## Problem

`scripts/linux/build-appimage.sh` invokes appimagetool with the `--appimage-extract-and-run` **CLI flag**. That flag is intercepted by the AppImage runtime and never reaches the binary — but only when the invoked path is an actual (Type 2) AppImage. When `APPIMAGETOOL` points at an already-extracted AppRun (the standard workaround on hosts without `libfuse2`), the flag leaks through to appimagetool's own option parser and the build fails:

```
Option parsing failed: Unknown option --appimage-extract-and-run
```

## Solution

Use the `APPIMAGE_EXTRACT_AND_RUN=1` **environment variable** instead of the CLI flag. The runtime honors it identically, and non-AppImage executables simply ignore it, so both invocation styles work — including on hosts without libfuse2.

## Testing

Built `Nuvio-Linux-x86_64-0.1.21-alpha.AppImage` (157 MB) locally both ways:
- `APPIMAGETOOL` → extracted AppRun (previously failed with the error above) ✅
- `APPIMAGETOOL` → real appimagetool 1.9.1 AppImage on a host without libfuse2 ✅