### PR TITLE
fix(desktop): improve fullscreen and keyboard back navigation

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/core/ui/PlatformBackHandler.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/core/ui/PlatformBackHandler.android.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
 @Composable
 actual fun PlatformBackHandler(
     enabled: Boolean,
+    onHistoryBack: (() -> Unit)?,
     onBack: () -> Unit,
 ) {
     BackHandler(enabled = enabled, onBack = onBack)

--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/settings/DesktopWindowSettings.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/settings/DesktopWindowSettings.android.kt
@@ -1,0 +1,11 @@
+package com.nuvio.app.features.settings
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+internal actual object DesktopWindowSettings {
+    actual val isSupported: Boolean = false
+    actual val escapeExitsFullscreen: StateFlow<Boolean> = MutableStateFlow(true)
+
+    actual fun setEscapeExitsFullscreen(enabled: Boolean) = Unit
+}

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -687,6 +687,8 @@
     <string name="settings_appearance_desktop_navigation_sheet_title">Choose Desktop Navigation</string>
     <string name="settings_appearance_desktop_navigation_sidebar">Sidebar</string>
     <string name="settings_appearance_desktop_navigation_top_bar">Top Bar</string>
+    <string name="settings_appearance_escape_exits_fullscreen">Escape key exits fullscreen</string>
+    <string name="settings_appearance_escape_exits_fullscreen_description">Exit fullscreen before using Escape as Back. Backspace always navigates back.</string>
     <string name="settings_appearance_hover_preview_description">Configure poster hover cards and their opening delay.</string>
     <string name="settings_appearance_liquid_glass">Liquid Glass</string>
     <string name="settings_appearance_liquid_glass_description">Use the native iPhone tab bar on iOS 26 and later.</string>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/AppTabNavigationHistory.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/AppTabNavigationHistory.kt
@@ -1,0 +1,21 @@
+package com.nuvio.app
+
+internal class AppTabNavigationHistory {
+    private val previousTabs = mutableListOf<AppScreenTab>()
+
+    fun recordTransition(from: AppScreenTab, to: AppScreenTab) {
+        if (from != to) previousTabs += from
+    }
+
+    fun popPrevious(current: AppScreenTab): AppScreenTab? {
+        while (previousTabs.isNotEmpty()) {
+            val previous = previousTabs.removeAt(previousTabs.lastIndex)
+            if (previous != current) return previous
+        }
+        return null
+    }
+
+    fun clear() {
+        previousTabs.clear()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/MainAppContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/MainAppContent.kt
@@ -68,6 +68,7 @@ import com.nuvio.app.core.ui.NuvioPosterZoomActionOverlay
 import com.nuvio.app.core.ui.NuvioStatusModal
 import com.nuvio.app.core.ui.NuvioToastController
 import com.nuvio.app.core.ui.NuvioToastHost
+import com.nuvio.app.core.ui.PlatformBackHandler
 import com.nuvio.app.core.ui.PosterZoomAnchor
 import com.nuvio.app.core.ui.PosterZoomAnchorHolder
 import com.nuvio.app.core.ui.PosterZoomOverlayAction
@@ -217,6 +218,7 @@ internal fun MainAppContent(
         val uriHandler = LocalUriHandler.current
         val coroutineScope = rememberCoroutineScope()
         var selectedTab by rememberSaveable(initialTab) { mutableStateOf(initialTab) }
+        val tabNavigationHistory = remember(initialTab) { AppTabNavigationHistory() }
         var searchFocusRequestCount by remember { mutableStateOf(0) }
         val homeScrollToTopRequests = remember { MutableSharedFlow<Unit>(extraBufferCapacity = 1) }
         val searchScrollToTopRequests = remember { MutableSharedFlow<Unit>(extraBufferCapacity = 1) }
@@ -231,6 +233,18 @@ internal fun MainAppContent(
         val currentRoute = navBackStack.lastOrNull() as? AppRoute
         var registeredPlayerSystemBack by remember {
             mutableStateOf<Pair<PlayerRoute, () -> Unit>?>(null)
+        }
+        if (isDesktop) {
+            PlatformBackHandler(enabled = currentRoute !is TabsRoute) {
+                val routeAtRequest = navController.currentRoute
+                dispatchNavigationBack(
+                    isPlayerRoute = routeAtRequest is PlayerRoute,
+                    playerBack = registeredPlayerSystemBack
+                        ?.takeIf { (route, _) -> route == routeAtRequest }
+                        ?.second,
+                    pop = { navController.popBackStack() },
+                )
+            }
         }
         val liquidGlassNativeTabBarEnabled by remember {
             ThemeSettingsRepository.liquidGlassNativeTabBarEnabled
@@ -339,7 +353,10 @@ internal fun MainAppContent(
     var lastNetworkToastCondition by rememberSaveable { mutableStateOf(NetworkCondition.Unknown.name) }
     var watchSourceReconnectPending by remember { mutableStateOf(false) }
 
-    fun activateTab(tab: AppScreenTab) {
+    fun activateTab(tab: AppScreenTab, recordInHistory: Boolean = true) {
+        if (isDesktop && recordInHistory && selectedTab != tab) {
+            tabNavigationHistory.recordTransition(from = selectedTab, to = tab)
+        }
         if (useNativeNavigation && onActivate != null) {
             onActivate(tab)
         } else {
@@ -1433,9 +1450,15 @@ internal fun MainAppContent(
                         },
                         onBack = {
                             if (selectedTab != AppScreenTab.Home) {
-                                activateTab(AppScreenTab.Home)
+                                tabNavigationHistory.clear()
+                                activateTab(AppScreenTab.Home, recordInHistory = false)
                             } else {
                                 showExitConfirmation = !showExitConfirmation
+                            }
+                        },
+                        onHistoryBack = {
+                            tabNavigationHistory.popPrevious(selectedTab)?.let { previousTab ->
+                                activateTab(previousTab, recordInHistory = false)
                             }
                         },
                         onTabSelected = ::handleRootTabClick,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/MainTabsDestination.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/MainTabsDestination.kt
@@ -61,11 +61,16 @@ internal fun MainTabsDestination(
     state: AppTabState,
     actions: (isTabletLayout: Boolean) -> AppTabActions,
     onBack: () -> Unit,
+    onHistoryBack: () -> Unit,
     onTabSelected: (AppScreenTab) -> Unit,
     onProfileSelected: (NuvioProfile) -> Unit,
     onAddProfileRequested: () -> Unit,
 ) {
-    PlatformBackHandler(enabled = true, onBack = onBack)
+    PlatformBackHandler(
+        enabled = true,
+        onBack = onBack,
+        onHistoryBack = onHistoryBack,
+    )
 
     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
         val isTabletLayout = useTabletFloatingTabBar || maxWidth >= 768.dp

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/PlatformBackHandler.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/PlatformBackHandler.kt
@@ -5,5 +5,6 @@ import androidx.compose.runtime.Composable
 @Composable
 expect fun PlatformBackHandler(
     enabled: Boolean,
+    onHistoryBack: (() -> Unit)? = null,
     onBack: () -> Unit,
 )

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/AppearanceSettingsPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/AppearanceSettingsPage.kt
@@ -71,6 +71,8 @@ import nuvio.composeapp.generated.resources.settings_appearance_amoled_descripti
 import nuvio.composeapp.generated.resources.settings_appearance_continue_watching_description
 import nuvio.composeapp.generated.resources.settings_appearance_desktop_navigation
 import nuvio.composeapp.generated.resources.settings_appearance_desktop_navigation_sheet_title
+import nuvio.composeapp.generated.resources.settings_appearance_escape_exits_fullscreen
+import nuvio.composeapp.generated.resources.settings_appearance_escape_exits_fullscreen_description
 import nuvio.composeapp.generated.resources.settings_appearance_hover_preview_description
 import nuvio.composeapp.generated.resources.settings_appearance_liquid_glass
 import nuvio.composeapp.generated.resources.settings_appearance_liquid_glass_description
@@ -175,6 +177,9 @@ internal fun LazyListScope.appearanceSettingsContent(
             ThemeSettingsRepository.ensureLoaded()
             ThemeSettingsRepository.desktopNavigationLayout
         }.collectAsStateWithLifecycle()
+        val escapeExitsFullscreen by remember {
+            DesktopWindowSettings.escapeExitsFullscreen
+        }.collectAsStateWithLifecycle()
         var showNavBarStyleSheet by remember { mutableStateOf(false) }
         var showAppIconPicker by remember { mutableStateOf(false) }
         SettingsSection(
@@ -206,6 +211,16 @@ internal fun LazyListScope.appearanceSettingsContent(
                         description = stringResource(desktopNavigationLayout.labelRes),
                         isTablet = isTablet,
                         onClick = { showDesktopNavigationSheet = true },
+                    )
+                    SettingsGroupDivider(isTablet = isTablet)
+                    SettingsSwitchRow(
+                        title = stringResource(Res.string.settings_appearance_escape_exits_fullscreen),
+                        description = stringResource(
+                            Res.string.settings_appearance_escape_exits_fullscreen_description,
+                        ),
+                        checked = escapeExitsFullscreen,
+                        isTablet = isTablet,
+                        onCheckedChange = DesktopWindowSettings::setEscapeExitsFullscreen,
                     )
                     SettingsGroupDivider(isTablet = isTablet)
                     SettingsNavigationRow(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/DesktopWindowSettings.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/DesktopWindowSettings.kt
@@ -1,0 +1,10 @@
+package com.nuvio.app.features.settings
+
+import kotlinx.coroutines.flow.StateFlow
+
+internal expect object DesktopWindowSettings {
+    val isSupported: Boolean
+    val escapeExitsFullscreen: StateFlow<Boolean>
+
+    fun setEscapeExitsFullscreen(enabled: Boolean)
+}

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/SettingsSearch.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/SettingsSearch.kt
@@ -388,6 +388,19 @@ internal fun settingsSearchEntries(
         section = stringResource(Res.string.settings_appearance_section_display),
         icon = Icons.Rounded.Palette,
     )
+    if (DesktopWindowSettings.isSupported) {
+        addRow(
+            page = SettingsPage.Appearance,
+            key = "escape-exits-fullscreen",
+            title = stringResource(Res.string.settings_appearance_escape_exits_fullscreen),
+            description = stringResource(
+                Res.string.settings_appearance_escape_exits_fullscreen_description,
+            ),
+            pageLabel = layoutPage,
+            section = stringResource(Res.string.settings_appearance_section_display),
+            icon = Icons.Rounded.Palette,
+        )
+    }
     if (liquidGlassNativeTabBarSupported) {
         addRow(
             page = SettingsPage.Appearance,

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.unit.dp
 import com.nuvio.app.core.deeplink.handleAppUrl
 import com.nuvio.app.core.diagnostics.SentryInitializer
 import com.nuvio.app.core.ui.NuvioTheme
+import com.nuvio.app.core.ui.handleDesktopWindowKeyEvent
 import com.nuvio.app.features.discordrpc.DiscordPresenceManager
 import com.nuvio.app.features.p2p.P2pStreamingEngine
 import com.nuvio.app.features.plugins.configureDesktopQuickJsLibrary
@@ -124,6 +125,7 @@ fun main(args: Array<String>) {
             title = if (smokePlayerUrl == null) "Nuvio" else "Nuvio Player Smoke",
             state = windowState,
             icon = painterResource(appIconState.selected.transparentPreviewResource),
+            onKeyEvent = ::handleDesktopWindowKeyEvent,
         ) {
             SideEffect {
                 window.background = NuvioDesktopNativeBackground

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/core/ui/DesktopWindowKeyboard.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/core/ui/DesktopWindowKeyboard.kt
@@ -1,0 +1,61 @@
+package com.nuvio.app.core.ui
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isAltPressed
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
+
+internal enum class DesktopWindowNavigationKey {
+    Escape,
+    Backspace,
+    Other,
+}
+
+internal enum class DesktopWindowKeyAction {
+    NavigateBack,
+    NavigateHistoryBack,
+    None,
+}
+
+internal fun resolveDesktopWindowKeyAction(
+    key: DesktopWindowNavigationKey,
+    isKeyDown: Boolean,
+    hasModifier: Boolean,
+    canNavigateBack: Boolean,
+): DesktopWindowKeyAction {
+    if (!isKeyDown || hasModifier) return DesktopWindowKeyAction.None
+    if (!canNavigateBack) return DesktopWindowKeyAction.None
+    return when (key) {
+        DesktopWindowNavigationKey.Escape -> DesktopWindowKeyAction.NavigateBack
+        DesktopWindowNavigationKey.Backspace -> DesktopWindowKeyAction.NavigateHistoryBack
+        DesktopWindowNavigationKey.Other -> DesktopWindowKeyAction.None
+    }
+}
+
+internal fun handleDesktopWindowKeyEvent(event: KeyEvent): Boolean {
+    val navigationKey = when (event.key) {
+        Key.Escape -> DesktopWindowNavigationKey.Escape
+        Key.Backspace -> DesktopWindowNavigationKey.Backspace
+        else -> DesktopWindowNavigationKey.Other
+    }
+    val action = resolveDesktopWindowKeyAction(
+        key = navigationKey,
+        isKeyDown = event.type == KeyEventType.KeyDown,
+        hasModifier = event.isAltPressed ||
+            event.isCtrlPressed ||
+            event.isMetaPressed ||
+            event.isShiftPressed,
+        canNavigateBack = DesktopBackHandlerDispatcher.hasEnabledHandler(),
+    )
+    return when (action) {
+        DesktopWindowKeyAction.NavigateBack -> DesktopBackHandlerDispatcher.dispatchBack()
+        DesktopWindowKeyAction.NavigateHistoryBack ->
+            DesktopBackHandlerDispatcher.dispatchBack(useHistory = true)
+        DesktopWindowKeyAction.None -> false
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/core/ui/PlatformBackHandler.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/core/ui/PlatformBackHandler.desktop.kt
@@ -1,9 +1,61 @@
 package com.nuvio.app.core.ui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.rememberUpdatedState
+
+internal object DesktopBackHandlerDispatcher {
+    private data class Registration(
+        val isEnabled: () -> Boolean,
+        val onBack: () -> Unit,
+        val onHistoryBack: () -> Unit,
+    )
+
+    private val registrations = mutableListOf<Registration>()
+
+    fun register(
+        isEnabled: () -> Boolean,
+        onBack: () -> Unit,
+        onHistoryBack: () -> Unit,
+    ): () -> Unit {
+        val registration = Registration(
+            isEnabled = isEnabled,
+            onBack = onBack,
+            onHistoryBack = onHistoryBack,
+        )
+        registrations += registration
+        return { registrations.remove(registration) }
+    }
+
+    fun hasEnabledHandler(): Boolean =
+        registrations.asReversed().any { it.isEnabled() }
+
+    fun dispatchBack(useHistory: Boolean = false): Boolean {
+        val registration = registrations.asReversed().firstOrNull { it.isEnabled() }
+            ?: return false
+        if (useHistory) registration.onHistoryBack() else registration.onBack()
+        return true
+    }
+}
 
 @Composable
 actual fun PlatformBackHandler(
     enabled: Boolean,
+    onHistoryBack: (() -> Unit)?,
     onBack: () -> Unit,
-) = Unit
+) {
+    val currentEnabled = rememberUpdatedState(enabled)
+    val currentOnBack = rememberUpdatedState(onBack)
+    val currentOnHistoryBack = rememberUpdatedState(onHistoryBack)
+
+    DisposableEffect(Unit) {
+        val unregister = DesktopBackHandlerDispatcher.register(
+            isEnabled = { currentEnabled.value },
+            onBack = { currentOnBack.value() },
+            onHistoryBack = {
+                currentOnHistoryBack.value?.invoke() ?: currentOnBack.value()
+            },
+        )
+        onDispose(unregister)
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopAppFullscreen.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/DesktopAppFullscreen.kt
@@ -3,6 +3,7 @@ package com.nuvio.app.features.player.desktop
 import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.window.WindowPlacement
 import androidx.compose.ui.window.WindowState
+import com.nuvio.app.features.settings.DesktopWindowSettings
 import java.awt.GraphicsEnvironment
 import java.awt.KeyEventDispatcher
 import java.awt.KeyboardFocusManager
@@ -245,7 +246,17 @@ internal fun applyMacosComposeFullscreenExit(
 
 internal fun installDesktopAppFullscreenShortcuts(window: Window): () -> Unit {
     val dispatcher = KeyEventDispatcher { event ->
-        if (!event.isDesktopAppFullscreenShortcut()) return@KeyEventDispatcher false
+        if (
+            !shouldHandleDesktopFullscreenKey(
+                eventId = event.id,
+                keyCode = event.keyCode,
+                modifiersEx = event.modifiersEx,
+                isFullscreen = DesktopAppFullscreen.isFullscreen(window),
+                escapeExitsFullscreen = DesktopWindowSettings.escapeExitsFullscreen.value,
+            )
+        ) {
+            return@KeyEventDispatcher false
+        }
         toggleDesktopAppFullscreen(window)
         true
     }
@@ -255,14 +266,28 @@ internal fun installDesktopAppFullscreenShortcuts(window: Window): () -> Unit {
     }
 }
 
-private fun KeyEvent.isDesktopAppFullscreenShortcut(): Boolean {
-    if (id != KeyEvent.KEY_PRESSED) return false
+internal fun shouldHandleDesktopFullscreenKey(
+    eventId: Int,
+    keyCode: Int,
+    modifiersEx: Int,
+    isFullscreen: Boolean = false,
+    escapeExitsFullscreen: Boolean = false,
+): Boolean {
+    if (eventId != KeyEvent.KEY_PRESSED) return false
     if (keyCode == KeyEvent.VK_F11) return true
+    if (keyCode == KeyEvent.VK_ESCAPE) {
+        val keyboardModifierMask = KeyEvent.SHIFT_DOWN_MASK or
+            KeyEvent.CTRL_DOWN_MASK or
+            KeyEvent.META_DOWN_MASK or
+            KeyEvent.ALT_DOWN_MASK
+        return modifiersEx and keyboardModifierMask == 0 &&
+            isFullscreen &&
+            escapeExitsFullscreen
+    }
     if (keyCode != KeyEvent.VK_F) return false
-    val modifiers = modifiersEx
     val hasMacFullscreenModifiers =
-        modifiers and KeyEvent.META_DOWN_MASK != 0 &&
-            modifiers and KeyEvent.CTRL_DOWN_MASK != 0 &&
-            modifiers and KeyEvent.ALT_DOWN_MASK == 0
+        modifiersEx and KeyEvent.META_DOWN_MASK != 0 &&
+            modifiersEx and KeyEvent.CTRL_DOWN_MASK != 0 &&
+            modifiersEx and KeyEvent.ALT_DOWN_MASK == 0
     return hasMacFullscreenModifiers
 }

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/player/desktop/NativePlayerController.kt
@@ -25,6 +25,7 @@ import com.nuvio.app.features.player.SubtitleStyleState
 import com.nuvio.app.features.player.SubtitleTrack
 import com.nuvio.app.features.player.inferForcedSubtitleTrack
 import com.nuvio.app.features.player.toStorageHexString
+import com.nuvio.app.features.settings.DesktopWindowSettings
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
@@ -427,9 +428,11 @@ internal class NativePlayerController(
         currentVolumeLevel = stateWithVolume.volumeLevel ?: currentVolumeLevel
         controlsState = stateWithVolume
         val isFullscreen = isDesktopAppFullscreen(SwingUtilities.getWindowAncestor(host))
+        val escapeExitsFullscreen = DesktopWindowSettings.escapeExitsFullscreen.value
         val structureKey = NativeControlsStructureKey(
             state = stateWithVolume.nativeControlsStructureKey(),
             isFullscreen = isFullscreen,
+            escapeExitsFullscreen = escapeExitsFullscreen,
         )
         if (structureKey == lastSentControlsStructureKey) return
         lastSentControlsStructureKey = structureKey
@@ -439,7 +442,13 @@ internal class NativePlayerController(
                 "speed=${stateWithVolume.playbackSpeedLabel} audioLabel=${stateWithVolume.audioLabel} " +
                 "subsLabel=${stateWithVolume.subtitlesLabel} fullscreen=$isFullscreen"
         }
-        NativePlayerBridge.updateControls(current, stateWithVolume.toControlsJson(isFullscreen))
+        NativePlayerBridge.updateControls(
+            current,
+            stateWithVolume.toControlsJson(
+                isFullscreen = isFullscreen,
+                escapeExitsFullscreen = escapeExitsFullscreen,
+            ),
+        )
     }
 
     fun onDesktopFullscreenChanged() {
@@ -1171,9 +1180,13 @@ private fun String.toPlayerControlsAction(): PlayerControlsAction? =
 private data class NativeControlsStructureKey(
     val state: PlayerControlsState,
     val isFullscreen: Boolean,
+    val escapeExitsFullscreen: Boolean,
 )
 
-private fun PlayerControlsState.toControlsJson(isFullscreen: Boolean): String =
+private fun PlayerControlsState.toControlsJson(
+    isFullscreen: Boolean,
+    escapeExitsFullscreen: Boolean,
+): String =
     buildString {
         append('{')
         appendJsonField("title", title)
@@ -1199,6 +1212,8 @@ private fun PlayerControlsState.toControlsJson(isFullscreen: Boolean): String =
         appendJsonField("playbackSpeedLabel", playbackSpeedLabel)
         append(',')
         appendJsonField("isFullscreen", isFullscreen)
+        append(',')
+        appendJsonField("escapeExitsFullscreen", escapeExitsFullscreen)
         append(',')
         appendJsonField("volumeLevel", volumeLevel)
         append(',')

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/settings/DesktopWindowSettings.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/settings/DesktopWindowSettings.desktop.kt
@@ -1,0 +1,24 @@
+package com.nuvio.app.features.settings
+
+import com.nuvio.app.core.storage.DesktopStorage
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+internal actual object DesktopWindowSettings {
+    private const val EscapeExitsFullscreenKey = "escape_exits_fullscreen"
+    private val store = DesktopStorage.store("nuvio_desktop_window_settings")
+    private val _escapeExitsFullscreen = MutableStateFlow(
+        store.getBoolean(EscapeExitsFullscreenKey) ?: true,
+    )
+
+    actual val isSupported: Boolean = true
+    actual val escapeExitsFullscreen: StateFlow<Boolean> =
+        _escapeExitsFullscreen.asStateFlow()
+
+    actual fun setEscapeExitsFullscreen(enabled: Boolean) {
+        if (_escapeExitsFullscreen.value == enabled) return
+        _escapeExitsFullscreen.value = enabled
+        store.putBoolean(EscapeExitsFullscreenKey, enabled)
+    }
+}

--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -180,6 +180,7 @@ let state = {
   resizeModeLabel: "Fit",
   playbackSpeedLabel: "1x",
   isFullscreen: false,
+  escapeExitsFullscreen: true,
   volumeLevel: null,
   subtitlesLabel: "Subs",
   audioLabel: "Audio",
@@ -3227,7 +3228,11 @@ document.addEventListener("keyup", event => {
 });
 
 document.addEventListener("keydown", event => {
-  if (event.key === "Escape" && activeModal) {
+  const isEscape = event.key === "Escape";
+  const isBackspace = event.key === "Backspace";
+  const isUnmodifiedBackspace = isBackspace &&
+    !event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey;
+  if ((isEscape || (isUnmodifiedBackspace && !isTextEntryTarget(event.target))) && activeModal) {
     if (spaceHoldTimer) {
       window.clearTimeout(spaceHoldTimer);
       spaceHoldTimer = null;
@@ -3241,7 +3246,7 @@ document.addEventListener("keydown", event => {
     focusShortcutRoot();
     return;
   }
-  if (event.key === "Escape") {
+  if (isEscape || (isUnmodifiedBackspace && !isTextEntryTarget(event.target))) {
     if (spaceHoldTimer) {
       window.clearTimeout(spaceHoldTimer);
       spaceHoldTimer = null;
@@ -3251,7 +3256,7 @@ document.addEventListener("keydown", event => {
       stopSpeedBoost();
     }
     event.preventDefault();
-    if (state.isFullscreen) {
+    if (isEscape && state.isFullscreen && state.escapeExitsFullscreen !== false) {
       togglePlayerFullscreen();
     } else {
       send("back", 0);

--- a/composeApp/src/desktopTest/kotlin/com/nuvio/app/AppTabNavigationHistoryTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/nuvio/app/AppTabNavigationHistoryTest.kt
@@ -1,0 +1,31 @@
+package com.nuvio.app
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AppTabNavigationHistoryTest {
+    @Test
+    fun `history restores visited tabs in reverse order`() {
+        val history = AppTabNavigationHistory()
+
+        history.recordTransition(AppScreenTab.Home, AppScreenTab.Search)
+        history.recordTransition(AppScreenTab.Search, AppScreenTab.Library)
+
+        assertEquals(AppScreenTab.Search, history.popPrevious(AppScreenTab.Library))
+        assertEquals(AppScreenTab.Home, history.popPrevious(AppScreenTab.Search))
+        assertNull(history.popPrevious(AppScreenTab.Home))
+    }
+
+    @Test
+    fun `same-tab selections are not added and history can be reset`() {
+        val history = AppTabNavigationHistory()
+
+        history.recordTransition(AppScreenTab.Home, AppScreenTab.Home)
+        assertNull(history.popPrevious(AppScreenTab.Home))
+
+        history.recordTransition(AppScreenTab.Home, AppScreenTab.Settings)
+        history.clear()
+        assertNull(history.popPrevious(AppScreenTab.Settings))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/com/nuvio/app/core/ui/DesktopWindowKeyboardTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/nuvio/app/core/ui/DesktopWindowKeyboardTest.kt
@@ -1,0 +1,89 @@
+package com.nuvio.app.core.ui
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DesktopWindowKeyboardTest {
+    @Test
+    fun `escape dispatches normal back after native fullscreen handling declines it`() {
+        assertEquals(
+            DesktopWindowKeyAction.NavigateBack,
+            resolveDesktopWindowKeyAction(
+                key = DesktopWindowNavigationKey.Escape,
+                isKeyDown = true,
+                hasModifier = false,
+                canNavigateBack = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `backspace dispatches history back`() {
+        assertEquals(
+            DesktopWindowKeyAction.NavigateHistoryBack,
+            resolveDesktopWindowKeyAction(
+                key = DesktopWindowNavigationKey.Backspace,
+                isKeyDown = true,
+                hasModifier = false,
+                canNavigateBack = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `keys are ignored without a back target`() {
+        listOf(
+            DesktopWindowNavigationKey.Escape,
+            DesktopWindowNavigationKey.Backspace,
+        ).forEach { key ->
+            assertEquals(
+                DesktopWindowKeyAction.None,
+                resolveDesktopWindowKeyAction(
+                    key = key,
+                    isKeyDown = true,
+                    hasModifier = false,
+                    canNavigateBack = false,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `modified keys releases and unrelated keys are ignored`() {
+        val ignoredInputs = listOf(
+            Triple(DesktopWindowNavigationKey.Backspace, true, true),
+            Triple(DesktopWindowNavigationKey.Escape, false, false),
+            Triple(DesktopWindowNavigationKey.Other, true, false),
+        )
+        ignoredInputs.forEach { (key, isKeyDown, hasModifier) ->
+            assertEquals(
+                DesktopWindowKeyAction.None,
+                resolveDesktopWindowKeyAction(
+                    key = key,
+                    isKeyDown = isKeyDown,
+                    hasModifier = hasModifier,
+                    canNavigateBack = true,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `dispatcher distinguishes normal and history callbacks`() {
+        val dispatched = mutableListOf<String>()
+        val unregister = DesktopBackHandlerDispatcher.register(
+            isEnabled = { true },
+            onBack = { dispatched += "back" },
+            onHistoryBack = { dispatched += "history" },
+        )
+
+        try {
+            assertTrue(DesktopBackHandlerDispatcher.dispatchBack())
+            assertTrue(DesktopBackHandlerDispatcher.dispatchBack(useHistory = true))
+            assertEquals(listOf("back", "history"), dispatched)
+        } finally {
+            unregister()
+        }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/com/nuvio/app/features/player/desktop/DesktopAppFullscreenTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/nuvio/app/features/player/desktop/DesktopAppFullscreenTest.kt
@@ -1,10 +1,101 @@
 package com.nuvio.app.features.player.desktop
 
 import androidx.compose.ui.window.WindowPlacement
+import java.awt.event.InputEvent
+import java.awt.event.KeyEvent
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class DesktopAppFullscreenTest {
+    @Test
+    fun `fullscreen shortcuts continue to toggle`() {
+        assertTrue(
+            shouldHandleDesktopFullscreenKey(
+                eventId = KeyEvent.KEY_PRESSED,
+                keyCode = KeyEvent.VK_F11,
+                modifiersEx = 0,
+            ),
+        )
+        assertTrue(
+            shouldHandleDesktopFullscreenKey(
+                eventId = KeyEvent.KEY_PRESSED,
+                keyCode = KeyEvent.VK_F,
+                modifiersEx = InputEvent.CTRL_DOWN_MASK or InputEvent.META_DOWN_MASK,
+            ),
+        )
+    }
+
+    @Test
+    fun `escape exits fullscreen only when enabled and unmodified`() {
+        assertTrue(
+            shouldHandleDesktopFullscreenKey(
+                eventId = KeyEvent.KEY_PRESSED,
+                keyCode = KeyEvent.VK_ESCAPE,
+                modifiersEx = 0,
+                isFullscreen = true,
+                escapeExitsFullscreen = true,
+            ),
+        )
+        assertFalse(
+            shouldHandleDesktopFullscreenKey(
+                eventId = KeyEvent.KEY_PRESSED,
+                keyCode = KeyEvent.VK_ESCAPE,
+                modifiersEx = 0,
+                isFullscreen = true,
+                escapeExitsFullscreen = false,
+            ),
+        )
+        assertFalse(
+            shouldHandleDesktopFullscreenKey(
+                eventId = KeyEvent.KEY_PRESSED,
+                keyCode = KeyEvent.VK_ESCAPE,
+                modifiersEx = InputEvent.SHIFT_DOWN_MASK,
+                isFullscreen = true,
+                escapeExitsFullscreen = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `escape does not consume windowed navigation`() {
+        assertFalse(
+            shouldHandleDesktopFullscreenKey(
+                eventId = KeyEvent.KEY_PRESSED,
+                keyCode = KeyEvent.VK_ESCAPE,
+                modifiersEx = 0,
+                isFullscreen = false,
+                escapeExitsFullscreen = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `key releases and unrelated keys are ignored`() {
+        assertFalse(
+            shouldHandleDesktopFullscreenKey(
+                eventId = KeyEvent.KEY_RELEASED,
+                keyCode = KeyEvent.VK_ESCAPE,
+                modifiersEx = 0,
+            ),
+        )
+        assertFalse(
+            shouldHandleDesktopFullscreenKey(
+                eventId = KeyEvent.KEY_PRESSED,
+                keyCode = KeyEvent.VK_ENTER,
+                modifiersEx = 0,
+            ),
+        )
+        assertFalse(
+            shouldHandleDesktopFullscreenKey(
+                eventId = KeyEvent.KEY_PRESSED,
+                keyCode = KeyEvent.VK_ESCAPE,
+                modifiersEx = 0,
+            ),
+        )
+    }
+
     @Test
     fun `native fullscreen exit lets the window listener restore placement`() {
         val updates = mutableListOf<String>()

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/core/ui/PlatformBackHandler.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/core/ui/PlatformBackHandler.ios.kt
@@ -5,5 +5,6 @@ import androidx.compose.runtime.Composable
 @Composable
 actual fun PlatformBackHandler(
     enabled: Boolean,
+    onHistoryBack: (() -> Unit)?,
     onBack: () -> Unit,
 ) = Unit

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/settings/DesktopWindowSettings.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/settings/DesktopWindowSettings.ios.kt
@@ -1,0 +1,11 @@
+package com.nuvio.app.features.settings
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+internal actual object DesktopWindowSettings {
+    actual val isSupported: Boolean = false
+    actual val escapeExitsFullscreen: StateFlow<Boolean> = MutableStateFlow(true)
+
+    actual fun setEscapeExitsFullscreen(enabled: Boolean) = Unit
+}


### PR DESCRIPTION
## Summary

- Adds an **Escape key exits fullscreen** setting under **Settings → General → Appearance → Display**, enabled by default.
- When enabled, Escape exits fullscreen before performing Nuvio's existing Back action.
- When disabled, Escape performs Back without changing fullscreen.
- Adds Backspace history navigation that never changes fullscreen.
- Restores previously visited Home, Search, Library, and Settings tabs while preserving their saved state.
- Applies the same keyboard behavior to nested Settings pages, details screens, overlays, and native playback.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Desktop keyboard navigation did not consistently distinguish between exiting fullscreen and returning to previously visited content.

Outside playback, Escape could not exit app fullscreen. Backspace also had no desktop navigation behavior, leaving users without a keyboard shortcut that could return through the actual route and tab history while preserving fullscreen.

The new behavior keeps Nuvio's existing Escape-as-Back shortcut while adding a separate Stremio-style Backspace history action.

## Desktop scope

The setting and keyboard handling are desktop-only.

Shared navigation code was updated only where required to expose the active Back handler and preserve root-tab history. Android and iOS use no-op desktop-setting implementations and retain their existing platform Back behavior.

The same navigation path is used by both desktop sidebar and top-bar layouts.

Windows was manually tested. macOS and Linux share the desktop implementation but were not available for runtime testing.

## Issue or approval

Fixes #560

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

- Does not add or reposition fullscreen buttons.
- Does not change fullscreen entry behavior.
- Does not alter existing F11 or macOS Ctrl+Command+F shortcuts.
- Does not allow Escape or Backspace to enter fullscreen.
- Does not intercept Backspace while editing text.
- Does not change mobile Back behavior.
- Does not include unrelated UI or navigation changes.

## Testing

- Ran `.\gradlew.bat :composeApp:desktopTest` successfully.
- Ran a JavaScript syntax check on the native player controls.
- Manually verified on Windows 11:
  - Escape exits fullscreen when the setting is enabled.
  - A second Escape performs Nuvio's normal Back action.
  - Disabling the setting keeps the app fullscreen while Escape performs Back.
  - Backspace never changes fullscreen.
  - Backspace restores previously visited root tabs in reverse order.
  - Nested Settings pages return to the Settings root before the previous tab.
  - Movie and series details return to their originating screen.
  - Playback returns to its originating screen.
  - Backspace continues editing normally in text fields.
- macOS and Linux were not available for runtime testing.

## Screenshots / Video

**Settings → General → Appearance → Display**

<img width="1136" height="540" alt="Escape key exits fullscreen setting" src="https://github.com/user-attachments/assets/0f8ffc0c-4418-447c-a0b3-f2b66e6e4a5b" />

## Breaking changes

None.

## Linked issues

Fixes #560