### PR TITLE
fix(linux): apply the desktop display scale to the UI

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt
@@ -1,6 +1,8 @@
 package com.nuvio.app
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.configureSwingGlobalsForCompose
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
@@ -55,6 +57,7 @@ fun main(args: Array<String>) {
     SentryInitializer.start()
     configureDesktopQuickJsLibrary()
     configureDesktopChrome()
+    configureLinuxSwingGlobalsBeforeAwt()
     installDesktopOpenUriHandler()
     handleDesktopLaunchArgs(args)
     preloadNativePlayerBridgeAsync()
@@ -229,6 +232,23 @@ private fun configureDesktopChrome() {
     if (System.getProperty("os.name").contains("mac", ignoreCase = true)) {
         System.setProperty("apple.awt.application.appearance", MacosDarkAquaAppearance)
     }
+}
+
+// application {} applies Compose's Swing globals, which on Linux include Skiko's
+// display-scale detection (it sets sun.java2d.uiScale). AWT reads that property
+// once, when its graphics environment starts, and installDesktopOpenUriHandler()
+// starts it before application {} runs, which left the UI at 1x on HiDPI Linux
+// desktops (#514). Apply the globals before anything touches AWT.
+@OptIn(ExperimentalComposeUiApi::class)
+private fun configureLinuxSwingGlobalsBeforeAwt() {
+    if (DesktopHostOs.current != DesktopHostOs.LINUX) return
+    if (System.getProperty("compose.application.configure.swing.globals") != "true") return
+    // Skiko's detection overwrites sun.java2d.uiScale, so keep an explicitly
+    // set scale (the documented #514 workaround) working by skipping it.
+    configureSwingGlobalsForCompose(
+        useAutoDpiOnLinux = System.getProperty("sun.java2d.uiScale") == null &&
+            System.getProperty("skiko.linux.autodpi", "true") == "true",
+    )
 }
 
 private fun installDesktopOpenUriHandler() {


### PR DESCRIPTION
## Summary

Apply Compose's Swing globals on Linux before anything initialises AWT, so the display scale Skiko detects actually reaches AWT and the UI follows the desktop's scaling instead of staying at 1x.

## PR type

- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

On HiDPI Linux desktops the whole UI renders at 1x, so everything is tiny (#514).

Skiko already detects the right scale on Linux: `configureSwingGlobalsForCompose()` (which `application {}` calls because the Compose plugin passes `-Dcompose.application.configure.swing.globals=true`) loads Skiko, and Skiko's `Setup.init` sets `sun.java2d.uiScale` from `Xft.dpi`. But AWT reads `sun.java2d.uiScale` only once, when its graphics environment starts, and `main()` starts it before `application {}` runs: `installDesktopOpenUriHandler()` calls `Desktop.isDesktopSupported()`, which initialises the toolkit and the graphics environment. The detected scale is therefore set too late and ignored. Passing `-Dsun.java2d.uiScale=2` on the command line (the workaround in #514) works because the property is already set when AWT starts; the automatic value is set about 0.2s later, after AWT has read it.

A class-load trace of the current `Dev` build (`-Xlog:class+load` with `-XX:LogClassLoadingCauseFor=sun.awt.X11GraphicsEnvironment`) shows the order:

```
[0.381s] sun.awt.X11GraphicsEnvironment
           at java.awt.Desktop.isDesktopSupported(Desktop.java:316)
           at com.nuvio.app.MainKt.installDesktopOpenUriHandler(Main.kt:235)
           at com.nuvio.app.MainKt.main(Main.kt:58)
[0.571s] androidx.compose.ui.window.Application_desktopKt
[0.582s] org.jetbrains.skiko.Setup
```

The released 0.1.23-alpha AppImage shows the same symptom: `jcmd <pid> VM.system_properties` reports `sun.java2d.uiScale=2.0` while the UI renders at 1x.

With this change, `org.jetbrains.skiko.Setup` loads at 0.388s and `sun.awt.X11GraphicsEnvironment` at 0.400s, after the scale is set.

Skiko's detection overwrites `sun.java2d.uiScale` unconditionally, so when the property is already set explicitly (the `_JAVA_OPTIONS=-Dsun.java2d.uiScale=2` workaround posted in #514) auto-DPI is turned off and the explicit value is kept. `skiko.linux.autodpi=false` is honoured as before.

## Desktop scope

Linux only. The new function returns immediately on other platforms, so Windows and macOS are unchanged. One file: `composeApp/src/desktopMain/kotlin/com/nuvio/app/Main.kt`.

## Issue or approval

Fixes #514

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only when the existing Compose Swing globals are applied on Linux. The GTK early init, the player bridge, the JVM args in `build.gradle.kts`, and the URI handler itself are unchanged. No in-app scale setting (the alternative suggested in #514). `application {}` still calls `configureSwingGlobalsForCompose()`; Skiko is already loaded by then, so it doesn't re-apply the scale (verified: an explicit `uiScale=1` survives it).

## Testing

Manual, on Fedora 44, GNOME Shell 50.4 on Wayland (the app runs under XWayland), 4K external monitor (3840x2160) at 150%. At that setting XWayland clients render at 2x and are scaled down by the compositor, and `Xft.dpi` is 192. Ryzen 7 6800HS + Radeon 680M + RTX 3050.

Built and ran this branch with `./gradlew :composeApp:run`, compared against the same build without the change, and against the released 0.1.23-alpha AppImage:

| Build | `sun.java2d.uiScale` (who set it) | UI |
| --- | --- | --- |
| 0.1.23-alpha AppImage | 2.0, by Skiko after AWT started | 1x |
| `Dev` without this change | 2.0, by Skiko after AWT started | 1x |
| This PR | 2.0, by Skiko before AWT starts | 2x |
| This PR, `-Dsun.java2d.uiScale=1` | 1, from the command line | 1x |
| This PR, same monitor at 100% (`Xft.dpi` 96) | 1.0, by Skiko before AWT starts | 1x (unchanged) |
| This PR, same monitor at 200% (`Xft.dpi` 192) | 2.0, by Skiko before AWT starts | 2x |

With this PR I also played a stream: the native player and its controls overlay are aligned, and click/hover targets match what's drawn. No GTK/GLib warnings in the log.

Not tested: KDE Plasma (the setup in #514).

## Screenshots / Video

Same window, same 4K display at 150%.

**Before** (`Dev`):
<img width="1600" height="857" alt="nuvio-514-before" src="https://github.com/user-attachments/assets/305c54a2-37f1-4cb3-9733-d9a953c5bb5a" />

**After** (this PR):
<img width="1600" height="857" alt="nuvio-514-after" src="https://github.com/user-attachments/assets/9004fcfd-53aa-41aa-8e27-f8409ce5d3a9" />

## Breaking changes

None. An explicitly set `sun.java2d.uiScale` still takes precedence.

## Linked issues

Fixes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)



