### PR TITLE
fix(desktop): Fix speed boost not working when payback paused and refactor code

### DIFF
--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -2559,7 +2559,10 @@ window.addEventListener("blur", () => {
   clearPressedButton();
   syncChromeAutoHideTimer(isOpeningOverlayActive());
   clearSpeedBoostTimers();
-  if (isHoldSpeedActive || isSpaceBoosting || isSpeedBoosting) preventClickAndStopSpeedBoost();
+  if (isHoldSpeedActive || isSpaceBoosting || isSpeedBoosting) {
+    suppressNextRootClick = true;
+    stopSpeedBoost();
+  }
 });
 
 document.querySelectorAll("[data-command]").forEach(button => {

--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -2558,18 +2558,8 @@ window.addEventListener("blur", () => {
   isChromeFocusInside = false;
   clearPressedButton();
   syncChromeAutoHideTimer(isOpeningOverlayActive());
-  if (speedBoostHoldTimer) {
-    window.clearTimeout(speedBoostHoldTimer);
-    speedBoostHoldTimer = null;
-  }
-  if (spaceHoldTimer) {
-    window.clearTimeout(spaceHoldTimer);
-    spaceHoldTimer = null;
-  }
-  if (isHoldSpeedActive || isSpaceBoosting || isSpeedBoosting) {
-    suppressNextRootClick = true;
-    stopSpeedBoost();
-  }
+  clearSpeedBoostTimers();
+  if (isHoldSpeedActive || isSpaceBoosting || isSpeedBoosting) preventClickAndStopSpeedBoost();
 });
 
 document.querySelectorAll("[data-command]").forEach(button => {
@@ -3062,6 +3052,44 @@ let rootPointerStartX = 0;
 let rootPointerStartY = 0;
 let spaceHoldTimer = null;
 let isSpaceBoosting = false;
+let pausedBeforeSpeedBoosting = false;
+
+const clearSpeedBoostHoldTimer = () => {
+  if (speedBoostHoldTimer) {
+    window.clearTimeout(speedBoostHoldTimer);
+    speedBoostHoldTimer = null;
+  }
+}
+
+const clearSpaceHoldTimer = () => {
+  if (spaceHoldTimer) {
+    window.clearTimeout(spaceHoldTimer);
+    spaceHoldTimer = null;
+  }
+}
+
+const clearSpeedBoostTimers = () => {
+  clearSpeedBoostHoldTimer();
+  clearSpaceHoldTimer();
+}
+
+const preventClickAndStopSpeedBoost = () => {
+  if (isHoldSpeedActive) {
+    suppressNextRootClick = true;
+    isHoldSpeedActive = false;
+    stopSpeedBoost();
+  }
+}
+
+const clearSpaceHoldTimerAndStopSpeedBoost = () => {
+  clearSpaceHoldTimer();
+  if (isSpaceBoosting || isSpeedBoosting) {
+    isSpaceBoosting = false;
+    stopSpeedBoost();
+    return true;
+  }
+  return false;
+}
 
 const startSpeedBoost = () => {
   if (isSpeedBoosting) return;
@@ -3071,25 +3099,26 @@ const startSpeedBoost = () => {
     const currentSpeedNum = parseFloat(currentSpeedStr.replace("x", "")) || 1.0;
     preSpeedBoostRate = currentSpeedNum === 2.0 ? 1.0 : currentSpeedNum;
   }
+  if (!state.isPlaying) {
+    pausedBeforeSpeedBoosting = true;
+    requestPlaybackState("setPlaybackStateQuiet", false);
+  }
   showPlayerToast("2x", { icon: "icon-speed", persistent: true });
   send("setPlaybackSpeed", 2.0);
 };
 
 const stopSpeedBoost = () => {
-  if (speedBoostHoldTimer) {
-    window.clearTimeout(speedBoostHoldTimer);
-    speedBoostHoldTimer = null;
-  }
-  if (spaceHoldTimer) {
-    window.clearTimeout(spaceHoldTimer);
-    spaceHoldTimer = null;
-  }
+  clearSpeedBoostTimers();
   if (!isSpeedBoosting) return;
   isSpeedBoosting = false;
   isHoldSpeedActive = false;
   isSpaceBoosting = false;
   const restoreSpeed = preSpeedBoostRate != null ? preSpeedBoostRate : 1.0;
   preSpeedBoostRate = null;
+  if (pausedBeforeSpeedBoosting) {
+    pausedBeforeSpeedBoosting = false;
+    requestPlaybackState("setPlaybackStateQuiet", false);
+  }
   send("setPlaybackSpeed", restoreSpeed);
   hidePlayerToast();
 };
@@ -3107,7 +3136,7 @@ root.addEventListener("pointerdown", event => {
   isHoldSpeedActive = false;
   suppressNextRootClick = false;
 
-  if (speedBoostHoldTimer) window.clearTimeout(speedBoostHoldTimer);
+  clearSpeedBoostHoldTimer();
   speedBoostHoldTimer = window.setTimeout(() => {
     isHoldSpeedActive = true;
     suppressNextRootClick = true;
@@ -3119,35 +3148,18 @@ window.addEventListener("pointermove", event => {
   if (speedBoostHoldTimer && !isHoldSpeedActive) {
     const dx = Math.abs(event.clientX - rootPointerStartX);
     const dy = Math.abs(event.clientY - rootPointerStartY);
-    if (dx > 12 || dy > 12) {
-      window.clearTimeout(speedBoostHoldTimer);
-      speedBoostHoldTimer = null;
-    }
+    if (dx > 12 || dy > 12) clearSpeedBoostHoldTimer();
   }
 });
 
 window.addEventListener("pointerup", () => {
-  if (speedBoostHoldTimer) {
-    window.clearTimeout(speedBoostHoldTimer);
-    speedBoostHoldTimer = null;
-  }
-  if (isHoldSpeedActive) {
-    suppressNextRootClick = true;
-    isHoldSpeedActive = false;
-    stopSpeedBoost();
-  }
+  clearSpeedBoostHoldTimer();
+  preventClickAndStopSpeedBoost();
 });
 
 window.addEventListener("pointercancel", () => {
-  if (speedBoostHoldTimer) {
-    window.clearTimeout(speedBoostHoldTimer);
-    speedBoostHoldTimer = null;
-  }
-  if (isHoldSpeedActive) {
-    suppressNextRootClick = true;
-    isHoldSpeedActive = false;
-    stopSpeedBoost();
-  }
+  clearSpeedBoostHoldTimer();
+  preventClickAndStopSpeedBoost();
 });
 
 root.addEventListener("click", event => {
@@ -3195,26 +3207,11 @@ root.addEventListener("wheel", event => {
 
 document.addEventListener("keyup", event => {
   if (event.key === "Alt" || event.key === "Control" || event.key === "Meta" || event.metaKey || event.ctrlKey || event.altKey) {
-    if (spaceHoldTimer) {
-      window.clearTimeout(spaceHoldTimer);
-      spaceHoldTimer = null;
-    }
-    if (isSpaceBoosting || isSpeedBoosting) {
-      isSpaceBoosting = false;
-      stopSpeedBoost();
-    }
+    clearSpaceHoldTimerAndStopSpeedBoost();
     return;
   }
   if (event.code === "Space") {
-    if (spaceHoldTimer) {
-      window.clearTimeout(spaceHoldTimer);
-      spaceHoldTimer = null;
-    }
-    if (isSpaceBoosting || isSpeedBoosting) {
-      isSpaceBoosting = false;
-      stopSpeedBoost();
-      return;
-    }
+    if (clearSpaceHoldTimerAndStopSpeedBoost()) return;
     if (event.metaKey || event.ctrlKey || event.altKey) return;
     if (activeModal || isTextEntryTarget(event.target)) return;
     event.preventDefault();
@@ -3226,28 +3223,14 @@ document.addEventListener("keyup", event => {
 
 document.addEventListener("keydown", event => {
   if (event.key === "Escape" && activeModal) {
-    if (spaceHoldTimer) {
-      window.clearTimeout(spaceHoldTimer);
-      spaceHoldTimer = null;
-    }
-    if (isSpaceBoosting || isSpeedBoosting) {
-      isSpaceBoosting = false;
-      stopSpeedBoost();
-    }
+    clearSpaceHoldTimerAndStopSpeedBoost();
     event.preventDefault();
     closePlayerModal(true);
     focusShortcutRoot();
     return;
   }
   if (event.key === "Escape") {
-    if (spaceHoldTimer) {
-      window.clearTimeout(spaceHoldTimer);
-      spaceHoldTimer = null;
-    }
-    if (isSpaceBoosting || isSpeedBoosting) {
-      isSpaceBoosting = false;
-      stopSpeedBoost();
-    }
+    clearSpaceHoldTimerAndStopSpeedBoost();
     event.preventDefault();
     if (state.isFullscreen) {
       togglePlayerFullscreen();
@@ -3259,28 +3242,14 @@ document.addEventListener("keydown", event => {
   if (playbackErrorText()) return;
   const isMacFullscreenShortcut = event.code === "KeyF" && event.metaKey && event.ctrlKey && !event.altKey;
   if (event.code === "F11" || isMacFullscreenShortcut) {
-    if (spaceHoldTimer) {
-      window.clearTimeout(spaceHoldTimer);
-      spaceHoldTimer = null;
-    }
-    if (isSpaceBoosting || isSpeedBoosting) {
-      isSpaceBoosting = false;
-      stopSpeedBoost();
-    }
+    clearSpaceHoldTimerAndStopSpeedBoost();
     event.preventDefault();
     focusShortcutRoot();
     togglePlayerFullscreen();
     return;
   }
   if (event.metaKey || event.ctrlKey || event.altKey || event.key === "Alt" || event.key === "Control" || event.key === "Meta") {
-    if (spaceHoldTimer) {
-      window.clearTimeout(spaceHoldTimer);
-      spaceHoldTimer = null;
-    }
-    if (isSpaceBoosting || isSpeedBoosting) {
-      isSpaceBoosting = false;
-      stopSpeedBoost();
-    }
+    clearSpaceHoldTimerAndStopSpeedBoost();
     return;
   }
   if (activeModal || isTextEntryTarget(event.target)) {
@@ -3295,7 +3264,7 @@ document.addEventListener("keydown", event => {
       }
       return;
     }
-    if (spaceHoldTimer) window.clearTimeout(spaceHoldTimer);
+    clearSpaceHoldTimer();
     isSpaceBoosting = false;
     spaceHoldTimer = window.setTimeout(() => {
       isSpaceBoosting = true;


### PR DESCRIPTION
## Summary

- If playback was paused before activating speed boost, start stream so speed boost can work. When speed boost is turned off, pause stream.
- Added couple of functions to deal with duplicate code.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Youtube supports this feature, so it would be nice for Nuvio to support it as well, since it now has speed boost.
Great foundation for this already exists. It was only missing `requestPlaybackState("setPlaybackStateQuiet", false)` call before speed boost if playback is paused.
I asked quiettinkerer if they wanted to fix this and since they ignored me, I posted fix myself. I also refactored code since there is a lot of duplicate code. If you want me to change commit to only include fix, I can do that.

## Desktop scope

Desktop shared code

## Issue or approval

Fixes #604 

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

Only changed `controls.js` from desktop shared code.

## Testing

- Tested only on Windows 11
- Tested holding LMB/Space while playback is paused
- Tested all stuff I touched with refactor (Escape/Alt/Ctrl key cancel, speed boost cancel if user moves mouse before 220ms timer, start/stop boost, cancel when window changes) both while playback is active and paused
- Tested if everything resets when reopening stream or changing episode

## Screenshots / Video


https://github.com/user-attachments/assets/8374a74b-cba1-47de-ba13-a2c8b2c940b0



## Breaking changes

None

## Linked issues

Fix #604 
