### PR TITLE
fix(desktop): inhibit screensaver/screen-lock during playback on Linux

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/PlayerPlatformEffects.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/PlayerPlatformEffects.desktop.kt
@@ -7,6 +7,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.unit.IntSize
 import com.nuvio.app.features.player.desktop.DesktopHostOs
 import com.nuvio.app.features.player.desktop.NativePlayerBridge
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 @Composable
 actual fun LockPlayerToLandscape() = Unit
@@ -41,6 +44,9 @@ actual fun rememberPlayerGestureController(): PlayerGestureController? = null
 private class DesktopKeepAwakeController : AutoCloseable {
     private var caffeinateProcess: Process? = null
     private var windowsDisplaySleepInhibited = false
+    private var linuxInhibitCookie: Long? = null
+    private var linuxInhibitProcess: Process? = null
+    private var linuxInhibitExecutor: ExecutorService? = null
 
     fun setEnabled(enabled: Boolean) {
         when (DesktopHostOs.current) {
@@ -53,7 +59,8 @@ private class DesktopKeepAwakeController : AutoCloseable {
             }
 
             DesktopHostOs.WINDOWS -> setWindowsDisplaySleepInhibited(enabled)
-            DesktopHostOs.LINUX, DesktopHostOs.UNKNOWN -> Unit
+            DesktopHostOs.LINUX -> setLinuxInhibitEnabled(enabled)
+            DesktopHostOs.UNKNOWN -> Unit
         }
     }
 
@@ -90,8 +97,109 @@ private class DesktopKeepAwakeController : AutoCloseable {
         }
     }
 
+    // Subprocess calls below block, so route them off the Compose thread.
+    private fun linuxExecutor(): ExecutorService =
+        linuxInhibitExecutor ?: Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "nuvio-linux-screensaver-inhibit").apply { isDaemon = true }
+        }.also { linuxInhibitExecutor = it }
+
+    // Held together, not as an either/or fallback: testing on KDE Plasma showed a successful
+    // D-Bus Inhibit call alone doesn't stop the screen lock, only systemd-inhibit does - other
+    // DEs may lean on the D-Bus call instead, so both run.
+    private fun setLinuxInhibitEnabled(enabled: Boolean) {
+        linuxExecutor().execute {
+            if (enabled) {
+                if (linuxInhibitCookie == null) tryStartDbusScreenSaverInhibit()
+                if (linuxInhibitProcess?.isAlive != true) tryStartSystemdInhibit()
+            } else {
+                stopDbusScreenSaverInhibit()
+                stopSystemdInhibit()
+            }
+        }
+    }
+
+    // Same freedesktop ScreenSaver D-Bus call mpv/VLC/browsers use - KDE, GNOME, and XFCE all honor it.
+    private fun tryStartDbusScreenSaverInhibit(): Boolean {
+        linuxInhibitCookie = runCatching {
+            val (exitCode, output) = runDbusSendBlocking(
+                "--print-reply=literal",
+                "--dest=org.freedesktop.ScreenSaver",
+                "/org/freedesktop/ScreenSaver",
+                "org.freedesktop.ScreenSaver.Inhibit",
+                "string:Nuvio",
+                "string:Media playback",
+            )
+            // --print-reply=literal still prefixes the value with its D-Bus type name (e.g.
+            // "uint32 19346"), it isn't a bare number - take the last token.
+            output.trim().substringAfterLast(' ').takeIf { exitCode == 0 && it.isNotEmpty() }?.toLongOrNull()
+        }.getOrNull()
+        return linuxInhibitCookie != null
+    }
+
+    private fun stopDbusScreenSaverInhibit() {
+        val cookie = linuxInhibitCookie ?: return
+        runCatching {
+            runDbusSendBlocking(
+                "--dest=org.freedesktop.ScreenSaver",
+                "/org/freedesktop/ScreenSaver",
+                "org.freedesktop.ScreenSaver.UnInhibit",
+                "uint32:$cookie",
+            )
+        }
+        linuxInhibitCookie = null
+    }
+
+    // If dbus-daemon never replies, readText() below blocks forever before a waitFor() timeout
+    // would even get a chance to fire, so the watchdog thread is the thing that actually kills it.
+    private fun runDbusSendBlocking(vararg args: String): Pair<Int, String> {
+        val process = ProcessBuilder("dbus-send", "--session", "--type=method_call", *args)
+            .redirectErrorStream(true)
+            .start()
+        Thread {
+            if (!process.waitFor(5, TimeUnit.SECONDS)) {
+                process.destroyForcibly()
+            }
+        }.apply {
+            isDaemon = true
+            start()
+        }
+        val output = process.inputStream.bufferedReader().use { it.readText() }
+        val exitCode = process.waitFor()
+        return exitCode to output
+    }
+
+    // Holds a systemd-logind idle/sleep lock for as long as this child process stays alive.
+    private fun tryStartSystemdInhibit(): Boolean {
+        linuxInhibitProcess = runCatching {
+            ProcessBuilder(
+                "systemd-inhibit",
+                "--what=idle:sleep",
+                "--who=Nuvio",
+                "--why=Media playback",
+                "--mode=block",
+                "sleep",
+                "infinity",
+            ).start()
+        }.getOrNull()
+        return linuxInhibitProcess?.isAlive == true
+    }
+
+    private fun stopSystemdInhibit() {
+        linuxInhibitProcess
+            ?.takeIf(Process::isAlive)
+            ?.destroy()
+        linuxInhibitProcess = null
+    }
+
     override fun close() {
         stopCaffeinate()
         setWindowsDisplaySleepInhibited(false)
+        linuxInhibitExecutor?.let { executor ->
+            executor.execute {
+                stopDbusScreenSaverInhibit()
+                stopSystemdInhibit()
+            }
+            executor.shutdown()
+        }
     }
 }


