### PR TITLE
fix(desktop): toggle fullscreen on plain F

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
@@ -6,8 +6,20 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isAltPressed
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.Modifier
 import org.jetbrains.compose.resources.painterResource
 import androidx.compose.ui.window.Window
@@ -45,6 +57,10 @@ import javax.swing.JComponent
 private val NuvioDesktopNativeBackground = AwtColor(0x0D, 0x0D, 0x0D)
 private const val MacosDarkAquaAppearance = "NSAppearanceNameDarkAqua"
 
+// Belt-and-suspenders: only the `decoration:` Window overload is experimental in CMP 1.11.1,
+// so this opt-in is currently unused — kept so a dependency upgrade can't turn this call
+// site into a compile error. Safe to drop if the compiler ever flags it as unnecessary.
+@OptIn(ExperimentalComposeUiApi::class)
 fun main(args: Array<String>) {
     // On Linux, initialize GTK BEFORE AWT/Compose/Skia to prevent GdkDisplayManager
     // type registration conflict (Skiko partially loads GDK without full GTK init).
@@ -114,6 +130,10 @@ fun main(args: Array<String>) {
             placement = initialPlacement,
         )
         val fullscreenController = remember { DesktopAppFullscreenController() }
+        var lastPlainFToggleNs by remember { mutableLongStateOf(0L) }
+        // AWT host window stash: Window's onKeyEvent lambda runs in the caller's scope,
+        // where the FrameWindowScope `window` isn't visible, so content keeps it updated.
+        val hostWindow = remember { mutableStateOf<java.awt.Window?>(null) }
 
         Window(
             onCloseRequest = {
@@ -122,11 +142,34 @@ fun main(args: Array<String>) {
                 SentryInitializer.close()
                 exitApplication()
             },
+            // Plain-F fullscreen toggle (YouTube-style). Window-scope onKeyEvent fires only
+            // for events the content didn't consume, so typing "f" in a focused search box
+            // still types and never reaches here. Unlike a root-modifier handler, this also
+            // fires when no Compose node holds focus. F11 and Cmd+Ctrl+F keep working via
+            // installDesktopAppFullscreenShortcuts.
+            onKeyEvent = { event ->
+                if (event.type != KeyEventType.KeyDown) return@Window false
+                if (event.key != Key.F) return@Window false
+                if (event.isMetaPressed || event.isCtrlPressed || event.isAltPressed || event.isShiftPressed) {
+                    return@Window false
+                }
+                val host = hostWindow.value ?: return@Window false
+                // Guard against key auto-repeat strobing fullscreen on/off.
+                val now = System.nanoTime()
+                if (now - lastPlainFToggleNs < 400_000_000L) return@Window true
+                lastPlainFToggleNs = now
+                fullscreenController.toggle(host, windowState)
+                DesktopWindowModeStorage.saveWasFullscreen(
+                    fullscreenController.isFullscreen(host, windowState),
+                )
+                true
+            },
             title = if (smokePlayerUrl == null) "Nuvio" else "Nuvio Player Smoke",
             state = windowState,
             icon = painterResource(appIconState.selected.transparentPreviewResource),
         ) {
             SideEffect {
+                hostWindow.value = window
                 window.background = NuvioDesktopNativeBackground
                 window.rootPane.background = NuvioDesktopNativeBackground
                 window.contentPane.background = NuvioDesktopNativeBackground


### PR DESCRIPTION
## Summary

Binds plain `F` (no modifiers) to the existing desktop fullscreen toggle in the Compose `Window(onKeyEvent = ...)` scope in `Main.kt`, complementing the plain-F binding in the player webview that already landed via #594 (see controls.js on `Dev`). No other behavior touched.

**Note on scope change:** this PR originally also bound plain `F` inside the player webview (`controls.js`). That half was merged independently via #594, so after rebasing on `Dev` this PR now contains only the `Main.kt` window-level handler — the part still uncovered by #594: `F` works outside the player (library/home screens) and when no Compose node holds focus.

## PR type

- [x] Behavior bug/regression fix

## Why

Pressing `F` in the desktop app did nothing outside the player webview, while every major video player (YouTube, VLC, IINA) and mpv itself — which Nuvio's player is built on — toggles fullscreen on `F`. The desktop shell swallows a key its own engine binds by default, so this restores intended fullscreen/keyboard behavior app-wide.

## Desktop scope

macOS desktop app (verified on macOS arm64). `Main.kt` is shared desktop shell code: the window-level binding applies to the whole app window. No Android/iOS code touched, no changes to `controls.js` in this PR.

## Issue or approval

Fixes #607

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Intentionally not changed: `F11` and `Cmd+Ctrl+F` bindings, `Shift+F` (rejected for parity), the player webview `controls.js` plain-F binding (already merged via #594), `DesktopAppFullscreen.kt` dispatcher, Windows native emulation, signing/packaging, any visual styling.

## Testing

- `./gradlew :composeApp:compileKotlinDesktop` → BUILD SUCCESSFUL, zero errors (Temurin JDK 17.0.20.1, macOS arm64), against latest `Dev` including #594.
- Manual (macOS arm64): `F` toggles fullscreen on library/home/player; `f` still types in search boxes; modal open = no-op; hold-`F` = single toggle (400 ms debounce); `F` on fresh launch before any click toggles; `F11` and `Cmd+Ctrl+F` regressed OK; plain `F` inside the player continues to work via the #594 webview binding.

Proof video (posted in comments): stock build (`F` does nothing) vs this build (`F` toggles fullscreen on macOS arm64).

## Breaking changes

None.

## Linked issues

Fixes #607
