### PR TITLE
Fix incomplete TorBox cache responses

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/debrid/LocalDebridService.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/debrid/LocalDebridService.kt
@@ -31,16 +31,7 @@ internal object LocalDebridService {
     ): Map<String, LocalDebridCachedItem>? =
         try {
             val response = TorboxApiClient.checkCached(apiKey = apiKey, hashes = hashes)
-            if (!response.isSuccessful || response.body?.success == false) {
-                null
-            } else {
-                response.body?.data.orEmpty().mapKeys { it.key.lowercase() }.mapValues { (_, value) ->
-                    LocalDebridCachedItem(
-                        name = value.name,
-                        size = value.size,
-                    )
-                }
-            }
+            torboxCachedItems(response)
         } catch (error: Exception) {
             if (error is CancellationException) throw error
             null
@@ -79,4 +70,20 @@ internal object LocalDebridService {
 private fun kotlinx.serialization.json.JsonElement?.asLongOrNull(): Long? {
     val primitive = this as? JsonPrimitive ?: return null
     return primitive.longOrNull ?: primitive.content.toLongOrNull()
+}
+
+internal fun torboxCachedItems(
+    response: DebridApiResponse<TorboxEnvelopeDto<Map<String, TorboxCachedItemDto>>>,
+): Map<String, LocalDebridCachedItem>? {
+    if (!response.isSuccessful) return null
+    val body = response.body ?: return null
+    if (body.success != true) return null
+    val data = body.data ?: return null
+
+    return data.mapKeys { it.key.lowercase() }.mapValues { (_, value) ->
+        LocalDebridCachedItem(
+            name = value.name,
+            size = value.size,
+        )
+    }
 }

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/debrid/LocalDebridServiceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/debrid/LocalDebridServiceTest.kt
@@ -1,0 +1,76 @@
+package com.nuvio.app.features.debrid
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class LocalDebridServiceTest {
+    @Test
+    fun `maps valid Torbox cache response and normalizes hashes`() {
+        val response = torboxResponse(
+            data = mapOf(
+                "ABC123" to TorboxCachedItemDto(
+                    name = "Movie.2026.mkv",
+                    size = 1234L,
+                ),
+            ),
+        )
+
+        assertEquals(
+            mapOf(
+                "abc123" to LocalDebridCachedItem(
+                    name = "Movie.2026.mkv",
+                    size = 1234L,
+                ),
+            ),
+            torboxCachedItems(response),
+        )
+    }
+
+    @Test
+    fun `maps valid empty Torbox cache response to no cached items`() {
+        assertEquals(emptyMap(), torboxCachedItems(torboxResponse(data = emptyMap())))
+    }
+
+    @Test
+    fun `rejects successful HTTP response with missing Torbox envelope`() {
+        val response = DebridApiResponse<TorboxEnvelopeDto<Map<String, TorboxCachedItemDto>>>(
+            status = 200,
+            body = null,
+            rawBody = "not-json",
+        )
+
+        assertNull(torboxCachedItems(response))
+    }
+
+    @Test
+    fun `rejects Torbox success response with missing cache data`() {
+        assertNull(torboxCachedItems(torboxResponse(data = null)))
+    }
+
+    @Test
+    fun `rejects unsuccessful Torbox response`() {
+        val response = DebridApiResponse(
+            status = 503,
+            body = TorboxEnvelopeDto<Map<String, TorboxCachedItemDto>>(
+                success = false,
+                data = emptyMap(),
+            ),
+            rawBody = "",
+        )
+
+        assertNull(torboxCachedItems(response))
+    }
+
+    private fun torboxResponse(
+        data: Map<String, TorboxCachedItemDto>?,
+    ): DebridApiResponse<TorboxEnvelopeDto<Map<String, TorboxCachedItemDto>>> =
+        DebridApiResponse(
+            status = 200,
+            body = TorboxEnvelopeDto(
+                success = true,
+                data = data,
+            ),
+            rawBody = "",
+        )
+}


### PR DESCRIPTION
## Summary

Validate TorBox cache-check envelopes before mapping their data. A successful HTTP response with an undecodable body, missing success confirmation, or missing `data` now follows the existing unknown/error path instead of becoming an authoritative empty cache result.

Adds focused common-code regression coverage for valid cached data, valid empty data, a missing envelope, missing cache data, and an unsuccessful response.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

`response.body?.data.orEmpty()` cannot distinguish a valid empty TorBox cache result from a response that could not be decoded or omitted its `data` field. Both become an empty map, which downstream availability annotation interprets as every requested hash being definitively uncached. Those streams are then hidden.

The existing nullable result already represents an unknown/API-failure state, so incomplete envelopes should use that path.

## Desktop scope

This changes shared debrid code used by the desktop stream-loading and playback flows on Windows, macOS, and Linux. No platform-specific or mobile-only code is changed.

## Issue or approval

Fixes #613

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

This does not add retries, caching, batching, UI changes, dependencies, or unrelated debrid changes. A valid `success=true` response with an empty `data` object continues to mean no hashes are cached.

## Testing

Executed with Temurin Java 17 on Linux:

```shell
./gradlew :composeApp:desktopTest \
  --tests 'com.nuvio.app.features.debrid.*' \
  -x :composeMediaPlayer:buildNativeLinux \
  -x :composeApp:buildLinuxPlayerBridge \
  --no-daemon --console=plain
```

Result: `BUILD SUCCESSFUL`; 41 tests, 0 skipped, 0 failures, 0 errors.

The native media-player build tasks were excluded because the test environment does not contain the optional Linux multimedia development SDKs; the changed common code and all debrid tests compiled and ran on the desktop JVM target.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #613
