### PR TITLE
fix(discord): show 'Watching <title>' instead of 'Playing Nuvio'

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/AppPresenceState.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/AppPresenceState.kt
@@ -25,5 +25,6 @@ internal sealed interface PresenceSnapshot {
         val posterUrl: String?,
         val isPlaying: Boolean,
         val positionMs: Long,
+        val durationMs: Long,
     ) : PresenceSnapshot
 }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
@@ -74,6 +74,7 @@ internal fun PlayerScreenRuntime.RenderPlayerRuntimeUi() {
                 posterUrl = runtime.poster,
                 isPlaying = playbackSnapshot.isPlaying,
                 positionMs = playbackSnapshot.positionMs,
+                durationMs = playbackSnapshot.durationMs,
             ),
         )
     }

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/discordrpc/DiscordActivity.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/discordrpc/DiscordActivity.kt
@@ -5,6 +5,14 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 internal data class DiscordActivity(
+    // Discord activity type: 0 = Playing, 2 = Listening, 3 = Watching, 5 = Competing.
+    // Sending 3 makes Discord show "Watching …" instead of the default "Playing …".
+    val type: Int = 0,
+    // Top line rendered under the username ("<verb> <name>"). When omitted, Discord uses the
+    // name of the application registered to the client id ("Nuvio"). Recent Discord clients honor
+    // a custom name here so the media title shows directly under the pseudo; older clients ignore
+    // it and fall back to the app name (that is why the title is also kept in `details`).
+    val name: String? = null,
     val details: String? = null,
     val state: String? = null,
     val timestamps: DiscordActivityTimestamps? = null,
@@ -14,6 +22,8 @@ internal data class DiscordActivity(
 @Serializable
 internal data class DiscordActivityTimestamps(
     val start: Long? = null,
+    // When both start and end are set, Discord renders a live progress bar with time remaining.
+    val end: Long? = null,
 )
 
 @Serializable

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/discordrpc/DiscordPresenceManager.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/discordrpc/DiscordPresenceManager.kt
@@ -89,15 +89,25 @@ private fun String.toDiscordEpisodeLabel(): String {
 private fun PresenceSnapshot.toDiscordActivity(): DiscordActivity = when (this) {
     is PresenceSnapshot.Tab -> DiscordActivity(details = "Browsing ${tab.name}")
     is PresenceSnapshot.Details -> DiscordActivity(details = "Viewing $title")
-    is PresenceSnapshot.Player -> DiscordActivity(
-        details = if (isPlaying) "Watching: $title" else "Paused: $title",
-        state = episodeLabel?.toDiscordEpisodeLabel() ?: if (isPlaying) "Watching" else "Paused",
-        timestamps = if (isPlaying) {
-            // Discord expects Unix timestamps in seconds, not milliseconds.
-            DiscordActivityTimestamps(start = (System.currentTimeMillis() - positionMs) / 1_000L)
-        } else {
-            null
-        },
-        assets = posterUrl?.let { DiscordActivityAssets(largeImage = it, largeText = title) },
-    )
+    is PresenceSnapshot.Player -> {
+        val episode = episodeLabel?.toDiscordEpisodeLabel()
+        // Discord expects Unix timestamps in seconds, not milliseconds.
+        val startSecs = (System.currentTimeMillis() - positionMs) / 1_000L
+        DiscordActivity(
+            type = 3, // Watching -> "Watching …" instead of the default "Playing …" (game).
+            name = title, // Show the media title under the pseudo when the client honors it.
+            details = title, // Always keep the title here as a fallback for clients that ignore `name`.
+            state = if (isPlaying) episode else episode?.let { "$it • Paused" } ?: "Paused",
+            timestamps = if (isPlaying) {
+                // start + end -> Discord renders a live progress bar with time remaining.
+                DiscordActivityTimestamps(
+                    start = startSecs,
+                    end = if (durationMs > 0L) startSecs + durationMs / 1_000L else null,
+                )
+            } else {
+                null
+            },
+            assets = posterUrl?.let { DiscordActivityAssets(largeImage = it, largeText = title) },
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the desktop Discord Rich Presence showing "Playing Nuvio" with a game icon while watching. It now shows the media title with the Watching activity type, plus a progress bar.

## PR type

- [x] Behavior bug/regression fix

## Why

The Discord presence never set an activity `type`, so Discord fell back to type `0` (Playing) and displayed "Playing Nuvio" with a game icon during playback, instead of what the user is watching. Reported in #591.

## Desktop scope

Windows/macOS/Linux desktop. The change is in the desktop-only `discordrpc` code; one shared field (`durationMs`) was added to the desktop player presence snapshot in `commonMain` to feed the progress bar, and is only consumed by the desktop Discord presence.

## Issue or approval

Fixes #591

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the Discord Rich Presence payload is changed (activity `type`, `name`, `details`/`state`, and an `end` timestamp). No player, UI, or app behavior is touched beyond the presence shown to Discord. No new dependencies.

## Testing

Built the Windows desktop app from this branch and watched a show and a movie with Rich Presence enabled:
- Discord now shows "Watching <title>" (the title on the line under the username, e.g. "Breaking Bad") instead of "Playing Nuvio", with no game icon.
- Details show the title; series show the episode as "S1, E2: …"; movies omit the episode.
- A progress bar with time remaining is shown while playing, and disappears when paused (state then shows "Paused").
- Poster still shown as the large image.

Note on client behavior: recent Discord clients render the custom `name` on the top line; older clients ignore it and fall back to the app name, in which case the title is still visible via `details`.

## Screenshots / Video

Not a UI change (the app UI is unchanged; only the external Discord presence card changes).
<img width="208" height="46" alt="image" src="https://github.com/user-attachments/assets/15735042-a947-47cc-9efd-6727aa69fb7f" />
<img width="284" height="98" alt="image" src="https://github.com/user-attachments/assets/40c7accf-55c4-42fd-8dfb-81823ea10c2f" />

## Breaking changes

None.

## Linked issues

Fixes #591