### PR DESCRIPTION
## Summary

Prevents the system from being considered idle on Linux while media is actively playing, so the screen no longer auto-locks/sleeps mid-playback.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

On Linux, Nuvio never told the desktop environment that media was playing, so the OS still saw the system as idle. With a screen-lock/sleep timeout configured (e.g. KDE Plasma set to lock after 5 minutes), the screen would lock or go to sleep while a movie/episode was actively playing and mouse/keyboard were untouched. macOS already handles this via caffeinate and Windows via a native display-sleep-inhibit call; the Linux branch of the same code path was a no-op. The fix holds two independent inhibitors at once: the org.freedesktop.ScreenSaver D-Bus interface (what mpv/VLC/browsers use, honored by KDE/GNOME/XFCE/Cinnamon/MATE) and a systemd-inhibit idle/sleep lock. Testing showed these aren't interchangeable - on KDE Plasma, a successful D-Bus Inhibit call alone did not actually stop the screen lock, only systemd-inhibit did - so both run together rather than one being a fallback for the other, for the widest coverage across desktop environments.

## Desktop scope

Linux only. Change is isolated to `composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/PlayerPlatformEffects.desktop.kt`, in the `DesktopKeepAwakeController` used by all three desktop platforms, only the Linux branch's behavior changes.

## Issue or approval

Fixes #537

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

No changes to macOS or Windows keep-awake behavior. No UI changes. No packaging/dependency changes, uses dbus-send/systemd-inhibit, both external system binaries invoked via ProcessBuilder, not new build dependencies. Setups with neither a screensaver daemon implementing org.freedesktop.ScreenSaver nor systemd (e.g. bare sway/i3/Hyprland without a compatible idle daemon, or non-systemd distros) are not covered by this fix and will fall back to prior (unfixed) behavior. No regression, just no improvement there.

## Testing

Manual, on EndeavourOS (Arch Linux) with KDE Plasma, using ./gradlew :composeApp:run, dbus-monitor --session "interface='org.freedesktop.ScreenSaver'", and systemd-inhibit --list:

- Confirmed the reported bug reproduces on Dev: qdbus org.freedesktop.ScreenSaver /ScreenSaver org.freedesktop.ScreenSaver.GetActive flips to true and the screen locks during active playback.
- Caught a real bug during implementation via dbus-monitor: dbus-send --print-reply=literal's reply includes the D-Bus type name (e.g. "uint32 19347"), not a bare number - the cookie was never parsed, so UnInhibit never fired on pause. Fixed the parsing and confirmed a correctly paired Inhibit/UnInhibit cycle.
- Also found that on this KDE Plasma version, a successful org.freedesktop.ScreenSaver.Inhibit call alone does not stop the screen-lock timer - only systemd-inhibit --what=idle:sleep does. Changed the implementation to hold both simultaneously rather than one as a fallback for the other.
- Final verification: played for several minutes with a shortened 1-minute lock timeout - screen stayed unlocked, and systemd-inhibit --list showed the expected Nuvio / idle:sleep / Media playback entry. Paused - UnInhibit fired with the matching cookie in dbus-monitor, the Nuvio row disappeared from systemd-inhibit --list, and the screen locked normally about a minute later.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #537
