### PR TITLE
i18n: translate the navigation bar Settings label

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ar/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ar/strings.xml
@@ -351,6 +351,7 @@
     <string name="compose_nav_library">المكتبة</string>
     <string name="compose_nav_profile">الملف الشخصي</string>
     <string name="compose_nav_search">بحث</string>
+    <string name="compose_nav_settings">الإعدادات</string>
     <string name="compose_player_audio_tracks">المسارات الصوتية</string>
     <string name="compose_player_audio">الصوت</string>
     <string name="compose_player_auto_sync">مزامنة تلقائية</string>

--- a/composeApp/src/commonMain/composeResources/values-bg/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-bg/strings.xml
@@ -413,6 +413,7 @@
     <string name="compose_nav_library">Библиотека</string>
     <string name="compose_nav_profile">Профил</string>
     <string name="compose_nav_search">Търси</string>
+    <string name="compose_nav_settings">Настройки</string>
     <string name="compose_player_audio_tracks">Аудио записи</string>
     <string name="compose_player_audio">Аудио</string>
     <string name="compose_player_auto_sync">Автоматична синхронизация</string>

--- a/composeApp/src/commonMain/composeResources/values-cs/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-cs/strings.xml
@@ -336,6 +336,7 @@
     <string name="compose_nav_library">Knihovna</string>
     <string name="compose_nav_profile">Profil</string>
     <string name="compose_nav_search">Hledat</string>
+    <string name="compose_nav_settings">Nastavení</string>
     <string name="compose_player_audio_tracks">Zvukové stopy</string>
     <string name="compose_player_audio">Zvuk</string>
     <string name="compose_player_auto_sync">Automatická synchronizace</string>

--- a/composeApp/src/commonMain/composeResources/values-de/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-de/strings.xml
@@ -300,6 +300,7 @@
     <string name="compose_nav_library">Bibliothek</string>
     <string name="compose_nav_profile">Profil</string>
     <string name="compose_nav_search">Suche</string>
+    <string name="compose_nav_settings">Einstellungen</string>
     <string name="compose_player_audio_tracks">Tonspuren</string>
     <string name="compose_player_audio">Audio</string>
     <string name="compose_player_built_in">Integriert</string>

--- a/composeApp/src/commonMain/composeResources/values-el/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-el/strings.xml
@@ -199,6 +199,7 @@
     <string name="compose_nav_library">Βιβλιοθήκη</string>
     <string name="compose_nav_profile">Προφίλ</string>
     <string name="compose_nav_search">Αναζήτηση</string>
+    <string name="compose_nav_settings">Ρυθμίσεις</string>
     <string name="compose_player_audio_tracks">Κομμάτια ήχου</string>
     <string name="compose_player_audio">Ήχος</string>
     <string name="compose_player_built_in">Ενσωματωμένο</string>

--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -413,6 +413,7 @@
     <string name="compose_nav_library">Biblioteca</string>
     <string name="compose_nav_profile">Perfil</string>
     <string name="compose_nav_search">Buscar</string>
+    <string name="compose_nav_settings">Configuración</string>
     <string name="compose_player_audio_tracks">Pistas de audio</string>
     <string name="compose_player_audio">Audio</string>
     <string name="compose_player_auto_sync">Sincronización automática</string>

--- a/composeApp/src/commonMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-fr/strings.xml
@@ -328,6 +328,7 @@
     <string name="compose_nav_library">Bibliothèque</string>
     <string name="compose_nav_profile">Profil</string>
     <string name="compose_nav_search">Rechercher</string>
+    <string name="compose_nav_settings">Paramètres</string>
     <string name="compose_player_audio_tracks">Pistes audio</string>
     <string name="compose_player_audio">Audio</string>
     <string name="compose_player_auto_sync">Synchro auto</string>

--- a/composeApp/src/commonMain/composeResources/values-he/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-he/strings.xml
@@ -183,6 +183,7 @@
     <string name="compose_nav_library">ספרייה</string>
     <string name="compose_nav_profile">פרופיל</string>
     <string name="compose_nav_search">חיפוש</string>
+    <string name="compose_nav_settings">הגדרות</string>
     <string name="compose_player_audio_tracks">רצועות שמע</string>
     <string name="compose_player_audio">אודיו</string>
     <string name="compose_player_auto_sync">סנכרון אוטומטי</string>

--- a/composeApp/src/commonMain/composeResources/values-hu/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-hu/strings.xml
@@ -309,6 +309,7 @@
     <string name="compose_nav_library">Könyvtár</string>
     <string name="compose_nav_profile">Profil</string>
     <string name="compose_nav_search">Keresés</string>
+    <string name="compose_nav_settings">Beállítások</string>
     <string name="compose_player_audio_tracks">Hangsávok</string>
     <string name="compose_player_audio">Hang</string>
     <string name="compose_player_built_in">Beépített</string>

