### PR TITLE
fix(discord): keep the presence a Watching activity outside playback

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/discordrpc/DiscordPresenceManager.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/discordrpc/DiscordPresenceManager.kt
@@ -19,6 +19,11 @@ private class DiscordDisconnected : Exception()
 
 private const val ReconnectDelayMs = 15_000L
 
+// Discord activity type: 0 = Playing, 2 = Listening, 3 = Watching, 5 = Competing.
+// Nuvio is a media app, so every presence it publishes is a Watching one -- including the menus,
+// where Discord renders "Watching Nuvio" instead of the default "Playing Nuvio" (a game).
+private const val WatchingActivityType = 3
+
 internal object DiscordPresenceManager {
     private val log = Logger.withTag("DiscordPresenceManager")
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -49,7 +54,7 @@ internal object DiscordPresenceManager {
                     lastActivity = null
                     try {
                         AppPresenceState.current.collect { snapshot ->
-                            val activity = snapshot?.toDiscordActivity() ?: DiscordActivity(details = "Browsing Nuvio")
+                            val activity = snapshot?.toDiscordActivity() ?: IdleActivity
                             if (activity == lastActivity) return@collect
                             if (client.setActivity(activity)) {
                                 lastActivity = activity
@@ -76,6 +81,12 @@ internal object DiscordPresenceManager {
     }
 }
 
+// Shown when nothing has been published yet, so the profile still reads "Watching Nuvio".
+private val IdleActivity = DiscordActivity(
+    type = WatchingActivityType,
+    details = "Browsing Nuvio",
+)
+
 private fun String.toDiscordEpisodeLabel(): String {
     val match = Regex("""S(\d+)E(\d+)(?:\s*-\s*(.*))?""").matchEntire(trim())
         ?: return this
@@ -87,14 +98,14 @@ private fun String.toDiscordEpisodeLabel(): String {
 
 
 private fun PresenceSnapshot.toDiscordActivity(): DiscordActivity = when (this) {
-    is PresenceSnapshot.Tab -> DiscordActivity(details = "Browsing ${tab.name}")
-    is PresenceSnapshot.Details -> DiscordActivity(details = "Viewing $title")
+    is PresenceSnapshot.Tab -> DiscordActivity(type = WatchingActivityType, details = "Browsing ${tab.name}")
+    is PresenceSnapshot.Details -> DiscordActivity(type = WatchingActivityType, details = "Viewing $title")
     is PresenceSnapshot.Player -> {
         val episode = episodeLabel?.toDiscordEpisodeLabel()
         // Discord expects Unix timestamps in seconds, not milliseconds.
         val startSecs = (System.currentTimeMillis() - positionMs) / 1_000L
         DiscordActivity(
-            type = 3, // Watching -> "Watching …" instead of the default "Playing …" (game).
+            type = WatchingActivityType,
             name = title, // Show the media title under the pseudo when the client honors it.
             details = title, // Always keep the title here as a fallback for clients that ignore `name`.
             state = if (isPlaying) episode else episode?.let { "$it • Paused" } ?: "Paused",


### PR DESCRIPTION
## Summary

Send Discord activity type 3 (Watching) for every presence Nuvio publishes, not just the one sent while a video is playing. Browsing a tab, opening a title and the idle state all used the default type 0, which Discord renders as "Playing Nuvio".

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

#591 reported that Discord advertises "Playing Nuvio", as if Nuvio were a game, instead of a Watching activity. #628 fixed that for the player, but only the player: `toDiscordActivity()` sets `type = 3` in the `Player` branch, while the `Tab` and `Details` branches and the idle fallback keep the `DiscordActivity` default of `type = 0`. So the exact wording the issue reported is still on the profile of every user who has Rich Presence enabled and is not currently playing something, which is most of the time the app is open.

## Desktop scope

Desktop only, all three platforms (Windows, macOS, Linux). The change is confined to `composeApp/src/desktopMain/.../discordrpc/DiscordPresenceManager.kt`; no common code is touched.

## Issue or approval

Completes #591, whose reported wording still appears outside playback after #628. Same bug, same file, remaining branches.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Deliberately not changed: the detail lines themselves (still the same English text), the player presence fields added in #628 (title, timestamps, poster), the Rich Presence setting and its default, and the IPC client. The magic number 3 is moved into a named constant so the three call sites read the same, and nothing else is refactored.

## Testing

Windows 11, MSI built from this branch, Discord desktop client, Rich Presence enabled in Settings > Advanced.

- App on Home, Search, Library, Settings: profile reads "Watching Nuvio" with the section on the detail line. Before the change it read "Playing Nuvio".
- Title detail page: "Watching Nuvio" / "Viewing <title>".
- Playing an episode: unchanged from #628, "Watching <title>" with the progress bar and poster.
- Pausing, resuming and leaving the player: presence follows, no stale activity.
- Turning the Rich Presence setting off clears the presence, turning it back on restores it.

## Screenshots / Video

Not a desktop UI change; nothing in the Nuvio window changes. The visible difference is on the Discord profile, screenshot attached showing the "Watching Nuvio" line while browsing.

## Breaking changes

None.

## Linked issues

#591, and #628 which fixed the playback half of it.
