### PR TITLE
fix(desktop): Restore IMDB logo with rating to Desktop detail

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/components/DesktopDetailHero.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/components/DesktopDetailHero.kt
@@ -2,6 +2,7 @@ package com.nuvio.app.features.details.components
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -48,10 +49,13 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.nuvio.app.core.build.AppFeaturePolicy
 import com.nuvio.app.core.ui.NuvioAsyncImage as AsyncImage
 import com.nuvio.app.core.ui.NuvioDesktopImageScaling
 import com.nuvio.app.core.ui.NuvioTokens
@@ -65,6 +69,7 @@ import com.nuvio.app.core.ui.isFullscreenActionSupported
 import com.nuvio.app.core.ui.WideDesktopViewportAspectRatio
 import com.nuvio.app.features.details.MetaDetails
 import com.nuvio.app.features.details.formatRuntimeForDisplay
+import com.nuvio.app.features.mdblist.MdbListMetadataService.PROVIDER_IMDB
 import com.nuvio.app.features.tmdb.originalTmdbImageUrl
 import nuvio.composeapp.generated.resources.Res
 import nuvio.composeapp.generated.resources.detail_logo_content_description
@@ -72,6 +77,9 @@ import nuvio.composeapp.generated.resources.hero_add_to_library
 import nuvio.composeapp.generated.resources.hero_mark_unwatched
 import nuvio.composeapp.generated.resources.hero_mark_watched
 import nuvio.composeapp.generated.resources.hero_remove_from_library
+import nuvio.composeapp.generated.resources.rating_imdb
+import nuvio.composeapp.generated.resources.source_imdb
+import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -389,6 +397,9 @@ private fun DesktopHeroMetaRow(meta: MetaDetails) {
         desktopSeasonCountLabel(meta)?.let(::add)
         formatRuntimeForDisplay(meta.runtime)?.let(::add)
     }
+    val hasMdbImdbRating = meta.externalRatings.any { it.source == PROVIDER_IMDB }
+    val validImdbRating = meta.imdbRating
+        ?.takeIf { raw -> raw.toDoubleOrNull()?.let { it > 0.0 } == true }
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(space.s16),
@@ -426,5 +437,48 @@ private fun DesktopHeroMetaRow(meta: MetaDetails) {
                 )
             }
         }
+        if (validImdbRating != null && !hasMdbImdbRating) {
+            val imdbTextStyle = MaterialTheme.typography.titleSmall.copy(
+                fontWeight = FontWeight.Bold,
+                letterSpacing = 0.sp,
+            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                ImdbRatingSourceLabel(
+                    storeTextStyle = imdbTextStyle,
+                    storeTextColor = ImdbYellow,
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    text = validImdbRating,
+                    style = imdbTextStyle,
+                    color = ImdbYellow,
+                )
+            }
+        }
     }
 }
+
+@Composable
+private fun ImdbRatingSourceLabel(
+    storeTextStyle: TextStyle,
+    storeTextColor: Color,
+) {
+    if (AppFeaturePolicy.imdbRatingLogoEnabled) {
+        Image(
+            painter = painterResource(Res.drawable.rating_imdb),
+            contentDescription = stringResource(Res.string.source_imdb),
+            modifier = Modifier.size(width = 30.dp, height = 16.dp),
+        )
+    } else {
+        Text(
+            text = stringResource(Res.string.source_imdb),
+            style = storeTextStyle,
+            color = storeTextColor,
+            maxLines = 1,
+        )
+    }
+}
+
+private val ImdbYellow = Color(0xFFF5C518)


### PR DESCRIPTION
## Summary

- Added IMDB rating to `DesktopHeroMetaRow` in `DesktopDetailHero` to copy Mobile look
- If MDBList integration is active, rating doesn't show

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

While Desktop closely follows Mobile, sometimes it uses different components. In this case, Desktop uses `DesktopHeroMetaRow` instead of `DetailMetaInfo`, and that's why IMDB rating was missing, because it was never added to `DesktopHeroMetaRow`.

I took parts from `DetailMetaInfo` and `DetailRatingsRow` (which is displayed on Desktop) and combined them in one. Rating should look exactly like it does when MDBList integration is active, except it sits at top, next to age badge.

## Desktop scope

While `DesktopDetailHero` is only used for Desktop, scope is global, since it's part of common components.

## Issue or approval

Fixes #592 

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

Only changed `DesktopDetailHero` thus only changing desktop, even though it's shared code.

## Testing

- Tested by resizing from 1920x1080 to small box, when rating gets hidden (it follows guidelines from `DetailRatingsRow`, it should look good on bigger screens also)
- Tested movies and series
- Tested unreleased movie/series without IMDB rating
- Tested look of IMDB logo when `AppFeaturePolicy.imdbRatingLogoEnabled` is false
- Tested movies/series while having MDBList integration active

## Screenshots / Video

Movie with IMDB logo
<img width="1919" height="1079" alt="with IMDB logo" src="https://github.com/user-attachments/assets/8d302656-c483-4efb-992f-64c09f0cb096" />
Tv series with IMDB logo
<img width="1919" height="1079" alt="Tv series with IMDB logo" src="https://github.com/user-attachments/assets/7ebafe13-fc81-44f0-8204-1594175c8b51" />
Movie with no IMDB rating
<img width="1919" height="1079" alt="Movie with no IMDB rating" src="https://github.com/user-attachments/assets/5e1e1854-ed86-4883-bf54-52154c125a52" />
Movie with IMDB logo disabled
<img width="1919" height="1079" alt="No IMDB logo" src="https://github.com/user-attachments/assets/753603d9-8b20-4fc3-a3fd-357d5f3c1b38" />
Movie while MDBList integration is active
<img width="1919" height="1079" alt="with MDB list integration" src="https://github.com/user-attachments/assets/90727041-8f0b-4220-a658-6acb23a108a5" />


## Breaking changes

None

## Linked issues

Fix #592 