--- a/composeApp/src/commonMain/composeResources/values-id/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-id/strings.xml
@@ -317,6 +317,7 @@
     <string name="compose_nav_library">Pustaka</string>
     <string name="compose_nav_profile">Profil</string>
     <string name="compose_nav_search">Pencarian</string>
+    <string name="compose_nav_settings">Pengaturan</string>
     <string name="compose_player_audio_tracks">Trek Audio</string>
     <string name="compose_player_audio">Audio</string>
     <string name="compose_player_auto_sync">Sinkronisasi Otomatis</string>

--- a/composeApp/src/commonMain/composeResources/values-in/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-in/strings.xml
@@ -317,6 +317,7 @@
     <string name="compose_nav_library">Pustaka</string>
     <string name="compose_nav_profile">Profil</string>
     <string name="compose_nav_search">Pencarian</string>
+    <string name="compose_nav_settings">Pengaturan</string>
     <string name="compose_player_audio_tracks">Trek Audio</string>
     <string name="compose_player_audio">Audio</string>
     <string name="compose_player_auto_sync">Sinkronisasi Otomatis</string>

--- a/composeApp/src/commonMain/composeResources/values-it/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-it/strings.xml
@@ -149,6 +149,7 @@
   <string name="compose_nav_library">Libreria</string>
   <string name="compose_nav_profile">Profilo</string>
   <string name="compose_nav_search">Cerca</string>
+  <string name="compose_nav_settings">Impostazioni</string>
   <string name="compose_player_audio_tracks">Tracce audio</string>
   <string name="compose_player_audio">Audio</string>
   <string name="compose_player_auto_sync">Auto Sync</string>

--- a/composeApp/src/commonMain/composeResources/values-ja/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ja/strings.xml
@@ -336,6 +336,7 @@
     <string name="compose_nav_library">ライブラリ</string>
     <string name="compose_nav_profile">プロフィール</string>
     <string name="compose_nav_search">検索</string>
+    <string name="compose_nav_settings">設定</string>
     <string name="compose_player_audio_tracks">音声トラック</string>
     <string name="compose_player_audio">音声</string>
     <string name="compose_player_auto_sync">自動同期</string>

--- a/composeApp/src/commonMain/composeResources/values-nb/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nb/strings.xml
@@ -315,6 +315,7 @@
     <string name="compose_nav_library">Bibliotek</string>
     <string name="compose_nav_profile">Profil</string>
     <string name="compose_nav_search">Søk</string>
+    <string name="compose_nav_settings">Innstillinger</string>
     <string name="compose_player_audio_tracks">Lydspor</string>
     <string name="compose_player_audio">Lyd</string>
     <string name="compose_player_built_in">Innebygd</string>

--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -338,6 +338,7 @@
     <string name="compose_nav_library">Bibliotheek</string>
     <string name="compose_nav_profile">Profiel</string>
     <string name="compose_nav_search">Zoeken</string>
+    <string name="compose_nav_settings">Instellingen</string>
     <string name="compose_player_audio_tracks">Audiosporen</string>
     <string name="compose_player_audio">Audio</string>
     <string name="compose_player_auto_sync">Automatische synchronisatie</string>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -317,6 +317,7 @@
     <string name="compose_nav_library">Biblioteka</string>
     <string name="compose_nav_profile">Profil</string>
     <string name="compose_nav_search">Szukaj</string>
+    <string name="compose_nav_settings">Ustawienia</string>
     <string name="compose_player_audio_tracks">Ścieżki audio</string>
     <string name="compose_player_audio">Audio</string>
     <string name="compose_player_auto_sync">Automatyczna synchronizacja</string>

--- a/composeApp/src/commonMain/composeResources/values-pt-rBR/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pt-rBR/strings.xml
@@ -316,6 +316,7 @@
     <string name="compose_nav_library">Biblioteca</string>
     <string name="compose_nav_profile">Perfil</string>
     <string name="compose_nav_search">Busca</string>
+    <string name="compose_nav_settings">Configurações</string>
     <string name="compose_player_audio_tracks">Faixas de Áudio</string>
     <string name="compose_player_audio">Áudio</string>
     <string name="compose_player_built_in">Incorporado</string>

--- a/composeApp/src/commonMain/composeResources/values-pt/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pt/strings.xml
@@ -333,6 +333,7 @@
     <string name="compose_nav_library">Biblioteca</string>
     <string name="compose_nav_profile">Perfil</string>
     <string name="compose_nav_search">Pesquisar</string>
+    <string name="compose_nav_settings">Definições</string>
     <string name="compose_player_audio_tracks">Faixas de áudio</string>
     <string name="compose_player_audio">Áudio</string>
     <string name="compose_player_auto_sync">Sincronização automática</string>

