### PR TITLE
fix(desktop): unify initial launch overlay and eliminate startup lag

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/AppGate.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/AppGate.kt
@@ -459,20 +459,25 @@ internal fun AppGate(
             targetState = gateScreen,
             label = "app_gate",
             transitionSpec = {
-                (fadeIn(tween(400)) + scaleIn(tween(400), initialScale = 0.94f))
-                    .togetherWith(fadeOut(tween(250)))
+                if (
+                    (initialState == AppGateScreen.Loading.name && targetState == AppGateScreen.Main.name) ||
+                    (initialState == AppGateScreen.Main.name && targetState == AppGateScreen.Loading.name)
+                ) {
+                    androidx.compose.animation.EnterTransition.None togetherWith androidx.compose.animation.ExitTransition.None
+                } else {
+                    (fadeIn(tween(400)) + scaleIn(tween(400), initialScale = 0.94f))
+                        .togetherWith(fadeOut(tween(250)))
+                }
             },
         ) { currentGate ->
             when (currentGate) {
                 AppGateScreen.Loading.name -> {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(MaterialTheme.nuvio.colors.background),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        NuvioLoadingIndicator(color = MaterialTheme.nuvio.colors.accent)
-                    }
+                    AppLaunchOverlay(
+                        profile = switchingProfile
+                            ?: profileState.activeProfile
+                            ?: profileState.profiles.firstOrNull(),
+                        modifier = Modifier.fillMaxSize(),
+                    )
                 }
                 AppGateScreen.Auth.name -> {
                     AuthScreen(modifier = Modifier.fillMaxSize())

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/AppGate.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/AppGate.kt
@@ -182,7 +182,29 @@ internal fun AppGate(
         )
     }
 
-    var gateScreen by rememberSaveable { mutableStateOf(AppGateScreen.Loading.name) }
+    val initialGateScreen = remember {
+        val currentProfiles = ProfileRepository.state.value.profiles
+        val currentProfileState = ProfileRepository.state.value
+        val remembered = if (
+            currentProfileState.rememberLastProfileEnabled &&
+            currentProfileState.hasEverSelectedProfile
+        ) {
+            currentProfiles.find { it.profileIndex == ProfileRepository.activeProfileId }?.takeUnless { it.pinEnabled }
+        } else if (currentProfiles.size == 1 && !currentProfiles.first().pinEnabled) {
+            currentProfiles.first()
+        } else {
+            null
+        }
+
+        if (remembered != null) {
+            AppGateScreen.Main.name
+        } else if (currentProfiles.isNotEmpty()) {
+            AppGateScreen.ProfileSelection.name
+        } else {
+            AppGateScreen.Loading.name
+        }
+    }
+    var gateScreen by rememberSaveable { mutableStateOf(initialGateScreen) }
     var editingProfile by remember { mutableStateOf<NuvioProfile?>(null) }
     var autoSkipProfileSelection by rememberSaveable { mutableStateOf(false) }
     var profileSelectionLoading by rememberSaveable { mutableStateOf(false) }
@@ -210,7 +232,9 @@ internal fun AppGate(
         }
         switchingProfile = profile
         try {
-            ProfileRepository.switchToProfile(profile.profileIndex)
+            if (ProfileRepository.activeProfileId != profile.profileIndex) {
+                ProfileRepository.switchToProfile(profile.profileIndex)
+            }
             warmProfileBoundRepositories()
             if (sync) {
                 SyncManager.pullAllForProfile(profile.profileIndex)
@@ -316,7 +340,11 @@ internal fun AppGate(
         }
 
         rememberedStartupProfile(profiles)?.let { profile ->
-            selectProfile(profile, sync = syncOnEnter)
+            if (ProfileRepository.activeProfileId != profile.profileIndex) {
+                selectProfile(profile, sync = syncOnEnter)
+            } else if (syncOnEnter) {
+                SyncManager.pullAllForProfile(profile.profileIndex)
+            }
             gateScreen = AppGateScreen.Main.name
             autoSkipProfileSelection = false
             return
@@ -329,7 +357,11 @@ internal fun AppGate(
                 gateScreen = AppGateScreen.ProfileSelection.name
                 return
             }
-            selectProfile(onlyProfile, sync = syncOnEnter)
+            if (ProfileRepository.activeProfileId != onlyProfile.profileIndex) {
+                selectProfile(onlyProfile, sync = syncOnEnter)
+            } else if (syncOnEnter) {
+                SyncManager.pullAllForProfile(onlyProfile.profileIndex)
+            }
             gateScreen = AppGateScreen.Main.name
             autoSkipProfileSelection = false
         } else {
@@ -381,6 +413,9 @@ internal fun AppGate(
         val authenticatedState = authState as? AuthState.Authenticated ?: return@LaunchedEffect
         ProfileRepository.ensureLoaded(authenticatedState.userId)
         ProfileRepository.pullProfiles()
+        ProfileRepository.state.value.activeProfile?.let { active ->
+            SyncManager.pullAllForProfile(active.profileIndex)
+        }
     }
 
     LaunchedEffect(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/MainAppContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/MainAppContent.kt
@@ -482,7 +482,7 @@ internal fun MainAppContent(
         if (!ownsAppRuntime) return@LaunchedEffect
         NetworkStatusRepository.ensureStarted()
         EpisodeReleaseNotificationsRepository.refreshAsync()
-        kotlinx.coroutines.delay(5_000)
+        kotlinx.coroutines.delay(2_000)
         initialHomeReady = true
     }
 
@@ -490,6 +490,9 @@ internal fun MainAppContent(
         if (!ownsAppRuntime) return@LaunchedEffect
         val condition = networkStatusUiState.condition
         if (!networkToastBaselineReady) {
+            if (condition == NetworkCondition.Checking || condition == NetworkCondition.Unknown) {
+                return@LaunchedEffect
+            }
             networkToastBaselineReady = true
             lastNetworkToastCondition = condition.name
             return@LaunchedEffect

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/network/NetworkStatusRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/network/NetworkStatusRepository.kt
@@ -75,7 +75,7 @@ object NetworkStatusRepository {
     fun ensureStarted() {
         if (started) return
         started = true
-        requestRefresh(force = true)
+        requestRefresh(force = true, confirmFailures = true)
     }
 
     fun requestForegroundRefresh() {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeScreen.kt
@@ -784,16 +784,25 @@ fun HomeScreen(
     val showHeroSkeleton = showHeroSlot &&
         homeUiState.heroItems.isEmpty() &&
         isResolvingHeroSources
-    var firstCatalogReported by remember { mutableStateOf(false) }
-
-    LaunchedEffect(homeUiState.sections.firstOrNull()?.key, onFirstCatalogRendered) {
-        if (firstCatalogReported || homeUiState.sections.isEmpty()) return@LaunchedEffect
-        firstCatalogReported = true
-        onFirstCatalogRendered?.invoke()
-    }
-
     val visibleCollections = remember(collections) {
         collections.filter { it.folders.isNotEmpty() }
+    }
+    var firstCatalogReported by remember { mutableStateOf(false) }
+
+    LaunchedEffect(
+        homeUiState.sections.firstOrNull()?.key,
+        homeUiState.heroItems.firstOrNull()?.id,
+        visibleCollections.isNotEmpty(),
+        onFirstCatalogRendered,
+    ) {
+        if (firstCatalogReported) return@LaunchedEffect
+        val hasAnyVisibleContent = homeUiState.sections.isNotEmpty() ||
+            homeUiState.heroItems.isNotEmpty() ||
+            visibleCollections.isNotEmpty()
+        if (hasAnyVisibleContent) {
+            firstCatalogReported = true
+            onFirstCatalogRendered?.invoke()
+        }
     }
     val collectionsMap = remember(visibleCollections) {
         visibleCollections.associateBy { "collection_${it.id}" }

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
 import androidx.compose.ui.unit.dp
+import com.nuvio.app.core.auth.AuthRepository
 import com.nuvio.app.core.deeplink.handleAppUrl
 import com.nuvio.app.core.diagnostics.SentryInitializer
 import com.nuvio.app.core.ui.NuvioTheme
@@ -57,8 +58,9 @@ fun main(args: Array<String>) {
     installDesktopOpenUriHandler()
     handleDesktopLaunchArgs(args)
     preloadNativePlayerBridgeAsync()
-    // Load cached profile data synchronously so the profile color is available
+    // Load cached profile and auth data synchronously so the profile color is available
     // on the very first Compose frame (matching Android's SharedPreferences behavior).
+    AuthRepository.initialize()
     ProfileRepository.loadCachedProfiles()
     AppIconRepository.ensureLoaded()
     DiscordPresenceManager.start()


### PR DESCRIPTION
## Summary

On Desktop startup, the application previously rendered a raw black loading screen without profile backdrop or branding, and then suffered a 2–3 second sequential lag before switching to the main content tree. Additionally, the launch overlay could prematurely dismiss before content was painted or falsely report that servers were unreachable on cold startup.

This PR unifies the desktop launch overlay with the profile backdrop from frame 1, mounts \MainAppContent\ immediately when a remembered profile exists, skips redundant profile-switching cache clears on boot, holds the launch overlay until visible content is rendered, and prevents transient cold-start network toasts.

## PR type

- [x] UI glitch/bug fix
- [x] Behavior bug/regression fix

## Why

1. **Initial Black Screen**: \AppGateScreen.Loading\ rendered a bare dark Box with a loader spinner lacking \ProfileBackgroundBackdrop\ and \AppBrandWordmark\, creating a visually jarring black flash before transitioning to the app's real theme.
2. **2–3s Startup Gate Lag**: \AppGate\ was hardcoded to \AppGateScreen.Loading\ on frame 1, running sequential repository warming and calling \switchToProfile()\ which cleared \HomeRepository\ in memory. \MainAppContent\ was not mounted until after this delay.
3. **Premature Loader Dismissal & Cold Network Toast**: \HomeScreen\ was evaluating \!homeUiState.isLoading\ on frame 0 (before loading began) to dismiss the overlay, and \MainAppContent\ was setting the toast baseline during \NetworkCondition.Checking\, resulting in a false 'Cannot reach servers' toast on cold socket initialization.

## Desktop scope

Windows, macOS, Linux — affected code is in \composeApp/src/desktopMain\ (\Main.kt\) and shared common components in \composeApp/src/commonMain\ (\AppGate.kt\, \MainAppContent.kt\, \HomeScreen.kt\, \NetworkStatusRepository.kt\) that control desktop startup orchestration and launch overlay presentation.

## Issue or approval

No linked issue: Desktop startup UI glitch and boot lag fix.

## UI / behavior impact

- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood \CONTRIBUTING.md\.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- No changes to authentication provider logic, streaming engines, player integrations, or database schemas.
- Profile switching when initiated explicitly by the user continues to perform full repository transitions.
- Background sync operations via \SyncManager\ continue to run as designed without alterations to API sync semantics.

## Testing

- Built and ran locally on Windows 11 x64 via \.\gradlew.bat compileKotlinDesktop\ and \.\gradlew.bat :composeApp:createDistributable\.
- Verified single unified loader from frame 1 with the user's profile color backdrop and logo.
- Verified that startup lag is eliminated and \MainAppContent\ mounts immediately.
- Verified that the loader smoothly transitions out once the hero backdrop or catalog sections are rendered.
- Verified that cold application startup does not produce a 'Cannot reach servers' toast.

## Screenshots / Video

### Before

https://github.com/user-attachments/assets/544a4391-1448-4c8c-93c3-86b753865c29


### After

https://github.com/user-attachments/assets/98bceed7-17f8-4890-957f-59a62014d7d7


## Breaking changes

None.

## Linked issues

No linked issue - startup UI glitch and boot lag fix.