### PR TITLE
fix(linux): update using the package format the app was installed from

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/updater/AppUpdaterPlatform.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/updater/AppUpdaterPlatform.desktop.kt
@@ -19,6 +19,7 @@ import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.time.Duration
 import java.util.Locale
+import java.util.concurrent.TimeUnit
 import kotlin.concurrent.thread
 import kotlin.io.path.createDirectories
 import kotlin.system.exitProcess
@@ -36,7 +37,18 @@ actual object AppUpdaterPlatform {
     private val store = DesktopStorage.store(desktopUpdaterPreferencesName)
     actual val isDebugBuild: Boolean = false
 
-    actual val isSupported: Boolean = currentOs != DesktopUpdaterOs.UNKNOWN
+    // Linux ships four package formats and the running app is the only place
+    // that can tell which one it was installed from, so the format is resolved
+    // once and then drives both the asset choice and the install command.
+    private val linuxInstallMethod: LinuxInstallMethod by lazy {
+        if (currentOs == DesktopUpdaterOs.LINUX) detectLinuxInstallMethod() else LinuxInstallMethod.UNKNOWN
+    }
+
+    // A Flatpak cannot install anything for itself: the sandbox has no write
+    // access to /app and the manifest grants no talk-name for the host Flatpak
+    // service, so the update belongs to the user's store, not to this dialog.
+    actual val isSupported: Boolean
+        get() = currentOs != DesktopUpdaterOs.UNKNOWN && linuxInstallMethod != LinuxInstallMethod.FLATPAK
 
     actual val releaseSource: AppUpdateReleaseSource = AppUpdateReleaseSource(
         owner = "NuvioMedia",
@@ -47,7 +59,7 @@ actual object AppUpdaterPlatform {
     )
 
     actual val assetSelector: AppUpdateAssetSelector
-        get() = currentOs.assetSelector
+        get() = currentOs.assetSelector(linuxInstallMethod)
 
     actual val currentVersionName: String = AppVersionConfig.DESKTOP_VERSION_NAME
 
@@ -139,7 +151,12 @@ actual object AppUpdaterPlatform {
         val command = when (currentOs) {
             DesktopUpdaterOs.WINDOWS -> windowsInstallerCommand(updateFile)
             DesktopUpdaterOs.MACOS -> listOf("open", updateFile.absolutePath)
-            DesktopUpdaterOs.LINUX -> listOf("xdg-open", updateFile.absolutePath)
+            DesktopUpdaterOs.LINUX -> linuxInstallerCommand(
+                method = linuxInstallMethod,
+                updateFile = updateFile,
+                appImagePath = System.getenv(appImageEnvName),
+                currentPid = ProcessHandle.current().pid(),
+            )
             DesktopUpdaterOs.UNKNOWN -> error("Desktop updates are not supported on this operating system.")
         }
         ProcessBuilder(command).start()
@@ -159,28 +176,27 @@ private enum class DesktopUpdaterOs {
     LINUX,
     UNKNOWN;
 
-    val assetSelector: AppUpdateAssetSelector
-        get() {
-            val archFragments = desktopArchitectureFragments()
-            return when (this) {
-                WINDOWS -> AppUpdateAssetSelector(
-                    fileExtensions = listOf(".msi", ".exe"),
-                    preferredNameFragments = archFragments + listOf("windows", "win"),
-                    fallbackNameFragments = listOf("universal", "all"),
-                )
-                MACOS -> AppUpdateAssetSelector(
-                    fileExtensions = listOf(".dmg", ".pkg"),
-                    preferredNameFragments = archFragments + listOf("macos", "mac", "darwin"),
-                    fallbackNameFragments = listOf("universal", "all"),
-                )
-                LINUX -> AppUpdateAssetSelector(
-                    fileExtensions = listOf(".deb", ".AppImage"),
-                    preferredNameFragments = archFragments + listOf("linux"),
-                    fallbackNameFragments = listOf("universal", "all"),
-                )
-                UNKNOWN -> AppUpdateAssetSelector(fileExtensions = emptyList())
-            }
+    fun assetSelector(linuxInstallMethod: LinuxInstallMethod): AppUpdateAssetSelector {
+        val archFragments = desktopArchitectureFragments()
+        return when (this) {
+            WINDOWS -> AppUpdateAssetSelector(
+                fileExtensions = listOf(".msi", ".exe"),
+                preferredNameFragments = archFragments + listOf("windows", "win"),
+                fallbackNameFragments = listOf("universal", "all"),
+            )
+            MACOS -> AppUpdateAssetSelector(
+                fileExtensions = listOf(".dmg", ".pkg"),
+                preferredNameFragments = archFragments + listOf("macos", "mac", "darwin"),
+                fallbackNameFragments = listOf("universal", "all"),
+            )
+            LINUX -> AppUpdateAssetSelector(
+                fileExtensions = linuxUpdateFileExtensions(linuxInstallMethod),
+                preferredNameFragments = archFragments + listOf("linux"),
+                fallbackNameFragments = listOf("universal", "all"),
+            )
+            UNKNOWN -> AppUpdateAssetSelector(fileExtensions = emptyList())
         }
+    }
 
     companion object {
         fun current(): DesktopUpdaterOs {
@@ -212,3 +228,130 @@ internal fun windowsInstallerCommand(updateFile: File): List<String> {
 
     return listOf("msiexec", "/i", updateFile.absolutePath)
 }
+
+internal enum class LinuxInstallMethod {
+    APP_IMAGE,
+    FLATPAK,
+    RPM,
+    DEB,
+    UNKNOWN,
+}
+
+internal const val appImageEnvName = "APPIMAGE"
+private const val flatpakIdEnvName = "FLATPAK_ID"
+private const val flatpakInfoPath = "/.flatpak-info"
+private const val jpackageAppPathProperty = "jpackage.app-path"
+private const val javaExecutableName = "java"
+private const val packageQueryTimeoutSeconds = 3L
+private const val appImageExitWaitTicks = 100
+
+// A release carries every Linux format at once, so the extension list has to be
+// the one the running install can actually consume. An unresolved install keeps
+// the previous list, leaving source and tarball builds no worse off than before.
+internal fun linuxUpdateFileExtensions(method: LinuxInstallMethod): List<String> = when (method) {
+    LinuxInstallMethod.APP_IMAGE -> listOf(".AppImage")
+    LinuxInstallMethod.RPM -> listOf(".rpm")
+    LinuxInstallMethod.DEB -> listOf(".deb")
+    LinuxInstallMethod.FLATPAK -> emptyList()
+    LinuxInstallMethod.UNKNOWN -> listOf(".deb", ".AppImage")
+}
+
+internal fun resolveLinuxInstallMethod(
+    appImagePath: String?,
+    appImageExists: Boolean,
+    flatpakId: String?,
+    flatpakInfoExists: Boolean,
+    launcherPath: String?,
+    isOwnedByRpm: (String) -> Boolean,
+    isOwnedByDpkg: (String) -> Boolean,
+): LinuxInstallMethod {
+    if (!appImagePath.isNullOrBlank() && appImageExists) return LinuxInstallMethod.APP_IMAGE
+    if (!flatpakId.isNullOrBlank() || flatpakInfoExists) return LinuxInstallMethod.FLATPAK
+
+    val path = launcherPath?.takeIf { it.isNotBlank() } ?: return LinuxInstallMethod.UNKNOWN
+    if (isOwnedByRpm(path)) return LinuxInstallMethod.RPM
+    if (isOwnedByDpkg(path)) return LinuxInstallMethod.DEB
+    return LinuxInstallMethod.UNKNOWN
+}
+
+private fun detectLinuxInstallMethod(): LinuxInstallMethod {
+    val appImagePath = System.getenv(appImageEnvName)
+    return resolveLinuxInstallMethod(
+        appImagePath = appImagePath,
+        appImageExists = !appImagePath.isNullOrBlank() && File(appImagePath).exists(),
+        flatpakId = System.getenv(flatpakIdEnvName),
+        flatpakInfoExists = File(flatpakInfoPath).exists(),
+        launcherPath = linuxLauncherPath(),
+        isOwnedByRpm = { path -> packageQuerySucceeds(listOf("rpm", "-qf", path)) },
+        isOwnedByDpkg = { path -> packageQuerySucceeds(listOf("dpkg", "-S", path)) },
+    )
+}
+
+private fun linuxLauncherPath(): String? = linuxLauncherPathFrom(
+    jpackageAppPath = System.getProperty(jpackageAppPathProperty),
+    processCommand = ProcessHandle.current().info().command().orElse(null),
+)
+
+// jpackage records the launcher it started, which is the only path that belongs
+// to this app's package. Without it the process command is the JVM itself, and
+// the JVM belongs to the distribution's own java package -- asking rpm or dpkg
+// who owns that would report a packaged install that is not Nuvio, so a source
+// or tarball run is left unresolved instead.
+internal fun linuxLauncherPathFrom(
+    jpackageAppPath: String?,
+    processCommand: String?,
+): String? {
+    jpackageAppPath?.takeIf { it.isNotBlank() }?.let { return it }
+
+    return processCommand?.takeIf { it.isNotBlank() && File(it).name != javaExecutableName }
+}
+
+private fun packageQuerySucceeds(command: List<String>): Boolean = runCatching {
+    val process = ProcessBuilder(command)
+        .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+        .redirectError(ProcessBuilder.Redirect.DISCARD)
+        .start()
+    if (!process.waitFor(packageQueryTimeoutSeconds, TimeUnit.SECONDS)) {
+        process.destroyForcibly()
+        return@runCatching false
+    }
+    process.exitValue() == 0
+}.getOrDefault(false)
+
+internal fun linuxInstallerCommand(
+    method: LinuxInstallMethod,
+    updateFile: File,
+    appImagePath: String?,
+    currentPid: Long,
+): List<String> {
+    if (method == LinuxInstallMethod.APP_IMAGE && !appImagePath.isNullOrBlank()) {
+        return listOf("sh", "-c", appImageReplaceScript(updateFile.absolutePath, appImagePath, currentPid))
+    }
+
+    return listOf("xdg-open", updateFile.absolutePath)
+}
+
+// An AppImage has no installer: updating one means replacing the file that is
+// running. The copy waits for this process to exit first, both because the
+// running image is still mounted from that file and because a half-written one
+// would leave nothing to start. When the image sits somewhere this user cannot
+// write, the download is handed to the desktop rather than failing in silence.
+internal fun appImageReplaceScript(
+    downloadedPath: String,
+    appImagePath: String,
+    currentPid: Long,
+): String {
+    val downloaded = singleQuote(downloadedPath)
+    val target = singleQuote(appImagePath)
+    return buildString {
+        append("i=0; ")
+        append("while [ \$i -lt $appImageExitWaitTicks ] && kill -0 $currentPid 2>/dev/null; do ")
+        append("sleep 0.1; i=\$((i+1)); ")
+        append("done; ")
+        append("if cp -f -- $downloaded $target; then ")
+        append("chmod +x -- $target; rm -f -- $downloaded; exec $target; ")
+        append("else xdg-open $downloaded; fi")
+    }
+}
+
+private fun singleQuote(value: String): String = "'" + value.replace("'", "'\\''") + "'"

--- a/composeApp/src/desktopTest/kotlin/com/nuvio/app/features/updater/LinuxUpdateInstallTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/nuvio/app/features/updater/LinuxUpdateInstallTest.kt
@@ -1,0 +1,242 @@
+package com.nuvio.app.features.updater
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class LinuxUpdateInstallTest {
+
+    // The asset names of a real release, in the order the GitHub API returns them.
+    private val releaseAssets = listOf(
+        asset("Nuvio-Linux-x86_64-0.1.22-alpha.AppImage"),
+        asset("Nuvio-Linux-x86_64-0.1.22-alpha.AppImage.zsync"),
+        asset("Nuvio-Linux-x86_64-0.1.22-alpha.deb"),
+        asset("Nuvio-Linux-x86_64-0.1.22-alpha.flatpak"),
+        asset("Nuvio-Linux-x86_64-0.1.22-alpha.rpm"),
+        asset("Nuvio-macOS-arm64-0.1.22-alpha.dmg"),
+        asset("Nuvio-macOS-x86_64-0.1.22-alpha.dmg"),
+        asset("Nuvio-Windows-x64-0.1.22-alpha.msi"),
+    )
+
+    @Test
+    fun `rpm install is offered the rpm asset`() {
+        assertEquals(
+            "Nuvio-Linux-x86_64-0.1.22-alpha.rpm",
+            selectFor(LinuxInstallMethod.RPM)?.name,
+        )
+    }
+
+    @Test
+    fun `deb install is offered the deb asset`() {
+        assertEquals(
+            "Nuvio-Linux-x86_64-0.1.22-alpha.deb",
+            selectFor(LinuxInstallMethod.DEB)?.name,
+        )
+    }
+
+    @Test
+    fun `app image install is offered the image itself and never its zsync file`() {
+        assertEquals(
+            "Nuvio-Linux-x86_64-0.1.22-alpha.AppImage",
+            selectFor(LinuxInstallMethod.APP_IMAGE)?.name,
+        )
+    }
+
+    @Test
+    fun `app image env wins over every other marker`() {
+        val method = resolveLinuxInstallMethod(
+            appImagePath = "/home/user/Apps/Nuvio.AppImage",
+            appImageExists = true,
+            flatpakId = "com.nuvio.media.desktop",
+            flatpakInfoExists = true,
+            launcherPath = "/opt/Nuvio/bin/Nuvio",
+            isOwnedByRpm = { true },
+            isOwnedByDpkg = { true },
+        )
+
+        assertEquals(LinuxInstallMethod.APP_IMAGE, method)
+    }
+
+    @Test
+    fun `a stale app image path does not claim the install`() {
+        val method = resolveLinuxInstallMethod(
+            appImagePath = "/home/user/Apps/deleted.AppImage",
+            appImageExists = false,
+            flatpakId = null,
+            flatpakInfoExists = false,
+            launcherPath = "/opt/Nuvio/bin/Nuvio",
+            isOwnedByRpm = { true },
+            isOwnedByDpkg = { false },
+        )
+
+        assertEquals(LinuxInstallMethod.RPM, method)
+    }
+
+    @Test
+    fun `flatpak is recognised from its sandbox marker file alone`() {
+        val method = resolveLinuxInstallMethod(
+            appImagePath = null,
+            appImageExists = false,
+            flatpakId = null,
+            flatpakInfoExists = true,
+            launcherPath = "/app/opt/Nuvio/bin/Nuvio",
+            isOwnedByRpm = { false },
+            isOwnedByDpkg = { false },
+        )
+
+        assertEquals(LinuxInstallMethod.FLATPAK, method)
+    }
+
+    @Test
+    fun `dpkg ownership is only consulted when rpm does not claim the launcher`() {
+        var rpmQueried = false
+        var dpkgQueried = false
+
+        val method = resolveLinuxInstallMethod(
+            appImagePath = null,
+            appImageExists = false,
+            flatpakId = null,
+            flatpakInfoExists = false,
+            launcherPath = "/opt/Nuvio/bin/Nuvio",
+            isOwnedByRpm = { rpmQueried = true; false },
+            isOwnedByDpkg = { dpkgQueried = true; true },
+        )
+
+        assertEquals(LinuxInstallMethod.DEB, method)
+        assertTrue(rpmQueried)
+        assertTrue(dpkgQueried)
+    }
+
+    @Test
+    fun `an unknown launcher is never handed to a package manager`() {
+        var queried = false
+
+        val method = resolveLinuxInstallMethod(
+            appImagePath = null,
+            appImageExists = false,
+            flatpakId = null,
+            flatpakInfoExists = false,
+            launcherPath = null,
+            isOwnedByRpm = { queried = true; true },
+            isOwnedByDpkg = { queried = true; true },
+        )
+
+        assertEquals(LinuxInstallMethod.UNKNOWN, method)
+        assertFalse(queried)
+    }
+
+    @Test
+    fun `the jpackage launcher is preferred over the process command`() {
+        assertEquals(
+            "/opt/nuvio/bin/Nuvio",
+            linuxLauncherPathFrom(
+                jpackageAppPath = "/opt/nuvio/bin/Nuvio",
+                processCommand = "/usr/lib/jvm/java-17-openjdk/bin/java",
+            ),
+        )
+    }
+
+    // rpm -qf answers for the distribution's own java package, so trusting the
+    // JVM path would report a source run as a packaged install.
+    @Test
+    fun `a jvm process command is not treated as the installed launcher`() {
+        assertNull(
+            linuxLauncherPathFrom(
+                jpackageAppPath = null,
+                processCommand = "/usr/lib/jvm/java-17-openjdk/bin/java",
+            ),
+        )
+    }
+
+    @Test
+    fun `a real launcher process command is still used when jpackage is silent`() {
+        assertEquals(
+            "/opt/nuvio/bin/Nuvio",
+            linuxLauncherPathFrom(
+                jpackageAppPath = "   ",
+                processCommand = "/opt/nuvio/bin/Nuvio",
+            ),
+        )
+    }
+
+    @Test
+    fun `an unresolved install keeps the previous asset list`() {
+        assertEquals(
+            listOf(".deb", ".AppImage"),
+            linuxUpdateFileExtensions(LinuxInstallMethod.UNKNOWN),
+        )
+    }
+
+    @Test
+    fun `a package install is handed to the desktop package handler`() {
+        val command = linuxInstallerCommand(
+            method = LinuxInstallMethod.RPM,
+            updateFile = File("/tmp/updates/Nuvio.rpm"),
+            appImagePath = null,
+            currentPid = 4242L,
+        )
+
+        assertEquals(listOf("xdg-open", "/tmp/updates/Nuvio.rpm"), command)
+    }
+
+    @Test
+    fun `an app image replaces itself once this process is gone`() {
+        val command = linuxInstallerCommand(
+            method = LinuxInstallMethod.APP_IMAGE,
+            updateFile = File("/tmp/updates/Nuvio.AppImage"),
+            appImagePath = "/home/user/Apps/Nuvio.AppImage",
+            currentPid = 4242L,
+        )
+
+        assertEquals("sh", command[0])
+        assertEquals("-c", command[1])
+        val script = command[2]
+        assertTrue(script.contains("kill -0 4242"))
+        assertTrue(script.contains("cp -f -- '/tmp/updates/Nuvio.AppImage' '/home/user/Apps/Nuvio.AppImage'"))
+        assertTrue(script.contains("exec '/home/user/Apps/Nuvio.AppImage'"))
+        assertTrue(script.contains("else xdg-open '/tmp/updates/Nuvio.AppImage'"))
+    }
+
+    @Test
+    fun `an app image with no known path falls back to the desktop handler`() {
+        val command = linuxInstallerCommand(
+            method = LinuxInstallMethod.APP_IMAGE,
+            updateFile = File("/tmp/updates/Nuvio.AppImage"),
+            appImagePath = null,
+            currentPid = 4242L,
+        )
+
+        assertEquals(listOf("xdg-open", "/tmp/updates/Nuvio.AppImage"), command)
+    }
+
+    @Test
+    fun `a quote in the app image path cannot break out of the script`() {
+        val script = appImageReplaceScript(
+            downloadedPath = "/tmp/updates/Nuvio.AppImage",
+            appImagePath = "/home/user/Ar'jun/Nuvio.AppImage",
+            currentPid = 7L,
+        )
+
+        assertTrue(script.contains("'/home/user/Ar'\\''jun/Nuvio.AppImage'"))
+        assertFalse(script.contains("Ar'jun"))
+    }
+
+    private fun selectFor(method: LinuxInstallMethod): AppUpdateAssetCandidate? =
+        selectBestUpdateAsset(
+            assets = releaseAssets,
+            selector = AppUpdateAssetSelector(
+                fileExtensions = linuxUpdateFileExtensions(method),
+                preferredNameFragments = listOf("x64", "x86_64", "amd64", "linux"),
+                fallbackNameFragments = listOf("universal", "all"),
+            ),
+        )
+
+    private fun asset(name: String): AppUpdateAssetCandidate =
+        AppUpdateAssetCandidate(
+            name = name,
+            downloadUrl = "https://example.test/$name",
+        )
+}


### PR DESCRIPTION
## Summary

The Linux updater only looked for `.deb` and `.AppImage` assets, but a release publishes `.deb`, `.rpm`, `.flatpak` and `.AppImage` together. On an RPM install it picked the AppImage, handed it to `xdg-open` and exited, so nothing was installed. The app now resolves which package format it was installed from and uses it for both the asset choice and the install step.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Reported in #574: on Fedora with the release RPM, the update runs but the app stays on the old version.

I reproduced it on a clean Fedora 44 container with the shipped `0.1.22-alpha` RPM installed, running the real `/opt/nuvio/bin/Nuvio` launcher. The updater reports:

```
jpackage.app-path=/opt/nuvio/bin/Nuvio
isSupported=true
fileExtensions=[.deb, .AppImage]
```

With `.rpm` and `.flatpak` absent from that list, `selectBestUpdateAsset` matches the AppImage, `launchInstaller` runs `xdg-open` on it, and `scheduleAppExit` closes the app 500ms later. Opening an AppImage does not install anything, so the RPM install is untouched. The same happens for Flatpak users, and a `.deb` handed to a distribution that cannot consume it fails the same way.

## Desktop scope

Linux only. `AppUpdaterPlatform.desktop.kt` is desktop code and every change sits behind `DesktopUpdaterOs.LINUX`; the Windows and macOS branches and the shared `selectBestUpdateAsset` ranking are untouched. No `commonMain` change.

## Issue or approval

Fixes #574

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

The updater is also reported as unsupported inside a Flatpak, since a sandboxed app cannot install a package for itself: there is no write access to `/app`, and `scripts/linux/nuvio-flatpak.yml` grants no talk-name for the host Flatpak service. That hides an action that could not succeed rather than offering Flatpak users a `.deb`. Happy to drop that part into a separate PR if you would rather keep the entry visible.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- No change to Windows or macOS behaviour, and no change to the shared asset ranking in `AppUpdater.kt`.
- No change to the release workflows or the packaging scripts.
- An install whose format cannot be resolved keeps the previous `.deb`/`.AppImage` list, so source and tarball builds behave exactly as before.
- No new dependencies. Detection uses `rpm`/`dpkg` only if they are present, with a 3s timeout each and any failure treated as "unresolved".
- No UI, string or settings change.

## Testing

Built an RPM from this branch, versioned `0.1.21`, using the same steps as `desktop-release.yml` (Ubuntu 24.04, Temurin 17, `:composeApp:packageReleaseRpm`), then tested on Fedora 44 with the official `0.1.22-alpha` RPM as the update target.

Before, on the shipped `0.1.22-alpha` RPM install:

```
fileExtensions=[.deb, .AppImage]
```

After, on the `0.1.21` build from this branch, printed by the app's own updater running through the installed launcher:

```
jpackage.app-path=/opt/nuvio/bin/Nuvio
isSupported=true
fileExtensions=[.rpm]
```

- `rpm -qf /opt/nuvio/bin/Nuvio` resolves to `nuvio-1.1.21-1.x86_64`, which is the query the detection makes.
- Installing the official `0.1.22-alpha` RPM over it upgrades cleanly: `Upgrading: 1 package`, `replacing nuvio 1.1.21-1`, ending on `nuvio-1.1.22-1.x86_64`.
- AppImage self-replace exercised against real files: the helper waits for the app process to exit, replaces the target, keeps it executable, removes the download and starts the new version. With an unwritable target it leaves the file alone and calls `xdg-open` on the download instead.
- `:composeApp:desktopTest` — 143 suites, 875 tests, 0 failures. 16 of those are new in `LinuxUpdateInstallTest`, covering detection precedence, the unresolved fallback, installer commands, and quoting.

Not tested: the desktop handler step itself, i.e. `xdg-open` opening Discover or GNOME Software for the downloaded package. That call is unchanged; only the file handed to it differs.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #574
