### PR TITLE
feat(player): add volume boost up to 200%

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopPlayerVolume.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopPlayerVolume.kt
@@ -1,0 +1,13 @@
+package com.nuvio.app.features.player.desktop
+
+internal const val DESKTOP_PLAYER_MAX_VOLUME_LEVEL = 2f
+
+internal fun Float.coerceDesktopPlayerVolumeLevel(): Float =
+    coerceIn(0f, DESKTOP_PLAYER_MAX_VOLUME_LEVEL)
+
+internal fun resolveDesktopPlayerVolumeLevel(
+    requestedLevel: Float?,
+    currentLevel: Float?,
+    rememberedLevel: Float,
+): Float =
+    (requestedLevel ?: currentLevel ?: rememberedLevel).coerceDesktopPlayerVolumeLevel()

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopPlayerVolumeStorage.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopPlayerVolumeStorage.kt
@@ -21,10 +21,10 @@ internal object DesktopPlayerVolumeStorage {
     }
 
     fun loadVolumeLevel(): Float? =
-        store.getFloat(VolumeLevelKey)?.coerceIn(0f, 1f)
+        store.getFloat(VolumeLevelKey)?.coerceDesktopPlayerVolumeLevel()
 
     fun saveVolumeLevel(level: Float) {
-        pendingVolumeLevel = level.coerceIn(0f, 1f)
+        pendingVolumeLevel = level.coerceDesktopPlayerVolumeLevel()
         persistTimer.restart()
     }
 }

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
@@ -96,6 +96,8 @@ internal class NativePlayerController(
     private var releaseTimedOut: Boolean = false
     private var terminalReleaseFailure: String? = null
     private var controlsState = PlayerControlsState()
+    @Volatile
+    private var currentVolumeLevel = rememberedVolumeLevel.coerceDesktopPlayerVolumeLevel()
     private var pendingSubtitleDelayMs: Int? = null
     private var pendingSubtitleStyle: SubtitleStyleState? = null
     private var pendingUseLibass: Boolean = false
@@ -407,6 +409,7 @@ internal class NativePlayerController(
         return { window.removeWindowFocusListener(listener) }
     }
 
+    @Synchronized
     fun updateControls(state: PlayerControlsState) {
         host.setControlsVisible(state.controlsVisible)
         val currentHandle = handle
@@ -414,11 +417,14 @@ internal class NativePlayerController(
             controlsState = state
             return
         }
-        val stateWithVolume = if (state.volumeLevel == null) {
-            state.copy(volumeLevel = NativePlayerBridge.volume(current).coerceIn(0f, 1f))
-        } else {
-            state
-        }
+        val stateWithVolume = state.copy(
+            volumeLevel = resolveDesktopPlayerVolumeLevel(
+                requestedLevel = state.volumeLevel,
+                currentLevel = currentVolumeLevel,
+                rememberedLevel = rememberedVolumeLevel,
+            ),
+        )
+        currentVolumeLevel = stateWithVolume.volumeLevel ?: currentVolumeLevel
         controlsState = stateWithVolume
         val isFullscreen = isDesktopAppFullscreen(SwingUtilities.getWindowAncestor(host))
         val structureKey = NativeControlsStructureKey(
@@ -509,6 +515,7 @@ internal class NativePlayerController(
         }
     }
 
+    @Synchronized
     private fun updateLocalProgress(positionMs: Long) {
         controlsState = controlsState.copy(positionMs = positionMs)
         updateControls(controlsState)
@@ -534,27 +541,34 @@ internal class NativePlayerController(
             PlayerControlsAction.KeyboardSeekBack -> fallbackSeekBy(-10_000L)
             PlayerControlsAction.SeekForward,
             PlayerControlsAction.KeyboardSeekForward -> fallbackSeekBy(10_000L)
-            PlayerControlsAction.KeyboardVolumeDown -> adjustFallbackVolume(-5f)
-            PlayerControlsAction.KeyboardVolumeUp -> adjustFallbackVolume(5f)
+            PlayerControlsAction.KeyboardVolumeDown -> adjustFallbackVolume(-10f)
+            PlayerControlsAction.KeyboardVolumeUp -> adjustFallbackVolume(10f)
             PlayerControlsAction.Speed -> cycleFallbackSpeed()
             else -> Unit
         }
     }
 
+    @Synchronized
     private fun adjustFallbackVolume(delta: Float) {
         val current = handle
         if (current != 0L) {
-            val currentLevel = controlsState.volumeLevel ?: NativePlayerBridge.volume(current).coerceIn(0f, 1f)
-            val nextLevel = (currentLevel + (delta / 100f)).coerceIn(0f, 1f)
+            val currentLevel = resolveDesktopPlayerVolumeLevel(
+                requestedLevel = null,
+                currentLevel = currentVolumeLevel,
+                rememberedLevel = rememberedVolumeLevel,
+            )
+            val nextLevel = (currentLevel + (delta / 100f)).coerceDesktopPlayerVolumeLevel()
             setFallbackVolume(nextLevel)
         }
     }
 
+    @Synchronized
     private fun setFallbackVolume(level: Float) {
         val current = handle
         if (current != 0L) {
-            val nextLevel = level.coerceIn(0f, 1f)
+            val nextLevel = level.coerceDesktopPlayerVolumeLevel()
             rememberedVolumeLevel = nextLevel
+            currentVolumeLevel = nextLevel
             DesktopPlayerVolumeStorage.saveVolumeLevel(nextLevel)
             NativePlayerBridge.setVolume(current, nextLevel)
             controlsState = controlsState.copy(volumeLevel = nextLevel)
@@ -562,20 +576,24 @@ internal class NativePlayerController(
         }
     }
 
+    @Synchronized
     private fun setTemporaryVolume(level: Float) {
         val current = handle
         if (current != 0L) {
-            val nextLevel = level.coerceIn(0f, 1f)
+            val nextLevel = level.coerceDesktopPlayerVolumeLevel()
+            currentVolumeLevel = nextLevel
             NativePlayerBridge.setVolume(current, nextLevel)
             controlsState = controlsState.copy(volumeLevel = nextLevel)
             updateControls(controlsState)
         }
     }
 
+    @Synchronized
     private fun applyRememberedVolume() {
         val current = handle
         if (current == 0L) return
-        val level = rememberedVolumeLevel.coerceIn(0f, 1f)
+        val level = rememberedVolumeLevel.coerceDesktopPlayerVolumeLevel()
+        currentVolumeLevel = level
         NativePlayerBridge.setVolume(current, level)
         controlsState = controlsState.copy(volumeLevel = level)
         log.d { "applied remembered volume level=$level handle=$current" }

--- a/composeApp/src/desktopMain/native/linux/player_bridge.cpp
+++ b/composeApp/src/desktopMain/native/linux/player_bridge.cpp
@@ -20,6 +20,7 @@
 #include <X11/Xlib.h>
 #include <X11/extensions/Xcomposite.h>
 
+#include <algorithm>
 #include <atomic>
 #include <clocale>
 #include <condition_variable>
@@ -48,6 +49,7 @@ static bool nuvioDebug() {
 namespace {
 
 JavaVM *gVm = nullptr;
+constexpr double kMaxVolumePercent = 200.0;
 
 struct Player {
     mpv_handle *mpv = nullptr;
@@ -854,14 +856,16 @@ gboolean pushPlayerUpdate(gpointer data) {
     }
     double duration = mpvGetDouble(player->mpv, "duration");
     double position = mpvGetDouble(player->mpv, "time-pos");
+    double volumeLevel = mpvGetDouble(player->mpv, "volume") / 100.0;
+    volumeLevel = std::max(0.0, std::min(kMaxVolumePercent / 100.0, volumeLevel));
     bool paused = mpvGetFlag(player->mpv, "pause");
     bool loading = playerLoading(player);
     std::string audioTracks = buildTracksJson(player->mpv, "audio");
     std::string subtitleTracks = buildTracksJson(player->mpv, "sub");
-    char head[192];
+    char head[224];
     snprintf(head, sizeof(head),
-             "window.playerUpdate&&window.playerUpdate({duration:%0.3f,position:%0.3f,paused:%s,loading:%s,audioTracks:",
-             duration, position, paused ? "true" : "false", loading ? "true" : "false");
+             "window.playerUpdate&&window.playerUpdate({duration:%0.3f,position:%0.3f,volumeLevel:%0.3f,paused:%s,loading:%s,audioTracks:",
+             duration, position, volumeLevel, paused ? "true" : "false", loading ? "true" : "false");
     std::string js = std::string(head) + audioTracks +
                      ",subtitleTracks:" + subtitleTracks + "})";
     evalJs(player->webview, js);
@@ -1560,6 +1564,7 @@ JNIEXPORT jlong JNICALL NP(create)(
         mpv_set_option_string(m, "input-cursor", "no");
         mpv_set_option_string(m, "cursor-autohide", "no");
         mpv_set_option_string(m, "keep-open", "yes");
+        mpv_set_option_string(m, "volume-max", "200");
         mpv_set_option_string(m, "idle", "yes");
         mpv_set_option_string(m, "vo", "gpu");
         // Bring the VO/OSD up immediately (before the first decoded frame) so the
@@ -1754,7 +1759,11 @@ JNIEXPORT void JNICALL NP(setSpeed)(JNIEnv *, jobject, jlong handle, jfloat spee
 
 JNIEXPORT void JNICALL NP(setVolume)(JNIEnv *, jobject, jlong handle, jfloat level) {
     Player *p = asPlayer(handle);
-    if (p) mpvSetDouble(p->mpv, "volume", level * 100.0); // Kotlin 0..1 -> mpv 0..100
+    if (!p) return;
+    double next = level * 100.0;
+    if (next < 0) next = 0;
+    if (next > kMaxVolumePercent) next = kMaxVolumePercent;
+    mpvSetDouble(p->mpv, "volume", next);
 }
 
 JNIEXPORT void JNICALL NP(adjustVolume)(JNIEnv *, jobject, jlong handle, jfloat delta) {
@@ -1763,7 +1772,7 @@ JNIEXPORT void JNICALL NP(adjustVolume)(JNIEnv *, jobject, jlong handle, jfloat 
     double current = mpvGetDouble(p->mpv, "volume");
     double next = current + delta * 100.0;
     if (next < 0) next = 0;
-    if (next > 100) next = 100;
+    if (next > kMaxVolumePercent) next = kMaxVolumePercent;
     mpvSetDouble(p->mpv, "volume", next);
 }
 

--- a/composeApp/src/desktopMain/native/macos/player_bridge.mm
+++ b/composeApp/src/desktopMain/native/macos/player_bridge.mm
@@ -42,6 +42,8 @@
 #define NX_KEYTYPE_REWIND 20
 #endif
 
+static constexpr double kMaxVolumePercent = 200.0;
+
 @class PlayerMetalView;
 @class MpvWebPlayer;
 @class NuvioPlayerOpenGLLayer;
@@ -1427,6 +1429,7 @@ static void setMpvOptionString(mpv_handle *mpv, const char *name, const char *va
     setMpvOptionString(_mpv, "input-default-bindings", "yes");
     setMpvOptionString(_mpv, "input-vo-keyboard", "no");
     setMpvOptionString(_mpv, "keep-open", "yes");
+    setMpvOptionString(_mpv, "volume-max", "200");
     setMpvOptionString(_mpv, "vo", "libmpv");
     setMpvOptionString(_mpv, "ao", "avfoundation,coreaudio,");
     setMpvOptionString(_mpv, "audio-channels", "auto");
@@ -1517,6 +1520,7 @@ static void setMpvOptionString(mpv_handle *mpv, const char *name, const char *va
 
             double duration = [self doubleProperty:"duration" fallback:0.0];
             double position = [self doubleProperty:"time-pos" fallback:0.0];
+            double volumeLevel = [self volume];
             double cacheAhead = [self cacheAheadSecondsForPosition:position];
             BOOL paused = [self rawIsPaused];
             BOOL ended = [self rawIsEnded];
@@ -1541,9 +1545,10 @@ static void setMpvOptionString(mpv_handle *mpv, const char *name, const char *va
                 }
                 [self applyHdrForPolledGamma:gamma primaries:primaries reason:@"sync" force:NO];
                 NSString *script = [NSString stringWithFormat:
-                    @"window.playerUpdate({duration:%0.3f,position:%0.3f,paused:%@,loading:%@,audioTracks:%@,subtitleTracks:%@})",
+                    @"window.playerUpdate({duration:%0.3f,position:%0.3f,volumeLevel:%0.3f,paused:%@,loading:%@,audioTracks:%@,subtitleTracks:%@})",
                     duration,
                     position,
+                    volumeLevel,
                     paused ? @"true" : @"false",
                     loading ? @"true" : @"false",
                     audioTracks,
@@ -1843,18 +1848,19 @@ static void setMpvOptionString(mpv_handle *mpv, const char *name, const char *va
 - (void)adjustVolume:(double)delta {
     if (!_mpv) return;
     double current = [self doubleProperty:"volume" fallback:100.0];
-    double next = fmax(0.0, fmin(100.0, current + delta));
+    double next = fmax(0.0, fmin(kMaxVolumePercent, current + delta));
     mpv_set_property(_mpv, "volume", MPV_FORMAT_DOUBLE, &next);
 }
 
 - (void)setVolume:(double)level {
     if (!_mpv) return;
-    double next = fmax(0.0, fmin(100.0, level * 100.0));
+    double next = fmax(0.0, fmin(kMaxVolumePercent, level * 100.0));
     mpv_set_property(_mpv, "volume", MPV_FORMAT_DOUBLE, &next);
 }
 
 - (double)volume {
-    return [self doubleProperty:"volume" fallback:100.0] / 100.0;
+    double level = [self doubleProperty:"volume" fallback:100.0];
+    return fmax(0.0, fmin(kMaxVolumePercent, level)) / 100.0;
 }
 
 - (void)setResizeMode:(int)mode {

--- a/composeApp/src/desktopMain/native/windows/player_bridge.cpp
+++ b/composeApp/src/desktopMain/native/windows/player_bridge.cpp
@@ -66,6 +66,7 @@ constexpr UINT_PTR NUVIO_TIMER_ID = 0x4E50;
 // thread is wedged; shutdown gives up rather than blocking the caller forever.
 constexpr UINT kUiTaskTimeoutMs = 2000;
 constexpr UINT kShutdownJoinTimeoutMs = 3000;
+constexpr double kMaxVolumePercent = 200.0;
 
 const wchar_t *kMessageWindowClass = L"NuvioPlayerBridgeMessageWindow";
 const wchar_t *kContainerWindowClass = L"NuvioPlayerBridgeContainerWindow";
@@ -1034,19 +1035,19 @@ public:
         if (!mpv) return;
         double current = 100.0;
         mpvApi().getProperty(mpv, "volume", MPV_FORMAT_DOUBLE, &current);
-        double next = std::max(0.0, std::min(100.0, current + delta));
+        double next = std::max(0.0, std::min(kMaxVolumePercent, current + delta));
         mpvApi().setProperty(mpv, "volume", MPV_FORMAT_DOUBLE, &next);
     }
 
     void setVolume(double level) {
         std::lock_guard<std::mutex> lock(mpvMutex);
         if (!mpv) return;
-        double next = std::max(0.0, std::min(100.0, level * 100.0));
+        double next = std::max(0.0, std::min(kMaxVolumePercent, level * 100.0));
         mpvApi().setProperty(mpv, "volume", MPV_FORMAT_DOUBLE, &next);
     }
 
     double volume() {
-        return std::max(0.0, std::min(100.0, doubleProperty("volume", 100.0))) / 100.0;
+        return std::max(0.0, std::min(kMaxVolumePercent, doubleProperty("volume", 100.0))) / 100.0;
     }
 
     void setResizeMode(int mode) {
@@ -1600,6 +1601,7 @@ private:
             setMpvOptionStringLocked("input-default-bindings", "yes");
             setMpvOptionStringLocked("input-vo-keyboard", "no");
             setMpvOptionStringLocked("keep-open", "yes");
+            setMpvOptionStringLocked("volume-max", "200");
             setMpvOptionStringLocked("vo", "gpu-next");
             if (nvidiaRtxSuperResolutionEnabled) {
                 setMpvOptionStringLocked("gpu-api", "d3d11");
@@ -1738,6 +1740,7 @@ private:
         if (!webView) return;
         double duration = doubleProperty("duration", 0.0);
         double position = doubleProperty("time-pos", 0.0);
+        double volumeLevel = volume();
         bool paused = isPaused();
         bool loading = isLoading();
         std::string audioTracks = audioTracksJson();
@@ -1746,6 +1749,7 @@ private:
         std::ostringstream script;
         script << "window.playerUpdate({duration:" << duration
                << ",position:" << position
+               << ",volumeLevel:" << volumeLevel
                << ",paused:" << (paused ? "true" : "false")
                << ",loading:" << (loading ? "true" : "false")
                << ",audioTracks:" << audioTracks

--- a/composeApp/src/desktopMain/resources/player-ui/controls.css
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.css
@@ -1389,7 +1389,7 @@ button:disabled {
 }
 
 .volume-control {
-  --volume: 100%;
+  --volume-position: 50%;
   display: flex;
   align-items: center;
   gap: 10px;
@@ -1450,8 +1450,17 @@ button:disabled {
   background:
     linear-gradient(
       to right,
-      var(--theme-accent) 0 var(--volume),
-      rgba(255, 255, 255, .26) var(--volume) 100%
+      transparent 0 50%,
+      rgba(224, 189, 85, 0) 50%,
+      rgba(224, 189, 85, .18) 60%,
+      rgba(224, 189, 85, .46) 70%,
+      rgba(255, 173, 50, .78) 84%,
+      #ff4d4d 100%
+    ),
+    linear-gradient(
+      to right,
+      var(--theme-accent) 0 var(--volume-position),
+      rgba(255, 255, 255, .26) var(--volume-position) 100%
     );
 }
 
@@ -1462,7 +1471,7 @@ button:disabled {
   margin-top: -8px;
   border: 0;
   border-radius: 999px;
-  background: var(--theme-accent);
+  background: #fff;
   box-shadow: none;
 }
 

--- a/composeApp/src/desktopMain/resources/player-ui/controls.html
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.html
@@ -214,7 +214,7 @@
               <button class="volume-button" id="volumeButton" aria-label="Mute" type="button">
                 <svg><use id="volumeIcon" href="#icon-volume"></use></svg>
               </button>
-              <input id="volumeSlider" class="volume-slider" type="range" min="0" max="100" value="100" aria-label="Volume">
+              <input id="volumeSlider" class="volume-slider" type="range" min="0" max="200" value="100" aria-label="Volume">
             </div>
             <div class="time-label" id="timeLabel">00:00 / 00:00</div>
           </div>

--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -400,7 +400,6 @@ let playerToastTimer = 0;
 let playerToastToken = 0;
 let pendingSettingToastCommand = "";
 let pendingSettingToastToken = 0;
-let pendingVolumeToast = false;
 const prefersReducedMotion = window.matchMedia &&
   window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 const modalTransitionMs = prefersReducedMotion ? 1 : 240;
@@ -471,10 +470,16 @@ const settingToastLabel = command => {
   return "";
 };
 
+const maxVolumeLevel = 2;
+const standardMaxVolumeLevel = 1;
+const volumeStepLevel = 0.05;
+
+const clampVolumeLevel = level => Math.max(0, Math.min(maxVolumeLevel, level));
+
 const volumeToastLabel = (fallbackDelta = 0) => {
   const volumeLevel = state.volumeLevel;
   if (typeof volumeLevel === "number" && Number.isFinite(volumeLevel)) {
-    return `Volume ${Math.round(Math.max(0, Math.min(1, volumeLevel)) * 100)}%`;
+    return `Volume ${Math.round(clampVolumeLevel(volumeLevel) * 100)}%`;
   }
   return fallbackDelta < 0 ? "Volume down" : "Volume up";
 };
@@ -483,12 +488,14 @@ const syncVolumeControl = () => {
   if (!volumeControl || !volumeSlider || !volumeIcon) return;
   const volumeLevel = state.volumeLevel;
   const hasLevel = typeof volumeLevel === "number" && Number.isFinite(volumeLevel);
-  const clampedLevel = hasLevel ? Math.max(0, Math.min(1, volumeLevel)) : 1;
+  const clampedLevel = hasLevel ? clampVolumeLevel(volumeLevel) : 1;
   const percent = Math.round(clampedLevel * 100);
+  const sliderPosition = Math.round((clampedLevel / maxVolumeLevel) * 100);
   const label = `Volume ${percent}%`;
-  volumeControl.style.setProperty("--volume", `${percent}%`);
+  volumeControl.style.setProperty("--volume-position", `${sliderPosition}%`);
   volumeSlider.value = String(percent);
   volumeSlider.setAttribute("aria-label", label);
+  volumeSlider.setAttribute("aria-valuetext", percent > 100 ? `${percent}%, boosted` : `${percent}%`);
   volumeSlider.setAttribute("title", label);
   volumeIcon.setAttribute("href", percent === 0 ? "#icon-volume-muted" : "#icon-volume");
   if (volumeButton) {
@@ -496,15 +503,6 @@ const syncVolumeControl = () => {
     volumeButton.setAttribute("aria-label", btnLabel);
     volumeButton.setAttribute("title", btnLabel);
   }
-};
-
-const nextVolumeToastLabel = delta => {
-  const volumeLevel = state.volumeLevel;
-  if (typeof volumeLevel === "number" && Number.isFinite(volumeLevel)) {
-    const nextLevel = Math.max(0, Math.min(1, volumeLevel + (delta * 0.05)));
-    return `Volume ${Math.round(nextLevel * 100)}%`;
-  }
-  return volumeToastLabel(delta);
 };
 
 const seekToastLabel = command => {
@@ -2336,9 +2334,24 @@ const keepChromeVisibleFromKeyboard = () => {
 };
 
 const sendKeyboardVolume = delta => {
-  pendingVolumeToast = true;
-  showPlayerToast(nextVolumeToastLabel(delta));
-  send(delta < 0 ? "keyboardVolumeDown" : "keyboardVolumeUp", 0);
+  const currentLevel = typeof state.volumeLevel === "number" && Number.isFinite(state.volumeLevel)
+    ? state.volumeLevel
+    : 1;
+  if (delta > 0 && currentLevel >= standardMaxVolumeLevel) {
+    showPlayerToast(volumeToastLabel(delta));
+    return;
+  }
+  const adjustedLevel = currentLevel + (delta * volumeStepLevel);
+  const nextLevel = delta > 0
+    ? Math.min(standardMaxVolumeLevel, clampVolumeLevel(adjustedLevel))
+    : clampVolumeLevel(adjustedLevel);
+  state.volumeLevel = nextLevel;
+  if (nextLevel > 0) {
+    preMuteVolumeLevel = nextLevel;
+  }
+  syncVolumeControl();
+  showPlayerToast(volumeToastLabel(delta));
+  send("volumeChange", nextLevel);
 };
 
 const setChromeVisibleFromKeyboard = (visible, { focusAction = false } = {}) => {
@@ -2755,7 +2768,7 @@ seek.addEventListener("change", () => {
 
 volumeSlider.addEventListener("input", () => {
   noteChromeActivity();
-  const percent = Math.max(0, Math.min(100, Number(volumeSlider.value) || 0));
+  const percent = Math.max(0, Math.min(maxVolumeLevel * 100, Number(volumeSlider.value) || 0));
   const nextLevel = percent / 100;
   state.volumeLevel = nextLevel;
   if (nextLevel > 0) {
@@ -2784,6 +2797,10 @@ if (volumeButton) {
 window.playerUpdate = update => {
   const durationMs = Math.round((Number(update.duration) || 0) * 1000);
   const positionMs = Math.round((Number(update.position) || 0) * 1000);
+  const reportedVolumeLevel = Number(update.volumeLevel);
+  const volumeLevel = Number.isFinite(reportedVolumeLevel)
+    ? clampVolumeLevel(reportedVolumeLevel)
+    : state.volumeLevel;
   const audioTracks = normalizeTracks(update.audioTracks);
   const subtitleTracks = normalizeTracks(update.subtitleTracks);
   const audioTracksChanged = trackListSignature(audioTracks) !== trackListSignature(state.audioTracks);
@@ -2801,9 +2818,13 @@ window.playerUpdate = update => {
     positionMs,
     isPlaying: pendingIsPlaying === null ? nativeIsPlaying : pendingIsPlaying,
     isLoading: Boolean(update.loading || update.isLoading),
+    volumeLevel,
     audioTracks,
     subtitleTracks,
   };
+  if (typeof volumeLevel === "number" && volumeLevel > 0) {
+    preMuteVolumeLevel = volumeLevel;
+  }
   if (subtitleTracksChanged && activeModal === "subtitles") {
     const selected = selectedSubtitleOption(subtitleSelectionOptions());
     if (selected) {
@@ -2824,14 +2845,19 @@ window.playerControls = nextState => {
   const previousNotificationToken = Number(state.notificationToken) || 0;
   const previousResizeLabel = state.resizeModeLabel || "";
   const previousSpeedLabel = state.playbackSpeedLabel || "";
-  const previousVolumeLevel = typeof state.volumeLevel === "number" ? state.volumeLevel : NaN;
   const previousEpisodeStreamsVisible = Boolean(state.episodeStreamsVisible);
   const previousSelectedSubtitleLanguageKey = state.selectedSubtitleLanguageKey || "__off__";
   const previousSelectedSubtitleOptionId = state.selectedSubtitleOptionId || "";
   const currentPlaybackState = pendingIsPlaying === null
     ? state.isPlaying
     : pendingIsPlaying;
-  state = { ...state, ...nextState, isPlaying: currentPlaybackState };
+  const currentVolumeLevel = state.volumeLevel;
+  state = {
+    ...state,
+    ...nextState,
+    isPlaying: currentPlaybackState,
+    volumeLevel: currentVolumeLevel ?? nextState.volumeLevel,
+  };
   if (typeof state.volumeLevel === "number" && state.volumeLevel > 0) {
     preMuteVolumeLevel = state.volumeLevel;
   }
@@ -2872,15 +2898,6 @@ window.playerControls = nextState => {
   } else if (pendingSettingToastCommand === "speed" && (state.playbackSpeedLabel || "") !== previousSpeedLabel) {
     pendingSettingToastCommand = "";
     showPlayerToast(settingToastLabel("speed"));
-  }
-  const nextVolumeLevel = typeof state.volumeLevel === "number" ? state.volumeLevel : NaN;
-  if (
-    pendingVolumeToast &&
-    Number.isFinite(nextVolumeLevel) &&
-    (!Number.isFinite(previousVolumeLevel) || Math.abs(nextVolumeLevel - previousVolumeLevel) > 0.001)
-  ) {
-    pendingVolumeToast = false;
-    showPlayerToast(volumeToastLabel());
   }
 };
 

--- a/composeApp/src/desktopTest/kotlin/com/nuvio/app/features/player/desktop/DesktopPlayerVolumeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/nuvio/app/features/player/desktop/DesktopPlayerVolumeTest.kt
@@ -1,0 +1,54 @@
+package com.nuvio.app.features.player.desktop
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DesktopPlayerVolumeTest {
+    @Test
+    fun `volume level supports boost through two hundred percent`() {
+        assertEquals(0f, (-0.1f).coerceDesktopPlayerVolumeLevel())
+        assertEquals(1f, 1f.coerceDesktopPlayerVolumeLevel())
+        assertEquals(1.5f, 1.5f.coerceDesktopPlayerVolumeLevel())
+        assertEquals(2f, 2.1f.coerceDesktopPlayerVolumeLevel())
+    }
+
+    @Test
+    fun `control refresh preserves current boosted or muted level`() {
+        assertEquals(
+            1.75f,
+            resolveDesktopPlayerVolumeLevel(
+                requestedLevel = null,
+                currentLevel = 1.75f,
+                rememberedLevel = 1f,
+            ),
+        )
+        assertEquals(
+            0f,
+            resolveDesktopPlayerVolumeLevel(
+                requestedLevel = null,
+                currentLevel = 0f,
+                rememberedLevel = 1.75f,
+            ),
+        )
+    }
+
+    @Test
+    fun `requested level wins and remembered level is the final fallback`() {
+        assertEquals(
+            1.25f,
+            resolveDesktopPlayerVolumeLevel(
+                requestedLevel = 1.25f,
+                currentLevel = 1.75f,
+                rememberedLevel = 1f,
+            ),
+        )
+        assertEquals(
+            1.5f,
+            resolveDesktopPlayerVolumeLevel(
+                requestedLevel = null,
+                currentLevel = null,
+                rememberedLevel = 1.5f,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Implements [#524: Audio volume control that allows boosting over 100%](https://github.com/NuvioMedia/NuvioDesktop/issues/524).

- Raises the embedded desktop player’s maximum volume from 100% to 200%.
- Adds a warning gradient across the boosted range while keeping the slider thumb white and readable.
- Keeps mouse-wheel and keyboard adjustments in 5% steps and caps upward adjustment at 100%, preventing an accidental scroll or key press from suddenly entering the amplified range.
- Requires deliberate clicking or dragging to enable volume above 100%.
- Allows wheel-down adjustment when already above 100%.
- Preserves boosted volume between streams and restores it after mute/unmute.
- Synchronizes the slider with MPV’s actual volume to prevent it from snapping back to 100%.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Some media has a low source volume even when the player is set to 100%. The existing limit prevents the embedded player from compensating for especially quiet sources. This change provides an optional software-amplified range up to 200% for those cases.

Mouse-wheel and keyboard increases remain capped at 100% so ordinary input cannot accidentally cause a sudden amplified-volume jump. Entering the boosted range requires deliberate clicking or dragging on the slider. Once boosted, mouse-wheel input can still lower the volume normally.

The yellow-to-red gradient visually distinguishes software amplification from the standard volume range.

## Desktop scope

This is limited to the embedded Nuvio desktop player.

The desktop controls and native MPV bridges for Windows, macOS, and Linux support the expanded range. The implementation does not change Mobile, TV, or external-player volume controls.

## Issue or approval

Implements [#524](https://github.com/NuvioMedia/NuvioDesktop/issues/524).

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Does not change external-player volume controls.
- Does not add audio normalization, compression, equalization, or automatic gain.
- Does not change Mobile or TV behavior.
- Does not add dependencies or introduce architectural changes.
- Software amplification may clip when the source audio has insufficient headroom.

## Testing

Tested locally on Windows 11:

- Verified that clicking and dragging the slider adjusts volume throughout the 0–200% range.
- Verified that mouse-wheel and keyboard changes use 5% steps and stop increasing at 100%.
- Verified that mouse-wheel input can reduce volume when already above 100%.
- Verified that mute/unmute restores the previous boosted level.
- Verified that the displayed slider remains synchronized with the audible native-player volume.
- Verified that the selected volume remains consistent between streams.
- Verified that the existing controls and playback behavior continue to function normally.
- Ran `.\gradlew.bat :composeApp:desktopTest`.
- Ran `.\gradlew.bat :composeApp:desktopJar`.
- Rebuilt the Windows native player bridge successfully.

macOS and Linux native bridge changes were not runtime-tested locally.

## Screenshots / Video

### Before

<img width="245" height="75" alt="Player volume control limited to 100%" src="https://github.com/user-attachments/assets/b6c78926-f8cc-4156-87ae-8c931bdfbe45" />

### After

<img width="232" height="76" alt="Player volume control with warning gradient up to 200%" src="https://github.com/user-attachments/assets/52851b0f-c50e-454a-86b8-be534e958396" />

## Breaking changes

None.

## Linked issues

Closes #524