### PR TITLE
fix(streams): set showContainerOnDesktop to true on back button

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamsScreen.kt
@@ -327,6 +327,7 @@ fun StreamsScreen(
                 modifier = Modifier
                     .size(40.dp),
                 containerColor = MaterialTheme.colorScheme.background.copy(alpha = 0.45f),
+                showContainerOnDesktop = true,
                 contentColor = MaterialTheme.colorScheme.onBackground,
             )
 


### PR DESCRIPTION
## Summary

Enabled `showContainerOnDesktop` for the back button in `StreamsScreen` to fix its visibility over white backgrounds.

The property was previously added by @haaihond, but its default value (`false`) changed the existing behavior. As a result, the back button container becomes invisible against light/white backgrounds. This PR restores previous behavior.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

<!-- Why this change is needed. Explain the user-visible bug, regression, maintenance need, docs error, or approved request. -->

The back button's container is no longer visible because `showContainerOnDesktop` was not explicitly enabled after the property was introduced. Previously, the container was shown on desktop by default because the `showContainerOnDesktop` property did not exist on `NuvioBackButton`. After the property was added, `StreamsScreen` no longer displayed the container. This made the back button difficult to see over light/white backgrounds.

## Desktop scope

<!-- This repository branch is for the desktop app. Explain which desktop platform(s) are affected: Windows, macOS, Linux, or desktop shared code. -->
<!-- If shared/common code changed, explain why it is needed for desktop behavior. -->
This change affects shared code. Needed for desktop behavior as the `showContainerOnDesktop` flag was introduced for desktop and wasn't properly set in all affected screens.

## Issue or approval

<!-- Required. Link the bug issue or approved feature request. For docs/translation/maintenance with no issue, explain why no issue is needed. -->
<!-- Examples: Fixes #123 / Approved in #456 / No linked issue: typo-only docs fix. -->
No issue needed, one-line bugfix restoring existing behavior.

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [x] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

<!-- List anything intentionally not changed. If this is a bug fix, confirm it does not include extra UI polish or behavior tweaks. -->
Only changes a single flag in a component to true. No other UI or behavior changes.

## Testing

<!-- What you tested and how. Include desktop OS/version, installer/updater checks if relevant, commands, and manual desktop flows. Do not write only "not tested" unless this is docs/translation-only. -->
Verified the back button container is visible on desktop against a light/white background.

## Screenshots / Video

<!-- Required for any desktop UI change. Write "Not a UI change" only if no UI changed. -->
<img width="349" height="114" alt="image" src="https://github.com/user-attachments/assets/24d15110-7235-4054-a7bf-432f8a364e01" />
<img width="399" height="129" alt="image" src="https://github.com/user-attachments/assets/73b52e25-2980-417a-b715-c6863dba4b3d" />


## Breaking changes

<!-- Any breaking behavior/config/schema changes? If none, write: None. -->
None.

## Linked issues

<!-- Required for bug fixes, UI glitch fixes, behavior fixes, and approved changes. For docs/translation/maintenance with no issue, write: No linked issue - reason. -->
No issue needed, one-line bugfix restoring existing behavior.