### PR TITLE
fix(home): scale entire continue watching card on desktop hover

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/components/HomeContinueWatchingSection.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/components/HomeContinueWatchingSection.kt
@@ -685,6 +685,12 @@ private fun ContinueWatchingCard(
 
     Box(
         modifier = Modifier
+            .posterCardClickable(
+                onClick = onClick,
+                onLongClick = onLongClick,
+                zoomImageUrl = imageUrl,
+                zoomCornerRadius = cardMetrics.cornerRadius,
+            )
             .width(cardMetrics.width)
             .aspectRatio(PosterLandscapeAspectRatio)
             .clip(RoundedCornerShape(cardMetrics.cornerRadius))
@@ -692,12 +698,6 @@ private fun ContinueWatchingCard(
             .nuvioCardDepth(
                 shape = RoundedCornerShape(cardMetrics.cornerRadius),
                 surface = NuvioCardDepthSurface.ContinueWatching,
-            )
-            .posterCardClickable(
-                onClick = onClick,
-                onLongClick = onLongClick,
-                zoomImageUrl = imageUrl,
-                zoomCornerRadius = cardMetrics.cornerRadius,
             ),
     ) {
         if (imageUrl != null) {


### PR DESCRIPTION
## Summary

Fixes the hover animation on Continue Watching landscape cards so the entire card scales up smoothly (1.05x) and elevates above neighboring cards, consistent with all other desktop catalog cards (`NuvioPosterCard`, `CollectionCard`, `ContinueWatchingWideCard`, etc.).

Previously, `.clip(RoundedCornerShape(...))` was chained before `.posterCardClickable(...)`, trapping the hover `graphicsLayer` scale inside the unscaled card boundaries. As a result, hovering would zoom and crop the inner image rather than scaling the entire card. Moving `.posterCardClickable(...)` to the start of the modifier chain allows the entire card to expand on hover.

## PR type

- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

In the desktop Continue Watching row, hovering over landscape cards resulted in the inner artwork zooming in place while the card frame remained stationary. All other cards across the app grow outwards when hovered. Placing `.posterCardClickable(...)` before `.clip()` fixes the modifier execution order so the card scales as expected.

## Desktop scope

Desktop app (`commonMain` layout component `ContinueWatchingLandscapeCard`). Affects Windows, macOS, and Linux desktop builds where desktop hover scaling is enabled. On touch-based mobile devices, `desktopPosterHoverScale` is a no-op (`if (!isDesktop) return this`).

## Issue or approval

Fixes #599

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Only modifies modifier chaining on `ContinueWatchingLandscapeCard` in `HomeContinueWatchingSection.kt`.
- Does not modify any other card components or layouts.
- Does not alter click handling, badge placement, or progress bar logic.

## Testing

- Tested on Windows 11 x64 desktop.
- Verified on local build (`Nuvio.exe`): hovering over Continue Watching landscape cards now smoothly expands the entire card (1.05x) and elevates above adjacent cards.
- Verified click and long-press interactions still trigger properly.
- Confirmed touch interaction on mobile remains unaffected.

## Screenshots / Video

Verified on desktop: Continue Watching landscape cards smoothly scale up the whole card container on mouse hover instead of zooming the inner image inside a stationary frame.
<img width="1338" height="286" alt="image" src="https://github.com/user-attachments/assets/273717d6-c997-4c99-9e78-c0e166f36c79" />
<img width="1285" height="315" alt="image" src="https://github.com/user-attachments/assets/a3f63523-5719-4f44-a807-3e2229938be7" />


## Breaking changes

None.

## Linked issues

Fixes #599
