### PR TITLE
fix(plugins): isolate the QuickJS runtime on a dedicated dispatcher

### DIFF
--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/runtime/js/JsRuntime.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/runtime/js/JsRuntime.kt
@@ -3,10 +3,22 @@ package com.nuvio.app.features.plugins.runtime.js
 import com.dokar.quickjs.QuickJs
 import com.dokar.quickjs.quickJs
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.newFixedThreadPoolContext
+
+// Dedicated, isolated thread pool for the QuickJS plugin runtime. QuickJS calls
+// native fetch *synchronously* (via runBlocking in FetchBridge), which parks the
+// engine thread for the whole request. Running that on Dispatchers.Default lets a
+// fan-out of scrapers occupy every shared scheduler thread, starving
+// Dispatchers.Default — and on desktop that deadlocks the UI, because Compose's
+// stringResource() does a blocking resource load on the EDT (also on Default).
+// Keeping the runtime off the shared dispatchers makes that impossible.
+// Process-lifetime singleton; never closed.
+@OptIn(DelicateCoroutinesApi::class)
+private val pluginJsDispatcher: CoroutineDispatcher = newFixedThreadPoolContext(24, "nuvio-plugin")
 
 internal class JsRuntime(
-    private val dispatcher: CoroutineDispatcher = Dispatchers.Default
+    private val dispatcher: CoroutineDispatcher = pluginJsDispatcher
 ) {
     suspend fun <T> use(block: suspend QuickJs.() -> T): T {
         return quickJs(dispatcher) {


### PR DESCRIPTION
## Problem

The QuickJS plugin runtime runs on `Dispatchers.Default`. QuickJS calls native fetch **synchronously** (`runBlocking` in `FetchBridge`), so the engine thread is *parked* for the duration of each request rather than suspending.

With a fan-out of scrapers, those blocking calls can occupy every thread in the shared `Default` scheduler.

On desktop this escalates from a slowdown into a hard UI deadlock:

1. Plugin fetches saturate `Dispatchers.Default` and block, waiting on the network.
2. Compose's `stringResource()` performs a blocking resource load on the EDT, which also dispatches to `Default`.
3. The UI thread now waits on a pool that is fully occupied by plugin work that is itself waiting on the network.

The app freezes with no error, and recovery requires killing the process.

## Fix

Move the plugin runtime onto its own fixed thread pool so plugin work can never starve the shared dispatchers. The pool is a process-lifetime singleton.

One file, one behavioral change — no API changes. `JsRuntime`'s constructor parameter is unchanged, so callers that inject a dispatcher (tests) are unaffected; only the default changes.

## Scope

This lives in `fullCommonMain`, so Android and iOS get the same isolation. The deadlock is most *visible* on desktop because of the EDT interaction described above, but the underlying starvation is platform-agnostic.

## Notes

This has been running in a downstream Linux fork since 0.1.10-alpha with no regressions observed. That fork is being retired now that official Linux support has shipped, so I'm sending the fix upstream rather than letting it disappear with the repo.

Verified with `./gradlew :composeApp:compileKotlinDesktop` against current `Dev` (785df9c3).

The thread count (24) is a conservative starting point rather than a tuned value — happy to change it, make it adaptive to `availableProcessors()`, or take any other shape you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)