### PR TITLE
feat(Shortcuts): add quick tab switching and activate search box shortcuts.

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/MainAppContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/MainAppContent.kt
@@ -403,7 +403,15 @@ internal fun MainAppContent(
                 liquidGlassNativeTabBarEnabled
             ) {
                 handleRootTabClick(requestedAppTab)
+            } else if (!useNativeNavigation && isDesktop) {
+                handleRootTabClick(requestedAppTab)
             }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        NativeTabBridge.focusSearchRequests.collectLatest {
+            searchFocusRequestCount++
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/MainAppContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/MainAppContent.kt
@@ -416,9 +416,6 @@ internal fun MainAppContent(
     }
 
     LaunchedEffect(Unit) {
-        // Esc and Backspace both funnel through NativeTabBridge.requestBack() (see
-        // Main.kt), so they reuse this exact same "go back" call as the mouse
-        // Back button below.
         NativeTabBridge.backRequests.collectLatest {
             navController.popBackStack()
         }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/MainAppContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/MainAppContent.kt
@@ -415,6 +415,15 @@ internal fun MainAppContent(
         }
     }
 
+    LaunchedEffect(Unit) {
+        // Esc and Backspace both funnel through NativeTabBridge.requestBack() (see
+        // Main.kt), so they reuse this exact same "go back" call as the mouse
+        // Back button below.
+        NativeTabBridge.backRequests.collectLatest {
+            navController.popBackStack()
+        }
+    }
+
     LaunchedEffect(
         nativeTabHomeTitle,
         nativeTabSearchTitle,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/MainAppContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/MainAppContent.kt
@@ -416,8 +416,20 @@ internal fun MainAppContent(
     }
 
     LaunchedEffect(Unit) {
+        // Esc and Backspace both funnel through NativeTabBridge.requestBack() (see
+        // Main.kt), so they reuse this exact same "go back" call as the mouse
+        // Back button below.
         NativeTabBridge.backRequests.collectLatest {
-            navController.popBackStack()
+            // Settings' sub-page navigation (e.g. Playback -> Root) is local
+            // composable state, not part of navBackStack, so popBackStack() has
+            // nothing to pop while sitting on the tab bar with Settings selected.
+            // Route through the same "step back one level" flow used when the
+            // Settings tab is reselected instead.
+            if (selectedTab == AppScreenTab.Settings && currentRoute is TabsRoute) {
+                settingsRootActionRequests.tryEmit(Unit)
+            } else {
+                navController.popBackStack()
+            }
         }
     }
 
@@ -1269,7 +1281,11 @@ internal fun MainAppContent(
                                     if (!event.changes.any { it.isConsumed }) {
                                         if (event.button == PointerButton.Back) {
                                             event.changes.forEach { it.consume() }
-                                            navController.popBackStack()
+                                            if (selectedTab == AppScreenTab.Settings && currentRoute is TabsRoute) {
+                                                settingsRootActionRequests.tryEmit(Unit)
+                                            } else {
+                                                navController.popBackStack()
+                                            }
                                         }
                                     }
                                 }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/Components.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/Components.kt
@@ -368,7 +368,9 @@ fun NuvioInputField(
     OutlinedTextField(
         value = value,
         onValueChange = onValueChange,
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .trackTextInputFocusForShortcutGuard(),
         singleLine = true,
         shape = RoundedCornerShape(NuvioTokens.Radius.lg),
         placeholder = {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/NativeTabBridge.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/NativeTabBridge.kt
@@ -36,8 +36,18 @@ internal object NativeTabBridge {
     private val _requestedTabs = MutableSharedFlow<NativeNavigationTab>(extraBufferCapacity = 1)
     val requestedTabs: SharedFlow<NativeNavigationTab> = _requestedTabs.asSharedFlow()
 
+    private val _focusSearchRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val focusSearchRequests: SharedFlow<Unit> = _focusSearchRequests.asSharedFlow()
+
+    var isSearchBoxFocused: Boolean = false
+
     fun requestTab(tabName: String) {
         _requestedTabs.tryEmit(NativeNavigationTab.fromName(tabName))
+    }
+
+    fun requestSearchWithFocus() {
+        requestTab("Search")
+        _focusSearchRequests.tryEmit(Unit)
     }
 
     fun publishSelectedTab(tab: NativeNavigationTab) {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/NativeTabBridge.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/NativeTabBridge.kt
@@ -39,6 +39,9 @@ internal object NativeTabBridge {
     private val _focusSearchRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val focusSearchRequests: SharedFlow<Unit> = _focusSearchRequests.asSharedFlow()
 
+    private val _backRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val backRequests: SharedFlow<Unit> = _backRequests.asSharedFlow()
+
     var isSearchBoxFocused: Boolean = false
 
     fun requestTab(tabName: String) {
@@ -48,6 +51,10 @@ internal object NativeTabBridge {
     fun requestSearchWithFocus() {
         requestTab("Search")
         _focusSearchRequests.tryEmit(Unit)
+    }
+
+    fun requestBack() {
+        _backRequests.tryEmit(Unit)
     }
 
     fun publishSelectedTab(tab: NativeNavigationTab) {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/NativeTabBridge.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/NativeTabBridge.kt
@@ -42,10 +42,13 @@ internal object NativeTabBridge {
     private val _backRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val backRequests: SharedFlow<Unit> = _backRequests.asSharedFlow()
 
-    // Set by any Compose text input (not just the Search tab's box) when it gains or
-    // loses focus, so the desktop window's global key shortcuts (see Main.kt) know to
-    // stand down while the user is typing anywhere in the app.
-    var isTextInputFocused: Boolean = false
+    // Set by the Search tab's input box when it gains or loses focus, so the desktop
+    // window's global key shortcuts (see Main.kt) know to stand down while the user is
+    // typing there. NOTE: this only covers the Search box — it is not a general
+    // "any text field is focused" signal. Other text inputs elsewhere in the app do not
+    // set this, which is why Main.kt's shortcut list is kept to bindings that are safe
+    // even when an untracked text field has focus.
+    var isSearchBoxFocused: Boolean = false
 
     fun requestTab(tabName: String) {
         _requestedTabs.tryEmit(NativeNavigationTab.fromName(tabName))

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/NativeTabBridge.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/NativeTabBridge.kt
@@ -42,7 +42,10 @@ internal object NativeTabBridge {
     private val _backRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val backRequests: SharedFlow<Unit> = _backRequests.asSharedFlow()
 
-    var isSearchBoxFocused: Boolean = false
+    // Set by any Compose text input (not just the Search tab's box) when it gains or
+    // loses focus, so the desktop window's global key shortcuts (see Main.kt) know to
+    // stand down while the user is typing anywhere in the app.
+    var isTextInputFocused: Boolean = false
 
     fun requestTab(tabName: String) {
         _requestedTabs.tryEmit(NativeNavigationTab.fromName(tabName))

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/NativeTabBridge.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/NativeTabBridge.kt
@@ -1,5 +1,10 @@
 package com.nuvio.app.core.ui
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import com.nuvio.app.features.profiles.AvatarRepository
 import com.nuvio.app.features.profiles.AvatarCatalogItem
 import com.nuvio.app.features.profiles.MAX_PROFILES
@@ -42,13 +47,28 @@ internal object NativeTabBridge {
     private val _backRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val backRequests: SharedFlow<Unit> = _backRequests.asSharedFlow()
 
-    // Set by the Search tab's input box when it gains or loses focus, so the desktop
-    // window's global key shortcuts (see Main.kt) know to stand down while the user is
-    // typing there. NOTE: this only covers the Search box — it is not a general
-    // "any text field is focused" signal. Other text inputs elsewhere in the app do not
-    // set this, which is why Main.kt's shortcut list is kept to bindings that are safe
-    // even when an untracked text field has focus.
-    var isSearchBoxFocused: Boolean = false
+    // Tokens for every text input that currently has focus, anywhere in the app. Using a
+    // set of per-field tokens (rather than a single boolean owned by one screen) means any
+    // number of text inputs — search, settings, addon URL, server URL, etc. — can report
+    // their own focus state independently without clobbering each other, and a field that
+    // leaves the composition while still focused (e.g. navigating away mid-edit) is
+    // guaranteed to clear itself via DisposableEffect instead of leaving the guard stuck on.
+    private val focusedTextInputTokens = mutableSetOf<Any>()
+
+    // True whenever ANY text input anywhere in the app currently has focus. Desktop's
+    // global keyboard shortcuts (1-4, /, 0, Esc — see Main.kt / installDesktopNavigationShortcuts)
+    // must stand down while this is true, or typing into any field would trigger navigation
+    // instead of entering the typed character.
+    val isAnyTextInputFocused: Boolean
+        get() = focusedTextInputTokens.isNotEmpty()
+
+    fun setTextInputFocused(token: Any, focused: Boolean) {
+        if (focused) {
+            focusedTextInputTokens.add(token)
+        } else {
+            focusedTextInputTokens.remove(token)
+        }
+    }
 
     fun requestTab(tabName: String) {
         _requestedTabs.tryEmit(NativeNavigationTab.fromName(tabName))
@@ -210,6 +230,22 @@ class NativeProfileSwitcherController {
 
 fun nativeTabSelect(tabName: String) {
     NativeTabBridge.requestTab(tabName)
+}
+
+// Attach to any text input's Modifier chain to register its focus state with the global
+// shortcut guard (NativeTabBridge.isAnyTextInputFocused). Unlike a bare
+// `.onFocusChanged { NativeTabBridge.isSearchBoxFocused = it.isFocused }`, this also clears
+// itself automatically if the field is disposed while still focused, so the guard can never
+// get stuck "on" after navigating away from a focused field.
+@Composable
+fun Modifier.trackTextInputFocusForShortcutGuard(): Modifier {
+    val token = remember { Any() }
+    DisposableEffect(token) {
+        onDispose { NativeTabBridge.setTextInputFocused(token, false) }
+    }
+    return this.onFocusChanged { state ->
+        NativeTabBridge.setTextInputFocused(token, state.isFocused)
+    }
 }
 
 internal expect fun isLiquidGlassNativeTabBarSupported(): Boolean

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/search/SearchScreen.kt
@@ -279,7 +279,7 @@ fun SearchScreen(
                             placeholder = stringResource(Res.string.compose_search_placeholder),
                             modifier = Modifier
                                 .focusRequester(focusRequester)
-                                .onFocusChanged { NativeTabBridge.isTextInputFocused = it.isFocused }
+                                .onFocusChanged { NativeTabBridge.isSearchBoxFocused = it.isFocused }
                                 .onKeyEvent {
                                     if (it.type == KeyEventType.KeyDown && it.key == Key.Escape) {
                                         focusManager.clearFocus()

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/search/SearchScreen.kt
@@ -35,10 +35,18 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.text.font.FontWeight
+import com.nuvio.app.core.ui.NativeTabBridge
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.key.KeyEventType
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.nuvio.app.core.network.NetworkCondition
 import com.nuvio.app.core.network.NetworkStatusRepository
@@ -98,6 +106,7 @@ fun SearchScreen(
     scrollToTopRequests: Flow<Unit> = emptyFlow(),
 ) {
     val focusRequester = remember { FocusRequester() }
+    val focusManager = LocalFocusManager.current
 
     LaunchedEffect(searchFocusRequestCount) {
         if (searchFocusRequestCount > 0) {
@@ -268,7 +277,17 @@ fun SearchScreen(
                             value = query,
                             onValueChange = { query = it },
                             placeholder = stringResource(Res.string.compose_search_placeholder),
-                            modifier = Modifier.focusRequester(focusRequester),
+                            modifier = Modifier
+                                .focusRequester(focusRequester)
+                                .onFocusChanged { NativeTabBridge.isSearchBoxFocused = it.isFocused }
+                                .onKeyEvent {
+                                    if (it.type == KeyEventType.KeyDown && it.key == Key.Escape) {
+                                        focusManager.clearFocus()
+                                        true
+                                    } else {
+                                        false
+                                    }
+                                },
                             trailingContent = if (query.isNotBlank()) {
                                 {
                                     IconButton(onClick = { query = "" }) {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/search/SearchScreen.kt
@@ -35,9 +35,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.focus.onFocusChanged
+import com.nuvio.app.core.ui.trackTextInputFocusForShortcutGuard
 import androidx.compose.ui.text.font.FontWeight
-import com.nuvio.app.core.ui.NativeTabBridge
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -279,7 +278,7 @@ fun SearchScreen(
                             placeholder = stringResource(Res.string.compose_search_placeholder),
                             modifier = Modifier
                                 .focusRequester(focusRequester)
-                                .onFocusChanged { NativeTabBridge.isSearchBoxFocused = it.isFocused }
+                                .trackTextInputFocusForShortcutGuard()
                                 .onKeyEvent {
                                     if (it.type == KeyEventType.KeyDown && it.key == Key.Escape) {
                                         focusManager.clearFocus()

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/search/SearchScreen.kt
@@ -279,7 +279,7 @@ fun SearchScreen(
                             placeholder = stringResource(Res.string.compose_search_placeholder),
                             modifier = Modifier
                                 .focusRequester(focusRequester)
-                                .onFocusChanged { NativeTabBridge.isSearchBoxFocused = it.isFocused }
+                                .onFocusChanged { NativeTabBridge.isTextInputFocused = it.isFocused }
                                 .onKeyEvent {
                                     if (it.type == KeyEventType.KeyDown && it.key == Key.Escape) {
                                         focusManager.clearFocus()

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/SettingsSearch.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/SettingsSearch.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.nuvio.app.core.ui.NuvioTokens
 import com.nuvio.app.core.ui.nuvio
+import com.nuvio.app.core.ui.trackTextInputFocusForShortcutGuard
 import com.nuvio.app.isDesktop
 import com.nuvio.app.isIos
 import nuvio.composeapp.generated.resources.*
@@ -1129,7 +1130,9 @@ private fun SettingsSearchField(
     OutlinedTextField(
         value = query,
         onValueChange = onQueryChange,
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .trackTextInputFocusForShortcutGuard(),
         singleLine = true,
         shape = tokens.shapes.compactCard,
         leadingIcon = {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/SettingsSecretTextField.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/SettingsSecretTextField.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
+import com.nuvio.app.core.ui.trackTextInputFocusForShortcutGuard
 import nuvio.composeapp.generated.resources.Res
 import nuvio.composeapp.generated.resources.settings_hide_secret
 import nuvio.composeapp.generated.resources.settings_show_secret
@@ -37,7 +38,7 @@ internal fun SettingsSecretTextField(
     OutlinedTextField(
         value = value,
         onValueChange = onValueChange,
-        modifier = modifier,
+        modifier = modifier.trackTextInputFocusForShortcutGuard(),
         isError = isError,
         singleLine = true,
         label = { Text(label) },

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
@@ -136,7 +136,7 @@ fun main(args: Array<String>) {
             icon = painterResource(appIconState.selected.transparentPreviewResource),
             onKeyEvent = { event ->
                 if (event.type == KeyEventType.KeyDown) {
-                    if (NativeTabBridge.isSearchBoxFocused) return@Window false
+                    if (NativeTabBridge.isAnyTextInputFocused) return@Window false
                     // Plain-key shortcuts only: bail out on any modifier so combinations
                     // like Ctrl+1 or Alt+Escape aren't swallowed by these bindings.
                     if (event.isCtrlPressed || event.isAltPressed || event.isMetaPressed || event.isShiftPressed) {

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
@@ -41,6 +41,7 @@ import com.nuvio.app.features.player.desktop.applyNativeDesktopWindowChrome
 import com.nuvio.app.features.player.desktop.installDesktopAppFullscreenShortcuts
 import com.nuvio.app.features.player.desktop.preloadNativePlayerBridgeAsync
 import com.nuvio.app.features.player.desktop.registerDesktopAppFullscreenToggle
+import com.nuvio.app.features.player.desktop.trackMaximizedBoundsForCurrentScreen
 import com.nuvio.app.features.profiles.ProfileRepository
 import com.nuvio.app.features.settings.AppIconRepository
 import com.nuvio.app.features.settings.applyDesktopRendererPreference
@@ -135,9 +136,9 @@ fun main(args: Array<String>) {
             icon = painterResource(appIconState.selected.transparentPreviewResource),
             onKeyEvent = { event ->
                 if (event.type == KeyEventType.KeyDown) {
-                    if (NativeTabBridge.isTextInputFocused) return@Window false
+                    if (NativeTabBridge.isSearchBoxFocused) return@Window false
                     // Plain-key shortcuts only: bail out on any modifier so combinations
-                    // like Ctrl+1 or Alt+Backspace aren't swallowed by these bindings.
+                    // like Ctrl+1 or Alt+Escape aren't swallowed by these bindings.
                     if (event.isCtrlPressed || event.isAltPressed || event.isMetaPressed || event.isShiftPressed) {
                         return@Window false
                     }
@@ -147,9 +148,7 @@ fun main(args: Array<String>) {
                         Key.Three, Key.NumPad3 -> { NativeTabBridge.requestTab("Library"); true }
                         Key.Four, Key.NumPad4 -> { NativeTabBridge.requestTab("Settings"); true }
                         Key.Slash, Key.Zero, Key.NumPad0 -> { NativeTabBridge.requestSearchWithFocus(); true }
-                        // Backspace mirrors Esc here: both are the "go back" keybinding
-                        // (see ShortcutsSettingsPage), reusing the exact same trigger.
-                        Key.Escape, Key.Backspace -> { NativeTabBridge.requestBack(); true }
+                        Key.Escape -> { NativeTabBridge.requestBack(); true }
                         else -> false
                     }
                 } else false
@@ -179,16 +178,9 @@ fun main(args: Array<String>) {
                 fullscreenController.applyRestoredFullscreenState(window, windowState, wasFullscreenOnLastExit)
             }
             DisposableEffect(window) {
-                // On Windows, java.awt.Frame maximizes to the bounds of whichever screen it
-                // last computed maximizedBounds for, and does not recompute this automatically
-                // when the window is dragged to a different monitor. Without this, maximizing
-                // a window that was moved to a secondary display can snap it to the primary
-                // display's work area instead. Keep it current for the screen under the window.
-                val stopTracking = if (DesktopHostOs.current == DesktopHostOs.WINDOWS) {
-                    trackMaximizedBoundsForCurrentScreen(window)
-                } else {
-                    {}
-                }
+                // Windows multi-monitor maximize workaround — see DesktopMaximizedBounds.kt.
+                // (No-op on non-Windows: the helper checks the host OS itself.)
+                val stopTracking = window.trackMaximizedBoundsForCurrentScreen()
                 onDispose { stopTracking() }
             }
             LaunchedEffect(windowState) {
@@ -275,31 +267,6 @@ fun main(args: Array<String>) {
  * whenever it moves or resizes, so double-click-titlebar / Win+Up maximize always targets the
  * correct monitor. Returns a callback to stop tracking and remove the listener.
  */
-private fun trackMaximizedBoundsForCurrentScreen(window: java.awt.Window): () -> Unit {
-    val frame = window as? java.awt.Frame ?: return {}
-
-    fun applyBoundsForCurrentScreen() {
-        val config = frame.graphicsConfiguration ?: return
-        val screenBounds = config.bounds
-        val insets = runCatching { frame.toolkit.getScreenInsets(config) }
-            .getOrDefault(java.awt.Insets(0, 0, 0, 0))
-        frame.maximizedBounds = java.awt.Rectangle(
-            screenBounds.x + insets.left,
-            screenBounds.y + insets.top,
-            screenBounds.width - insets.left - insets.right,
-            screenBounds.height - insets.top - insets.bottom,
-        )
-    }
-
-    applyBoundsForCurrentScreen()
-    val listener = object : java.awt.event.ComponentAdapter() {
-        override fun componentMoved(e: java.awt.event.ComponentEvent) = applyBoundsForCurrentScreen()
-        override fun componentResized(e: java.awt.event.ComponentEvent) = applyBoundsForCurrentScreen()
-    }
-    frame.addComponentListener(listener)
-    return { frame.removeComponentListener(listener) }
-}
-
 private fun configureDesktopChrome() {
     if (System.getProperty("os.name").contains("mac", ignoreCase = true)) {
         System.setProperty("apple.awt.application.appearance", MacosDarkAquaAppearance)

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
@@ -22,6 +22,10 @@ import com.nuvio.app.core.ui.NuvioTheme
 import com.nuvio.app.features.discordrpc.DiscordPresenceManager
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isAltPressed
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
 import com.nuvio.app.core.ui.NativeTabBridge
@@ -131,7 +135,12 @@ fun main(args: Array<String>) {
             icon = painterResource(appIconState.selected.transparentPreviewResource),
             onKeyEvent = { event ->
                 if (event.type == KeyEventType.KeyDown) {
-                    if (NativeTabBridge.isSearchBoxFocused) return@Window false
+                    if (NativeTabBridge.isTextInputFocused) return@Window false
+                    // Plain-key shortcuts only: bail out on any modifier so combinations
+                    // like Ctrl+1 or Alt+Backspace aren't swallowed by these bindings.
+                    if (event.isCtrlPressed || event.isAltPressed || event.isMetaPressed || event.isShiftPressed) {
+                        return@Window false
+                    }
                     when (event.key) {
                         Key.One, Key.NumPad1 -> { NativeTabBridge.requestTab("Home"); true }
                         Key.Two, Key.NumPad2 -> { NativeTabBridge.requestTab("Search"); true }
@@ -168,6 +177,19 @@ fun main(args: Array<String>) {
                 // Windows fullscreen is emulated natively and isn't reflected by
                 // WindowPlacement, so it must be re-applied once the window peer exists.
                 fullscreenController.applyRestoredFullscreenState(window, windowState, wasFullscreenOnLastExit)
+            }
+            DisposableEffect(window) {
+                // On Windows, java.awt.Frame maximizes to the bounds of whichever screen it
+                // last computed maximizedBounds for, and does not recompute this automatically
+                // when the window is dragged to a different monitor. Without this, maximizing
+                // a window that was moved to a secondary display can snap it to the primary
+                // display's work area instead. Keep it current for the screen under the window.
+                val stopTracking = if (DesktopHostOs.current == DesktopHostOs.WINDOWS) {
+                    trackMaximizedBoundsForCurrentScreen(window)
+                } else {
+                    {}
+                }
+                onDispose { stopTracking() }
             }
             LaunchedEffect(windowState) {
                 // Covers OS-driven placement changes too (e.g. the native macOS
@@ -241,6 +263,41 @@ fun main(args: Array<String>) {
             }
         }
     }
+}
+
+/**
+ * Windows multi-monitor maximize workaround.
+ *
+ * [java.awt.Frame.setMaximizedBounds] is sticky: once set, Windows keeps using those bounds
+ * for the maximize action regardless of which monitor the window is currently on, so a window
+ * dragged to a secondary display can maximize to the primary display's work area instead.
+ * This recomputes and re-applies the bounds for the screen currently under the window
+ * whenever it moves or resizes, so double-click-titlebar / Win+Up maximize always targets the
+ * correct monitor. Returns a callback to stop tracking and remove the listener.
+ */
+private fun trackMaximizedBoundsForCurrentScreen(window: java.awt.Window): () -> Unit {
+    val frame = window as? java.awt.Frame ?: return {}
+
+    fun applyBoundsForCurrentScreen() {
+        val config = frame.graphicsConfiguration ?: return
+        val screenBounds = config.bounds
+        val insets = runCatching { frame.toolkit.getScreenInsets(config) }
+            .getOrDefault(java.awt.Insets(0, 0, 0, 0))
+        frame.maximizedBounds = java.awt.Rectangle(
+            screenBounds.x + insets.left,
+            screenBounds.y + insets.top,
+            screenBounds.width - insets.left - insets.right,
+            screenBounds.height - insets.top - insets.bottom,
+        )
+    }
+
+    applyBoundsForCurrentScreen()
+    val listener = object : java.awt.event.ComponentAdapter() {
+        override fun componentMoved(e: java.awt.event.ComponentEvent) = applyBoundsForCurrentScreen()
+        override fun componentResized(e: java.awt.event.ComponentEvent) = applyBoundsForCurrentScreen()
+    }
+    frame.addComponentListener(listener)
+    return { frame.removeComponentListener(listener) }
 }
 
 private fun configureDesktopChrome() {

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
@@ -1,6 +1,8 @@
 package com.nuvio.app
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.configureSwingGlobalsForCompose
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
@@ -18,6 +20,7 @@ import androidx.compose.ui.window.rememberWindowState
 import androidx.compose.ui.unit.dp
 import com.nuvio.app.core.deeplink.handleAppUrl
 import com.nuvio.app.core.diagnostics.SentryInitializer
+import com.nuvio.app.core.ui.NativeTabBridge
 import com.nuvio.app.core.ui.NuvioTheme
 import com.nuvio.app.features.discordrpc.DiscordPresenceManager
 import androidx.compose.ui.input.key.Key
@@ -28,7 +31,6 @@ import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
-import com.nuvio.app.core.ui.NativeTabBridge
 import com.nuvio.app.features.p2p.P2pStreamingEngine
 import com.nuvio.app.features.plugins.configureDesktopQuickJsLibrary
 import com.nuvio.app.features.player.PlatformPlayerSurface
@@ -64,6 +66,7 @@ fun main(args: Array<String>) {
     SentryInitializer.start()
     configureDesktopQuickJsLibrary()
     configureDesktopChrome()
+    configureLinuxSwingGlobalsBeforeAwt()
     installDesktopOpenUriHandler()
     handleDesktopLaunchArgs(args)
     preloadNativePlayerBridgeAsync()
@@ -231,9 +234,13 @@ fun main(args: Array<String>) {
                     },
                 )
                 val uninstallFullscreenShortcuts = installDesktopAppFullscreenShortcuts(window)
+                // Windows multi-monitor maximize workaround — see DesktopMaximizedBounds.kt.
+                // (No-op on non-Windows: the helper checks the host OS itself.)
+                val untrackMaximizedBounds = window.trackMaximizedBoundsForCurrentScreen()
                 onDispose {
                     fullscreenController.dispose(window)
                     uninstallFullscreenShortcuts()
+                    untrackMaximizedBounds()
                     unregisterFullscreenToggle()
                 }
             }
@@ -271,6 +278,23 @@ private fun configureDesktopChrome() {
     if (System.getProperty("os.name").contains("mac", ignoreCase = true)) {
         System.setProperty("apple.awt.application.appearance", MacosDarkAquaAppearance)
     }
+}
+
+// application {} applies Compose's Swing globals, which on Linux include Skiko's
+// display-scale detection (it sets sun.java2d.uiScale). AWT reads that property
+// once, when its graphics environment starts, and installDesktopOpenUriHandler()
+// starts it before application {} runs, which left the UI at 1x on HiDPI Linux
+// desktops (#514). Apply the globals before anything touches AWT.
+@OptIn(ExperimentalComposeUiApi::class)
+private fun configureLinuxSwingGlobalsBeforeAwt() {
+    if (DesktopHostOs.current != DesktopHostOs.LINUX) return
+    if (System.getProperty("compose.application.configure.swing.globals") != "true") return
+    // Skiko's detection overwrites sun.java2d.uiScale, so keep an explicitly
+    // set scale (the documented #514 workaround) working by skipping it.
+    configureSwingGlobalsForCompose(
+        useAutoDpiOnLinux = System.getProperty("sun.java2d.uiScale") == null &&
+            System.getProperty("skiko.linux.autodpi", "true") == "true",
+    )
 }
 
 private fun installDesktopOpenUriHandler() {

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
@@ -138,6 +138,9 @@ fun main(args: Array<String>) {
                         Key.Three, Key.NumPad3 -> { NativeTabBridge.requestTab("Library"); true }
                         Key.Four, Key.NumPad4 -> { NativeTabBridge.requestTab("Settings"); true }
                         Key.Slash, Key.Zero, Key.NumPad0 -> { NativeTabBridge.requestSearchWithFocus(); true }
+                        // Backspace mirrors Esc here: both are the "go back" keybinding
+                        // (see ShortcutsSettingsPage), reusing the exact same trigger.
+                        Key.Escape, Key.Backspace -> { NativeTabBridge.requestBack(); true }
                         else -> false
                     }
                 } else false

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
@@ -20,6 +20,11 @@ import com.nuvio.app.core.deeplink.handleAppUrl
 import com.nuvio.app.core.diagnostics.SentryInitializer
 import com.nuvio.app.core.ui.NuvioTheme
 import com.nuvio.app.features.discordrpc.DiscordPresenceManager
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
+import com.nuvio.app.core.ui.NativeTabBridge
 import com.nuvio.app.features.p2p.P2pStreamingEngine
 import com.nuvio.app.features.plugins.configureDesktopQuickJsLibrary
 import com.nuvio.app.features.player.PlatformPlayerSurface
@@ -32,7 +37,6 @@ import com.nuvio.app.features.player.desktop.applyNativeDesktopWindowChrome
 import com.nuvio.app.features.player.desktop.installDesktopAppFullscreenShortcuts
 import com.nuvio.app.features.player.desktop.preloadNativePlayerBridgeAsync
 import com.nuvio.app.features.player.desktop.registerDesktopAppFullscreenToggle
-import com.nuvio.app.features.player.desktop.trackMaximizedBoundsForCurrentScreen
 import com.nuvio.app.features.profiles.ProfileRepository
 import com.nuvio.app.features.settings.AppIconRepository
 import com.nuvio.app.features.settings.applyDesktopRendererPreference
@@ -125,6 +129,19 @@ fun main(args: Array<String>) {
             title = if (smokePlayerUrl == null) "Nuvio" else "Nuvio Player Smoke",
             state = windowState,
             icon = painterResource(appIconState.selected.transparentPreviewResource),
+            onKeyEvent = { event ->
+                if (event.type == KeyEventType.KeyDown) {
+                    if (NativeTabBridge.isSearchBoxFocused) return@Window false
+                    when (event.key) {
+                        Key.One, Key.NumPad1 -> { NativeTabBridge.requestTab("Home"); true }
+                        Key.Two, Key.NumPad2 -> { NativeTabBridge.requestTab("Search"); true }
+                        Key.Three, Key.NumPad3 -> { NativeTabBridge.requestTab("Library"); true }
+                        Key.Four, Key.NumPad4 -> { NativeTabBridge.requestTab("Settings"); true }
+                        Key.Slash, Key.Zero, Key.NumPad0 -> { NativeTabBridge.requestSearchWithFocus(); true }
+                        else -> false
+                    }
+                } else false
+            }
         ) {
             SideEffect {
                 window.background = NuvioDesktopNativeBackground
@@ -197,11 +214,9 @@ fun main(args: Array<String>) {
                     },
                 )
                 val uninstallFullscreenShortcuts = installDesktopAppFullscreenShortcuts(window)
-                val untrackMaximizedBounds = window.trackMaximizedBoundsForCurrentScreen()
                 onDispose {
                     fullscreenController.dispose(window)
                     uninstallFullscreenShortcuts()
-                    untrackMaximizedBounds()
                     unregisterFullscreenToggle()
                 }
             }


### PR DESCRIPTION
## Summary

Added global keyboard shortcuts to quickly navigate between root tabs and improved search accessibility on Desktop.

- 1, 2, 3, 4: Switches to Home, Search, Library, and Settings tabs respectively.
- / or 0: Switches to the Search tab and immediately focuses the search text box so you can begin typing.
Focus safety: All of the above global shortcuts are explicitly disabled while the search text box is actively focused, allowing users to type "1", "0", or "/" normally without triggering accidental tab switches.
Escape focus: Pressing the Escape key while the search box is focused will now seamlessly drop focus and re-enable the global navigation shortcuts.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

<!-- Why this change is needed. Explain the user-visible bug, regression, maintenance need, docs error, or approved request. -->
To improve keyboard-first navigation on Desktop platforms. Users expect standard global hotkeys to switch between primary interface tabs without reaching for the mouse, and need a frictionless way to instantly jump into the search bar from anywhere in the app.

## Desktop scope

<!-- This repository branch is for the desktop app. Explain which desktop platform(s) are affected: Windows, macOS, Linux, or desktop shared code. -->
<!-- If shared/common code changed, explain why it is needed for desktop behavior. -->
This change spans across Compose Desktop shared commonMain logic and desktopMain window event dispatching. It affects all desktop platforms (Windows, macOS, Linux). Shared native tab bridge logic was slightly extended to support explicit focus requests purely for desktop consumption.

## Issue or approval

<!-- Required. Link the bug issue or approved feature request. For docs/translation/maintenance with no issue, explain why no issue is needed. -->
<!-- Examples: Fixes #123 / Approved in #456 / No linked issue: typo-only docs fix. -->
Fixes #625, Fixes #635

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

<!-- List anything intentionally not changed. If this is a bug fix, confirm it does not include extra UI polish or behavior tweaks. -->
This is strictly limited to adding the keyboard listener for the four primary root tabs and the search focus logic. Intentionally avoided adding shortcuts for deeper nested navigation, internal settings pages, or playback shortcuts to keep the PR focused and minimal. Did not apply any UI polishing or cosmetic changes.

## Testing

<!-- What you tested and how. Include desktop OS/version, installer/updater checks if relevant, commands, and manual desktop flows. Do not write only "not tested" unless this is docs/translation-only. -->
- Desktop OS: Windows
- Manual Flows Tested:
- Pressed 1, 2, 3, 4 (both number row and Numpad) from the Home screen; verified the app navigates successfully to Home, Search, Library, and Settings.
- Pressed /, 0, and Numpad 0 from the Library screen; verified it switches to the Search screen and brings up the text input cursor.
- Typed 1, 2, 3, 4, /, 0 directly into the focused search box; verified the characters are typed out natively and no tab routing is accidentally triggered.
- Pressed Esc while the search box was actively receiving text; verified that the cursor drops focus and the global hotkeys are re-enabled.

## Screenshots / Video

Not a UI change.
<!-- Required for any desktop UI change. Write "Not a UI change" only if no UI changed. -->

## Breaking changes

<!-- Any breaking behavior/config/schema changes? If none, write: None. -->
None.

## Linked issues

<!-- Required for bug fixes, UI glitch fixes, behavior fixes, and approved changes. For docs/translation/maintenance with no issue, write: No linked issue - reason. -->
Fixes #625, Fixes #635