### PR TITLE
fix(subtitles): keep language list fully scrollable

### DIFF
--- a/composeApp/src/desktopMain/resources/player-ui/controls.css
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.css
@@ -2050,7 +2050,7 @@ button:disabled {
 .subtitle-rails {
   display: grid;
   grid-template-columns: 200px 300px;
-  align-items: start;
+  align-items: stretch;
   gap: 14px;
   max-width: 100%;
   overflow-x: auto;
@@ -2068,6 +2068,7 @@ button:disabled {
 
 .subtitle-rail {
   min-width: 0;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   gap: 8px;


### PR DESCRIPTION
## Summary

Fix the desktop subtitle language rail so its final entries can scroll fully into view above the player controls.

- Stretch both subtitle rails to the height already constrained by the player overlay.
- Allow each rail's flex container to shrink so the inner list owns vertical scrolling.

## PR type

- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

The subtitle rail grid is correctly bounded above the playback controls, but `align-items: start` lets each rail retain its intrinsic content height. The language list therefore overflows the grid's clipped boundary, leaving its final row partially hidden behind the playback controls even at maximum scroll.

Stretching the rail items to the grid's constrained height and allowing the flex containers to shrink keeps the list inside that boundary. The list can then scroll its final language row completely into view.

## Desktop scope

This changes the shared desktop player web UI under `desktopMain`, so it applies to the Windows, macOS, and Linux desktop overlays. Issue #587 was reported on Windows 11. The corrected layout and packaged application were runtime-tested on macOS arm64; Windows and Linux were not runtime-tested. Android and iOS are unchanged.

## Issue or approval

Fixes #587

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

This PR only changes the vertical sizing and overflow behavior of the existing desktop subtitle rails. It does not change subtitle selection, language ordering or labels, subtitle data, rail styling, audio tracks, playback controls, mobile UI, dependencies, or unrelated player behavior.

## Testing

- Ran `./gradlew :composeApp:desktopTest :composeApp:packageDmg -Pcompose.desktop.packaging.checkJdkVendor=false --no-configuration-cache` on macOS arm64 with JDK 17: 859 tests passed and the DMG build succeeded.
- Ran the real desktop player HTML/CSS at the issue's 1920×1020 viewport with 20 synthetic language rows. At maximum scroll, the final row remained fully within the list and 18.4 px above the playback timeline.
- Confirmed the packaged desktop JAR contains the corrected rail constraints and launched the packaged macOS app.
- Ran `hdiutil verify` on the generated DMG successfully.
- Ran `codesign --verify --deep --strict --verbose=2` on the generated app successfully. This local package uses an ad hoc signature; it is not a Developer ID-signed or notarized release artifact.
- Windows and Linux were not runtime-tested.

## Screenshots / Video

Before:

![Subtitle language list clipped behind the player controls](https://github.com/user-attachments/assets/c3e4e443-62ee-44a0-8043-ed918157bb01)

After:

<img width="1404" height="1020" alt="Subtitle language list scrolled fully above the player controls" src="https://github.com/user-attachments/assets/23b299ac-b5fd-426f-b9e1-21eb92365e4a" />

## Breaking changes

None.

## Linked issues

Fixes #587
