### PR TITLE
fix(desktop): remove per-request timeout and clean up partial downloads in updater

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/updater/AppUpdaterPlatform.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/updater/AppUpdaterPlatform.desktop.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import nuvio.composeapp.generated.resources.Res
+import nuvio.composeapp.generated.resources.updates_download_failed
 import nuvio.composeapp.generated.resources.updates_download_failed_http
 import nuvio.composeapp.generated.resources.updates_downloaded_file_missing
 import nuvio.composeapp.generated.resources.updates_empty_download_body
@@ -70,7 +71,6 @@ actual object AppUpdaterPlatform {
 
             val request = HttpRequest.newBuilder()
                 .uri(URI(assetUrl))
-                .timeout(Duration.ofSeconds(60))
                 .GET()
                 .build()
             val response = desktopUpdaterHttpClient.send(request, HttpResponse.BodyHandlers.ofInputStream())
@@ -82,25 +82,34 @@ actual object AppUpdaterPlatform {
                 ?.toLongOrNull()
                 ?.takeIf { it > 0L }
             var downloadedBytes = 0L
-            response.body()?.use { input ->
-                FileOutputStream(tempFile).use { output ->
-                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
-                    while (true) {
-                        val read = input.read(buffer)
-                        if (read <= 0) break
-                        output.write(buffer, 0, read)
-                        downloadedBytes += read.toLong()
-                        onProgress(downloadedBytes, totalBytes)
+            try {
+                response.body()?.use { input ->
+                    FileOutputStream(tempFile).use { output ->
+                        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                        while (true) {
+                            val read = input.read(buffer)
+                            if (read <= 0) break
+                            output.write(buffer, 0, read)
+                            downloadedBytes += read.toLong()
+                            onProgress(downloadedBytes, totalBytes)
+                        }
+                        output.flush()
                     }
-                    output.flush()
-                }
-            } ?: error(runBlocking { getString(Res.string.updates_empty_download_body) })
+                } ?: error(runBlocking { getString(Res.string.updates_empty_download_body) })
 
-            if (!tempFile.renameTo(destination)) {
-                tempFile.copyTo(destination, overwrite = true)
-                tempFile.delete()
+                if (totalBytes != null && downloadedBytes != totalBytes) {
+                    error(runBlocking { getString(Res.string.updates_download_failed) })
+                }
+
+                if (!tempFile.renameTo(destination)) {
+                    tempFile.copyTo(destination, overwrite = true)
+                    tempFile.delete()
+                }
+                destination.absolutePath
+            } catch (t: Throwable) {
+                if (tempFile.exists()) tempFile.delete()
+                throw t
             }
-            destination.absolutePath
         }
     }
 


### PR DESCRIPTION
## Summary

The desktop in-app updater could fail to download the ~200 MB installer on connections slower than ~30 Mbps because a 60-second per-request timeout was set on the `HttpRequest`. This PR removes that timeout and adds cleanup of leftover `.part` files on failure, plus a `Content-Length` integrity check to detect truncated downloads early.

## PR type

- [x] Reproducible bug fix

## Why

`HttpRequest.newBuilder().timeout(Duration.ofSeconds(60))` aborts the entire download if it is not completed within 60 seconds. A 200 MB file at 25 Mbps takes ~64 seconds, causing the download to fail for users on average connections. The connect-level timeout on `HttpClient` (also 60 s) is correct and is left in place; only the per-request timeout is removed.

Two additional defensive fixes are included because they are caused by the same code path:
1. Without a `try/catch` around the stream loop, any mid-download I/O error leaves a `.part` file on disk.
2. Without a `Content-Length` check, a network drop that closes the stream early produces a silently truncated installer passed to `msiexec`, resulting in a confusing Windows error rather than a clear in-app message.

## Desktop scope

Windows, macOS, Linux — the changed file is `AppUpdaterPlatform.desktop.kt` which is the shared desktop updater implementation. The timeout removal benefits all three platforms. The `.part` cleanup and integrity check also apply to all platforms.

## Issue or approval

Fixes #540

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood \CONTRIBUTING.md\.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- No UI changes of any kind.
- No changes to update check logic, version comparison, asset selection, or install flow.
- The connect-level timeout on `HttpClient` (`connectTimeout(Duration.ofSeconds(60))`) is intentionally left unchanged — it guards only the initial TCP handshake, which is correct.
- No refactoring, renaming, or formatting changes beyond the minimal lines required for the fix.

## Testing

- Built a local distributable (`./gradlew :composeApp:createDistributable`) with the version temporarily set to `0.1.20-alpha` to trigger the update check against the live `0.1.21-alpha` GitHub release.
- Ran `Nuvio.exe` on Windows 11 x64, triggered Check for updates from Settings → About.
- Confirmed the update dialog appeared, download started, and completed successfully without timeout.
- Confirmed that interrupting the download left no `.part` file in the updates directory.
- Kotlin compilation verified with `./gradlew :composeApp:compileKotlinDesktop` — zero errors.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #540