### PR TITLE
fix(desktop): show volume feedback while dragging slider

### DIFF
--- a/composeApp/src/desktopMain/resources/player-ui/controls.js
+++ b/composeApp/src/desktopMain/resources/player-ui/controls.js
@@ -2897,6 +2897,7 @@ volumeSlider.addEventListener("input", event => {
     preMuteVolumeLevel = nextLevel;
   }
   syncVolumeControl();
+  showPlayerToast(volumeToastLabel());
   send("volumeChange", nextLevel);
 });
 


### PR DESCRIPTION
## Summary

Show the existing volume toast on every volume slider input event. Dragging the slider now displays the current percentage, including boosted levels above 100%, or the existing muted label at zero.

## PR type

- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Mouse dragging changed the audio level without displaying its value. Keyboard and scroll volume changes already show this toast; the slider handler was missing the same call.

## Desktop scope

One line in `composeApp/src/desktopMain/resources/player-ui/controls.js`, the shared desktop player controls used on macOS, Windows, and Linux. Runtime verification was on macOS only. No commonMain or mobile code changes.

## Issue or approval

Fixes #647

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

Reuses the existing toast, localization, and timeout. No layout or style changes, extra UI polish, or unrelated behavior tweaks. Volume limits, steps, persistence, mute behavior, and keyboard/scroll handling are unchanged. No player engine, fork, source revision, dependency, or enabled-feature changes. No expected material change to bandwidth, disk use, or memory use; resource usage was not measured.

## Testing

- `node --check composeApp/src/desktopMain/resources/player-ui/controls.js` passed.
- `git diff --check` passed.
- Node callback checks passed for 75%, 42%, mute, 100%, 150%, and 200%, matching volume bridge commands, and the untrusted-event guard.
- Manually tested in the locally compiled macOS DMG build; slider feedback works. Test host: macOS 26.6.2, Apple M4.
- Tested mouse dragging; the running build displays `Volume 143%`. Windows, Linux, and installer/updater flows were not tested.

## Screenshots / Video

Before: dragging changed the volume without showing the percentage toast, as reported in #647. No before image was captured.

After: the running macOS build shows `Volume 143%` after a mouse drag.

<img width="1000" alt="Player showing Volume 143% after dragging the volume slider" src="https://github.com/user-attachments/assets/b980aa62-3f5b-40f0-af43-484c309a60df" />

## Breaking changes

None.

## Linked issues

#647

