### PR TITLE
fix(linux): register Nuvio and Stremio URI handlers

### DIFF
--- a/scripts/linux/build-appimage.sh
+++ b/scripts/linux/build-appimage.sh
@@ -70,7 +70,7 @@ mkdir -p "$app_dir"
 cp -a "$app_root"/. "$app_dir/"
 
 desktop_file="$app_dir/${NUVIO_LINUX_SHORTCUT_NAME}.desktop"
-nuvio_linux_write_desktop_entry_file "$desktop_file" "AppRun" "$NUVIO_LINUX_SHORTCUT_NAME"
+nuvio_linux_write_desktop_entry_file "$desktop_file" "AppRun %u" "$NUVIO_LINUX_SHORTCUT_NAME"
 if [[ -n "$website_url" ]]; then
     printf 'X-AppImage-Website=%s\n' "$website_url" >> "$desktop_file"
 fi

--- a/scripts/linux/linux-shortcut-definition.sh
+++ b/scripts/linux/linux-shortcut-definition.sh
@@ -6,6 +6,7 @@ readonly NUVIO_LINUX_SHORTCUT_COMMENT="Nuvio Media Player"
 readonly NUVIO_LINUX_SHORTCUT_CATEGORIES="AudioVideo;"
 readonly NUVIO_LINUX_SHORTCUT_STARTUP_NOTIFY="true"
 readonly NUVIO_LINUX_SHORTCUT_STARTUP_WM_CLASS="com-nuvio-app-MainKt"
+readonly NUVIO_LINUX_SHORTCUT_MIME_TYPES="x-scheme-handler/nuvio;x-scheme-handler/stremio;"
 
 nuvio_linux_desktop_entry_exists() {
     if [[ $# -ne 1 ]]; then
@@ -40,7 +41,43 @@ nuvio_linux_write_desktop_entry() {
     local root_dir="$1"
     local desktop_file="$root_dir/$NUVIO_LINUX_SHORTCUT_RELATIVE_PATH"
     mkdir -p "$(dirname "$desktop_file")"
-    nuvio_linux_write_desktop_entry_file "$desktop_file" "/opt/nuvio/bin/Nuvio" "/opt/nuvio/lib/Nuvio.png"
+    nuvio_linux_write_desktop_entry_file "$desktop_file" "/opt/nuvio/bin/Nuvio %u" "/opt/nuvio/lib/Nuvio.png"
+}
+
+nuvio_linux_ensure_uri_handler() {
+    if [[ $# -ne 1 ]]; then
+        return 2
+    fi
+
+    local desktop_file="$1/$NUVIO_LINUX_SHORTCUT_RELATIVE_PATH"
+    [[ -f "$desktop_file" ]] || return 1
+
+    local mime_types
+    mime_types="$(sed -n 's/^MimeType=//p' "$desktop_file" | head -n 1)"
+    if [[ -n "$mime_types" && "$mime_types" != *';' ]]; then
+        mime_types+=';'
+    fi
+    local handler
+    local -a handlers
+    IFS=';' read -r -a handlers <<< "$NUVIO_LINUX_SHORTCUT_MIME_TYPES"
+    for handler in "${handlers[@]}"; do
+        [[ -z "$handler" ]] && continue
+        if [[ ";$mime_types" != *";$handler;"* ]]; then
+            mime_types+="$handler;"
+        fi
+    done
+
+    if grep -q '^MimeType=' "$desktop_file"; then
+        sed -i "s|^MimeType=.*$|MimeType=${mime_types}|" "$desktop_file"
+    else
+        printf 'MimeType=%s\n' "$mime_types" >> "$desktop_file"
+    fi
+
+    if grep -Eq '^Exec=.*%[fF]' "$desktop_file"; then
+        sed -i -E 's|^(Exec=.*)%[fF](.*)$|\1%u\2|' "$desktop_file"
+    elif ! grep -Eq '^Exec=.*%[uU]' "$desktop_file"; then
+        sed -i -E 's|^(Exec=.*)$|\1 %u|' "$desktop_file"
+    fi
 }
 
 nuvio_linux_write_desktop_entry_file() {
@@ -63,6 +100,7 @@ Terminal=false
 Categories=__NUVIO_CATEGORIES__
 StartupNotify=__NUVIO_STARTUP_NOTIFY__
 StartupWMClass=__NUVIO_STARTUP_WM_CLASS__
+MimeType=__NUVIO_MIME_TYPES__
 EOF
 
     sed -i \
@@ -73,5 +111,6 @@ EOF
         -e "s|__NUVIO_CATEGORIES__|${NUVIO_LINUX_SHORTCUT_CATEGORIES}|g" \
         -e "s|__NUVIO_STARTUP_NOTIFY__|${NUVIO_LINUX_SHORTCUT_STARTUP_NOTIFY}|g" \
         -e "s|__NUVIO_STARTUP_WM_CLASS__|${NUVIO_LINUX_SHORTCUT_STARTUP_WM_CLASS}|g" \
+        -e "s|__NUVIO_MIME_TYPES__|${NUVIO_LINUX_SHORTCUT_MIME_TYPES}|g" \
         "$desktop_file"
 }

--- a/scripts/linux/patch-linux-deb.sh
+++ b/scripts/linux/patch-linux-deb.sh
@@ -49,6 +49,7 @@ if ! nuvio_linux_desktop_entry_exists "$work_dir"; then
     nuvio_linux_write_desktop_entry "$work_dir"
 fi
 nuvio_linux_ensure_startup_wm_class "$work_dir"
+nuvio_linux_ensure_uri_handler "$work_dir"
 
 depends="$(dpkg-deb -f "$deb" Depends)"
 for dependency in "${NUVIO_LINUX_DEB_RUNTIME_DEPENDENCIES[@]}"; do

--- a/scripts/linux/patch-linux-rpm.sh
+++ b/scripts/linux/patch-linux-rpm.sh
@@ -65,6 +65,7 @@ if ! nuvio_linux_desktop_entry_exists "$payload_dir"; then
     nuvio_linux_write_desktop_entry "$payload_dir"
 fi
 nuvio_linux_ensure_startup_wm_class "$payload_dir"
+nuvio_linux_ensure_uri_handler "$payload_dir"
 
 name="$(rpm -qp --qf '%{NAME}\n' "$rpm_path")"
 version="$(rpm -qp --qf '%{VERSION}\n' "$rpm_path")"


### PR DESCRIPTION
## Summary

Register `nuvio://` and `stremio://` in Linux DEB, RPM, and AppImage launchers and pass opened URIs to Nuvio.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Nuvio already accepts supported links as launch arguments, but its Linux package launchers do not consistently declare the schemes or include a URI field code.

## Desktop scope

Linux packaging only. Windows, macOS, URI parsing, playback, taskbar grouping, and MPRIS are unchanged.

## Issue or approval

Approved by @KhooLy in the maintainer review on #652.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

This PR only changes Linux launcher metadata and package post-processing. URI parsing and package validation are unchanged. Existing MIME types are preserved, and repeated patching does not duplicate handlers.

## Testing

- `bash -n scripts/linux/*.sh`
- ShellCheck on the changed scripts
- Local launcher probe covering existing MIME types, `%f` to `%u` conversion, both schemes, and repeated execution
- Desktop application compilation completed during the AppImage packaging attempt
- `git diff --check`

AppImage generation reached the final packaging task but this host does not have `appimagetool`. DEB/RPM installation and opening a URI through an installed desktop launcher have not been completed.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue.