### PR TITLE
fix(linux): size the player overlay in GDK logical pixels

### DIFF
--- a/composeApp/src/desktopMain/native/linux/player_bridge.cpp
+++ b/composeApp/src/desktopMain/native/linux/player_bridge.cpp
@@ -633,13 +633,24 @@ void compositeOverlay(Player *player) {
             // resize so the widget allocation follows on the forced clock tick.
             // No early return: a transiently mis-sized snapshot beats a frozen
             // overlay, and returning here would skip the clock forcing.
-            gdk_window_resize(gw, hostWa.width, hostWa.height);
-            gtk_window_resize(GTK_WINDOW(player->gtkWindow), hostWa.width, hostWa.height);
+            // GDK sizes are logical: it multiplies by the window's scale factor
+            // when it talks to X, while hostWa/ovWa0 above are X device pixels.
+            // Passing device pixels here made the overlay scale-times too large
+            // on a HiDPI output (3072x1782 host -> 6144x3564 overlay at scale 2),
+            // so the mismatch could never settle: every tick resized, took the
+            // overlay down and repushed it a tick later — a continuous
+            // add/remove cycle that reads on screen as flicker.
+            int ovScale = gdk_window_get_scale_factor(gw);
+            if (ovScale < 1) ovScale = 1;
+            const int logicalW = hostWa.width / ovScale;
+            const int logicalH = hostWa.height / ovScale;
+            gdk_window_resize(gw, logicalW, logicalH);
+            gtk_window_resize(GTK_WINDOW(player->gtkWindow), logicalW, logicalH);
             // The X window now resizes, but the WebKit view renders at the GTK
             // widget *allocation* size, and allocations are applied in the same
             // stalled layout phase — the page would stay at the old size
             // indefinitely. Allocate synchronously so the viewport follows now.
-            GtkAllocation alloc = {0, 0, hostWa.width, hostWa.height};
+            GtkAllocation alloc = {0, 0, logicalW, logicalH};
             gtk_widget_size_allocate(player->gtkWindow, &alloc);
             // Take the old-size overlay down while the sizes disagree: painting
             // it 1:1 over a differently-sized window garbles the controls. The
@@ -1120,10 +1131,14 @@ gboolean createWebviewOnGtk(gpointer data) {
     Display *dpy = GDK_WINDOW_XDISPLAY(gdkWin);
     Window gtkXid = GDK_WINDOW_XID(gdkWin);
 
-    // size to the host window
+    // size to the host window (X device pixels -> GDK logical pixels, so the
+    // overlay comes up at the host's size on a HiDPI output instead of
+    // scale-times too large; see the resize in compositeOverlay)
     XWindowAttributes attrs;
     if (XGetWindowAttributes(dpy, s->hostXid, &attrs)) {
-        gtk_window_resize(GTK_WINDOW(win), attrs.width, attrs.height);
+        int initScale = gdk_window_get_scale_factor(gdkWin);
+        if (initScale < 1) initScale = 1;
+        gtk_window_resize(GTK_WINDOW(win), attrs.width / initScale, attrs.height / initScale);
     }
 
     // Reparent THROUGH GDK (not raw XReparentWindow): GDK must know the window is


### PR DESCRIPTION
## Summary

Size the Linux player controls overlay in GDK logical pixels instead of X11 device pixels, so it stops being torn down and repushed on every composite tick on HiDPI displays.

## PR type

- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

On a HiDPI display the player flickers continuously as soon as a stream starts, and the controls are misaligned. Both come from one bug.

`compositeOverlay` sizes the overlay from the AWT host window's X11 geometry, which is in device pixels, but `gdk_window_resize`/`gtk_window_resize` take logical pixels and multiply by the window's scale factor. At scale 2 a 3072x1782 host produced a 6144x3564 overlay. The function compares the two sizes every tick and removes the overlay while they disagree, so the mismatch never settled: each tick resized, removed the overlay, and repushed it on the next snapshot. That add/remove cycle at tick rate is the flicker, and the oversized snapshot is why the controls were misaligned.

The overlay is also the input-topmost window, so an oversized one puts the click/hover hit areas out of alignment with where the controls are drawn — the same misalignment the existing comments in `compositeOverlay` describe. Correcting the size fixes that too.

Instrumented counts over one ~10s playback, same machine and stream:

| | before | after |
| --- | --- | --- |
| `overlay-remove` (size mismatch) | 35 | 0 |
| `overlay-add` | 35 | 2 |

## Desktop scope

Linux desktop only (`composeApp/src/desktopMain/native/linux/player_bridge.cpp`). Windows and macOS bridges are untouched. No shared/common code changed.

## Issue or approval

Fixes #507

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the device-to-logical pixel conversion at the two sites that hand a size to GDK/GTK: the per-tick resize in `compositeOverlay` and the initial sizing in `createWebviewOnGtk`. The XComposite redirect, the snapshot pipeline, the visibility gate, and the teardown path are all unchanged. No logging, no new options, no formatting changes. The separate teardown X error (#464 family) is not addressed here.

## Testing

Manual, on Fedora 44 (kernel 7.1.10), GNOME on Wayland so the app runs under XWayland, 3072x1920 internal display at scale 2, Ryzen 7 6800HS + Radeon 680M + RTX 3050 hybrid, mpv 0.41.0.

Built the bridge against system libmpv/webkit2gtk-4.1/gtk3 and loaded it into the 0.1.21-alpha AppImage via `findLocalBuildLibrary`. Played the same stream before and after, ~10s each, and counted overlay mutations from bridge logging (table above). Before: continuous flicker, controls misaligned. After: stable picture, controls aligned, and the only overlay removal is the normal one when the chrome fades out.

Also confirmed the fix holds with the UI at 2x (`-Dsun.java2d.uiScale=2`): still 0 size-mismatch removals. Playback path was unchanged throughout (`VO: [gpu] vaapi`).

Not verified on a scale-1 display by me, but at scale 1 `gdk_window_get_scale_factor()` returns 1 and both expressions reduce to the previous code, so behaviour there is unchanged by construction.

## Screenshots / Video

Same stream, same episode and timestamp, same fullscreen capture, on a scale-2 display.

**Before** — the controls never render usably. Only fragments of the oversized overlay land on screen in the top-left, appearing and disappearing every tick:

https://github.com/user-attachments/assets/69637c72-24dc-4ddb-a0b0-4d087b851d33

**After** — the controls render at the correct size and position and stay stable, with the usual fade when the chrome hides:

https://github.com/user-attachments/assets/10044c6f-0eac-458f-b0ca-6970f5854c6a

## Breaking changes

None.

## Linked issues

Fixes #507

