### PR TITLE
feat (Desktop): Add ability to boost volume beyond 100% using keyboard/mouse wheel

### DIFF
--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -490,7 +490,6 @@ const settingToastLabel = command => {
 };
 
 const maxVolumeLevel = 2;
-const standardMaxVolumeLevel = 1;
 const volumeStepLevel = 0.05;
 
 const clampVolumeLevel = level => Math.max(0, Math.min(maxVolumeLevel, level));
@@ -2436,14 +2435,8 @@ const sendKeyboardVolume = delta => {
   const currentLevel = typeof state.volumeLevel === "number" && Number.isFinite(state.volumeLevel)
     ? state.volumeLevel
     : 1;
-  if (delta > 0 && currentLevel >= standardMaxVolumeLevel) {
-    showPlayerToast(volumeToastLabel(delta));
-    return;
-  }
   const adjustedLevel = currentLevel + (delta * volumeStepLevel);
-  const nextLevel = delta > 0
-    ? Math.min(standardMaxVolumeLevel, clampVolumeLevel(adjustedLevel))
-    : clampVolumeLevel(adjustedLevel);
+  const nextLevel = clampVolumeLevel(adjustedLevel);
   state.volumeLevel = nextLevel;
   if (nextLevel > 0) {
     preMuteVolumeLevel = nextLevel;


### PR DESCRIPTION
## Summary

Changed default behavior of volume boost PR to allow volume boost using keyboard/mouse wheel

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Judging by Discord, this is a controversial topic.
At first I was against it, but after checking out MPV and VLC players, they both have this behaviour by default, where user can go beyond 100% freely and without being alerted.

## Desktop scope

Desktop shared code

## Issue or approval

Fixes #618 

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

Does not include extra UI polish. Only changed default behavior of volume booster.

## Testing

- Tested changing volume using wheel and keyboard
- Tested changing volume using mouse
- Tested min and max volume and if you can go beyond those limits
- Tested if volume is remembered when unmuting
- Tested if volume is remembered when reopening stream

## Screenshots / Video

Sorry about video missing sound.

https://github.com/user-attachments/assets/d45d5a7f-aac4-4dab-8ac4-cb517491653d



## Breaking changes

None

## Linked issues

Fix #618 