--- a/composeApp/src/commonMain/composeResources/values-ro/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ro/strings.xml
@@ -336,6 +336,7 @@
     <string name="compose_nav_library">Bibliotecă</string>
     <string name="compose_nav_profile">Profil</string>
     <string name="compose_nav_search">Caută</string>
+    <string name="compose_nav_settings">Setări</string>
     <string name="compose_player_audio_tracks">Piste audio</string>
     <string name="compose_player_audio">Audio</string>
     <string name="compose_player_auto_sync">Sincronizare automată</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -413,6 +413,7 @@
     <string name="compose_nav_library">Медиатека</string>
     <string name="compose_nav_profile">Профиль</string>
     <string name="compose_nav_search">Поиск</string>
+    <string name="compose_nav_settings">Настройки</string>
     <string name="compose_player_audio_tracks">Аудиодорожки</string>
     <string name="compose_player_audio">Аудио</string>
     <string name="compose_player_auto_sync">Автосинхронизация</string>

--- a/composeApp/src/commonMain/composeResources/values-sk/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-sk/strings.xml
@@ -326,6 +326,7 @@
     <string name="compose_nav_library">Knižnica</string>
     <string name="compose_nav_profile">Profil</string>
     <string name="compose_nav_search">Hľadať</string>
+    <string name="compose_nav_settings">Nastavenia</string>
     <string name="compose_player_audio_tracks">Zvukové stopy</string>
     <string name="compose_player_audio">Zvuk</string>
     <string name="compose_player_auto_sync">Automatická synchronizácia</string>

--- a/composeApp/src/commonMain/composeResources/values-tr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-tr/strings.xml
@@ -338,6 +338,7 @@
     <string name="compose_nav_library">Kitaplık</string>
     <string name="compose_nav_profile">Profil</string>
     <string name="compose_nav_search">Ara</string>
+    <string name="compose_nav_settings">Ayarlar</string>
     <string name="compose_player_audio_tracks">Ses parçaları</string>
     <string name="compose_player_audio">Ses</string>
     <string name="compose_player_auto_sync">Otomatik Senkronizasyon</string>

--- a/composeApp/src/commonMain/composeResources/values-vi/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-vi/strings.xml
@@ -335,6 +335,7 @@
     <string name="compose_nav_library">Thư viện</string>
     <string name="compose_nav_profile">Hồ sơ</string>
     <string name="compose_nav_search">Tìm kiếm</string>
+    <string name="compose_nav_settings">Cài đặt</string>
     <string name="compose_player_audio_tracks">Âm thanh</string>
     <string name="compose_player_audio">Âm thanh</string>
     <string name="compose_player_auto_sync">Tự đồng bộ</string>


### PR DESCRIPTION
## Summary

Add the missing `compose_nav_settings` translation to the 23 non-English locales. Each locale reuses the wording it already uses for the settings page title (`compose_settings_page_root`).

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [x] Translation/localization only
- [ ] Approved larger or directional change

## Why

`compose_nav_settings` is the only one of the five navigation labels with no translation in any locale: `compose_nav_home`, `compose_nav_search`, `compose_nav_library` and `compose_nav_profile` are all translated in the 23 locales, `compose_nav_settings` in none. It is the navigation bar label (`AppShellComponents.kt`), so every non-English user sees an English "Settings" sitting next to translated siblings, for example "Accueil / Rechercher / Bibliothèque / Settings" in French.

Rather than invent new wording, each locale takes the string it already ships for the settings page title, so the label matches the screen it opens.

## Desktop scope

Shared string resources under `composeApp/src/commonMain/composeResources`, which the desktop navigation bar renders. The desktop app is where the mismatch was noticed; the same resources are used by the other targets, so they benefit identically. No code changes.

## Issue or approval

No linked issue: translation-only fix for a missing string, filed under the translation/localization category that `CONTRIBUTING.md` accepts without a prior issue. Nothing about the label's meaning, placement or behavior changes.

## UI / behavior impact

- [x] No behavior change
- [ ] No UI change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] UI change has explicit maintainer approval
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

One key, 23 files, one line added per file. No other string is added, changed or reworded, no key is renamed, no existing translation is touched, and no code is modified. The English `values/strings.xml` already had the key and is left alone.

## Testing

Windows 11, MSI built from this branch. Switched the app language in Settings > Appearance and checked the navigation bar label: French shows "Paramètres", German "Einstellungen", Russian "Настройки", Japanese "設定", where the build before this change showed "Settings" in all of them. English is unchanged. All 24 `strings.xml` files parse as valid XML with exactly one `compose_nav_settings` entry and no duplicate keys.

## Screenshots / Video

Navigation bar in French, before and after: "Accueil / Rechercher / Bibliothèque / Settings" becomes "Accueil / Rechercher / Bibliothèque / Paramètres". Screenshots attached.

## Breaking changes

None.

## Linked issues

No linked issue - translation-only fix for a string that was never translated.
