### PR TITLE
fix(details): adapt scrollbar contrast to backdrop

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/core/ui/DesktopScrollbar.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/core/ui/DesktopScrollbar.android.kt
@@ -5,21 +5,25 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 
 @Composable
 internal actual fun NuvioDesktopVerticalScrollbar(
     state: LazyListState,
     modifier: Modifier,
+    backgroundColor: Color?,
 ) = Unit
 
 @Composable
 internal actual fun NuvioDesktopVerticalScrollbar(
     state: LazyGridState,
     modifier: Modifier,
+    backgroundColor: Color?,
 ) = Unit
 
 @Composable
 internal actual fun NuvioDesktopVerticalScrollbar(
     state: ScrollState,
     modifier: Modifier,
+    backgroundColor: Color?,
 ) = Unit

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/DesktopScrollbar.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/DesktopScrollbar.kt
@@ -5,21 +5,25 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 
 @Composable
 internal expect fun NuvioDesktopVerticalScrollbar(
     state: LazyListState,
     modifier: Modifier = Modifier,
+    backgroundColor: Color? = null,
 )
 
 @Composable
 internal expect fun NuvioDesktopVerticalScrollbar(
     state: LazyGridState,
     modifier: Modifier = Modifier,
+    backgroundColor: Color? = null,
 )
 
 @Composable
 internal expect fun NuvioDesktopVerticalScrollbar(
     state: ScrollState,
     modifier: Modifier = Modifier,
+    backgroundColor: Color? = null,
 )

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsScreen.kt
@@ -983,6 +983,10 @@ fun MetaDetailsScreen(
                     val dominantColorEnabled = backgroundMode == MetaScreenBackgroundMode.DominantColor &&
                         deferredMetaWorkAllowed &&
                         !backdropUrl.isNullOrBlank()
+                    val adaptiveScrollbarColorEnabled = useDesktopDetailLayout &&
+                        deferredMetaWorkAllowed &&
+                        !backdropUrl.isNullOrBlank()
+                    val backdropColorExtractionEnabled = dominantColorEnabled || adaptiveScrollbarColorEnabled
                     var dominantBackdropPainter by remember(meta.id, backdropUrl) {
                         mutableStateOf<Painter?>(null)
                     }
@@ -997,10 +1001,10 @@ fun MetaDetailsScreen(
                         defaultColor = colorScheme.background,
                         defaultOnColor = colorScheme.onBackground,
                     )
-                    LaunchedEffect(dominantColorEnabled, dominantBackdropImageBitmap, dominantBackdropPainter) {
+                    LaunchedEffect(backdropColorExtractionEnabled, dominantBackdropImageBitmap, dominantBackdropPainter) {
                         val imageBitmap = dominantBackdropImageBitmap
                         val painter = dominantBackdropPainter
-                        if (dominantColorEnabled) {
+                        if (backdropColorExtractionEnabled) {
                             when {
                                 imageBitmap != null -> runCatching {
                                     dominantImageBitmapColorState.updateFrom(imageBitmap)
@@ -1372,6 +1376,7 @@ fun MetaDetailsScreen(
                         }
                         NuvioDesktopVerticalScrollbar(
                             state = listState,
+                            backgroundColor = extractedDominantColor.takeIf { adaptiveScrollbarColorEnabled },
                             modifier = Modifier
                                 .align(Alignment.CenterEnd)
                                 .fillMaxHeight()

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/core/ui/DesktopScrollbar.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/core/ui/DesktopScrollbar.desktop.kt
@@ -10,17 +10,20 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.unit.dp
 
 @Composable
 internal actual fun NuvioDesktopVerticalScrollbar(
     state: LazyListState,
     modifier: Modifier,
+    backgroundColor: Color?,
 ) {
     VerticalScrollbar(
         adapter = rememberScrollbarAdapter(state),
         modifier = modifier,
-        style = nuvioDesktopScrollbarStyle(),
+        style = nuvioDesktopScrollbarStyle(backgroundColor),
     )
 }
 
@@ -28,11 +31,12 @@ internal actual fun NuvioDesktopVerticalScrollbar(
 internal actual fun NuvioDesktopVerticalScrollbar(
     state: LazyGridState,
     modifier: Modifier,
+    backgroundColor: Color?,
 ) {
     VerticalScrollbar(
         adapter = rememberScrollbarAdapter(state),
         modifier = modifier,
-        style = nuvioDesktopScrollbarStyle(),
+        style = nuvioDesktopScrollbarStyle(backgroundColor),
     )
 }
 
@@ -40,23 +44,31 @@ internal actual fun NuvioDesktopVerticalScrollbar(
 internal actual fun NuvioDesktopVerticalScrollbar(
     state: ScrollState,
     modifier: Modifier,
+    backgroundColor: Color?,
 ) {
     VerticalScrollbar(
         adapter = rememberScrollbarAdapter(state),
         modifier = modifier,
-        style = nuvioDesktopScrollbarStyle(),
+        style = nuvioDesktopScrollbarStyle(backgroundColor),
     )
 }
 
 @Composable
-private fun nuvioDesktopScrollbarStyle(): ScrollbarStyle {
+private fun nuvioDesktopScrollbarStyle(backgroundColor: Color?): ScrollbarStyle {
     val colorScheme = MaterialTheme.colorScheme
+    val adaptiveThumbColor = backgroundColor?.let { color ->
+        if (color.luminance() > EqualBlackWhiteContrastLuminance) Color.Black else Color.White
+    }
     return ScrollbarStyle(
         minimalHeight = 48.dp,
         thickness = 6.dp,
         shape = RoundedCornerShape(100),
         hoverDurationMillis = 180,
-        unhoverColor = colorScheme.onSurfaceVariant.copy(alpha = 0.34f),
-        hoverColor = colorScheme.primary.copy(alpha = 0.78f),
+        unhoverColor = adaptiveThumbColor?.copy(alpha = 0.72f)
+            ?: colorScheme.onSurfaceVariant.copy(alpha = 0.34f),
+        hoverColor = adaptiveThumbColor?.copy(alpha = 0.94f)
+            ?: colorScheme.primary.copy(alpha = 0.78f),
     )
 }
+
+private const val EqualBlackWhiteContrastLuminance = 0.179f

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/core/ui/DesktopScrollbar.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/core/ui/DesktopScrollbar.ios.kt
@@ -5,21 +5,25 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 
 @Composable
 internal actual fun NuvioDesktopVerticalScrollbar(
     state: LazyListState,
     modifier: Modifier,
+    backgroundColor: Color?,
 ) = Unit
 
 @Composable
 internal actual fun NuvioDesktopVerticalScrollbar(
     state: LazyGridState,
     modifier: Modifier,
+    backgroundColor: Color?,
 ) = Unit
 
 @Composable
 internal actual fun NuvioDesktopVerticalScrollbar(
     state: ScrollState,
     modifier: Modifier,
+    backgroundColor: Color?,
 ) = Unit


### PR DESCRIPTION
## Summary

Fixes #548.

- Makes the Desktop metadata-details scrollbar adapt to the loaded backdrop’s dominant brightness.
- Uses a dark neutral thumb over bright artwork and a light neutral thumb over dark artwork.
- Strengthens the adaptive thumb on hover while preserving its existing size and interaction.
- Retains the original restrained scrollbar colors and opacity on Home, Catalog, Settings, and other ordinary surfaces.
- Addresses the contrast regression exposed by the metadata UI overhaul in #544.

## PR type

- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Before this fix, the details scrollbar always retained the same light theme color instead of adapting to the backdrop. On series and movie pages with bright artwork, the light thumb remained light and blended into the background, making it difficult to locate and drag.

Increasing the shared scrollbar opacity globally also made it unnecessarily prominent on ordinary dark screens. The fix therefore applies adaptive contrast only to artwork-backed metadata details while preserving the existing scrollbar appearance elsewhere.

## Desktop scope

This change affects the shared Desktop metadata-details UI on Windows, macOS, and Linux.

The shared scrollbar declaration accepts an optional backdrop color because `MetaDetailsScreen` is common code, but only the Desktop implementation renders and uses it. Android and iOS implementations remain no-ops, so Mobile and TV behavior is unchanged.

## Issue or approval

Fixes #548.

Related regression source: #544.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Does not change scrollbar thickness, minimum thumb height, position, hover duration, scrolling, or dragging behavior.
- Does not globally increase scrollbar opacity on ordinary app surfaces.
- Does not change horizontal episode rows or player controls.
- Does not change Mobile or TV behavior.
- Does not alter the metadata layout introduced in #544.
- Adds no dependencies or unrelated UI changes.

## Testing

Tested locally on Windows 11:

- Reproduced the light scrollbar blending into a bright metadata backdrop before the fix.
- Verified that bright artwork now receives a clearly visible dark scrollbar thumb.
- Verified that the thumb becomes more prominent on hover and remains draggable.
- Verified that the adaptive styling is limited to artwork-backed metadata details.
- Confirmed that Home, Catalog, Settings, and other ordinary surfaces continue using their existing scrollbar colors and opacity.
- Ran `.\gradlew.bat :composeApp:compileKotlinDesktop` successfully.

macOS and Linux were not runtime-tested locally.

## Screenshots / Video

### Before

<img width="46" height="156" alt="Light scrollbar blending into a bright metadata backdrop" src="https://github.com/user-attachments/assets/5626a8c8-14a3-4eee-9cfa-ba58ea753cba" />

### After

<img width="79" height="130" alt="Adaptive dark scrollbar visible against a bright metadata backdrop" src="https://github.com/user-attachments/assets/e5c80887-5363-426c-a26b-e63a00cbed91" />

## Breaking changes

None.

## Linked issues

Closes #548