### PR TITLE
perf(desktop): preload auth before the first Compose frame

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
 import androidx.compose.ui.unit.dp
+import com.nuvio.app.core.auth.AuthRepository
 import com.nuvio.app.core.deeplink.handleAppUrl
 import com.nuvio.app.core.diagnostics.SentryInitializer
 import com.nuvio.app.core.ui.NuvioTheme
@@ -57,8 +58,9 @@ fun main(args: Array<String>) {
     installDesktopOpenUriHandler()
     handleDesktopLaunchArgs(args)
     preloadNativePlayerBridgeAsync()
-    // Load cached profile data synchronously so the profile color is available
+    // Load cached profile and auth data synchronously so the profile color is available
     // on the very first Compose frame (matching Android's SharedPreferences behavior).
+    AuthRepository.initialize()
     ProfileRepository.loadCachedProfiles()
     AppIconRepository.ensureLoaded()
     DiscordPresenceManager.start()


### PR DESCRIPTION
## Summary

Initialize cached authentication in the Desktop entry point before the first Compose frame, alongside the existing cached-profile preload.

This is the exact Desktop-only `Main.kt` portion of the original implementation in [NuvioDesktop PR #546](https://github.com/NuvioMedia/NuvioDesktop/pull/546), rebased onto the latest `Dev`. The four shared `commonMain` changes are intentionally submitted through companion [NuvioMobile PR #1854](https://github.com/NuvioMedia/NuvioMobile/pull/1854).

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Desktop already restores cached profiles synchronously before creating the Compose window, but cached authentication was initialized later from the shared app gate.

Preloading authentication beside the profile cache gives the first frame the complete restored startup state and avoids an unnecessary startup-state transition. The later shared initialization remains safe because `AuthRepository.initialize()` is idempotent.

## Desktop scope

This changes only the shared Desktop entry point used by Windows, macOS, and Linux.

It does not modify `commonMain` or native Mobile entry points. The related shared startup behavior is isolated in [NuvioMobile PR #1854](https://github.com/NuvioMedia/NuvioMobile/pull/1854), following the maintainer direction recorded in [NuvioDesktop PR #546](https://github.com/NuvioMedia/NuvioDesktop/pull/546).

## Issue or approval

Fixes #580

Original implementation and visual context: [NuvioDesktop PR #546](https://github.com/NuvioMedia/NuvioDesktop/pull/546)

Companion shared change: [NuvioMobile PR #1854](https://github.com/NuvioMedia/NuvioMobile/pull/1854)

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only `composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt` was changed.

No shared startup flow, UI implementation, dependencies, architecture, profile behavior, networking, or unrelated Desktop initialization was changed in this PR.

The newer startup-performance work already present in `Dev`, including commit `82310de4`, is preserved.

## Testing

- Ran `.\gradlew.bat --offline --console=plain :composeApp:compileKotlinDesktop`.
- Launched the Desktop app from the updated branch on Windows 11 with an existing signed-in account and cached profile.
- Confirmed the app reached Home normally, remained responsive, and showed no regression from the preload ordering change.
- macOS and Linux runtime behavior was not manually verified.

## Screenshots / Video

Not a UI change.

The complete combined startup result and original before/after recordings are available in [NuvioDesktop PR #546](https://github.com/NuvioMedia/NuvioDesktop/pull/546). Its four shared `commonMain` files are now represented by companion [NuvioMobile PR #1854](https://github.com/NuvioMedia/NuvioMobile/pull/1854).

## Breaking changes

None.

## Linked issues

Fixes #580

Companion shared change: [NuvioMobile PR #1854](https://github.com/NuvioMedia/NuvioMobile/pull/1854)
