### PR TITLE
fix(linux): fix Zoom resize mode

### DIFF
--- a/composeApp/src/desktopMain/native/linux/player_bridge.cpp
+++ b/composeApp/src/desktopMain/native/linux/player_bridge.cpp
@@ -1849,13 +1849,18 @@ JNIEXPORT jfloat JNICALL NP(speed)(JNIEnv *, jobject, jlong handle) {
 JNIEXPORT void JNICALL NP(setResizeMode)(JNIEnv *, jobject, jlong handle, jint mode) {
     Player *p = asPlayer(handle);
     if (!p) return;
-    // 0 fit, 1 fill/zoom, 2 fixed-width, 3 stretch (best-effort mpv mapping)
+    // 0 fit, 1 fill, 2 zoom, 3 stretch
     switch (mode) {
-        case 3: mpv_set_option_string(p->mpv, "keepaspect", "no"); break;
-        case 1: mpv_set_option_string(p->mpv, "keepaspect", "yes");
-                mpv_set_option_string(p->mpv, "panscan", "1.0"); break;
-        default: mpv_set_option_string(p->mpv, "keepaspect", "yes");
-                 mpv_set_option_string(p->mpv, "panscan", "0.0"); break;
+        case 3: mpv_set_property_string(p->mpv, "keepaspect", "no");
+                mpv_set_property_string(p->mpv, "panscan", "0.0");
+                mpv_set_property_string(p->mpv, "video-unscaled", "no"); break;
+        case 1:
+        case 2: mpv_set_property_string(p->mpv, "keepaspect", "yes");
+                mpv_set_property_string(p->mpv, "panscan", "1.0");
+                mpv_set_property_string(p->mpv, "video-unscaled", "no"); break;
+        default: mpv_set_property_string(p->mpv, "keepaspect", "yes");
+                 mpv_set_property_string(p->mpv, "panscan", "0.0");
+                 mpv_set_property_string(p->mpv, "video-unscaled", "no"); break;
     }
 }
 


### PR DESCRIPTION
## Summary

Fix Zoom resize mode on Linux.

Previously, Zoom (`mode 2`) fell through to the Fit behavior, so switching from Fit to Zoom had no effect.

Linux now uses the same resize mapping as Windows/macOS:
- Fit: preserve aspect ratio
- Zoom/Fill: crop to fill
- Stretch: fill without preserving aspect ratio

Runtime resize changes also use `mpv_set_property_string()` instead of `mpv_set_option_string()`.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

On Linux, the player maps resize modes as:

- Fit → `0`
- Fill → `1`
- Zoom → `2`
- Stretch → `3`

The native Linux bridge handled mode `1` as the crop/fill mode, but mode `2` was not handled and fell through to the default Fit branch.

This made Zoom behave exactly like Fit.

## Desktop scope

Linux only.

The change is limited to:

`composeApp/src/desktopMain/native/linux/player_bridge.cpp`

Only `NP(setResizeMode)` is changed.

## Issue or approval

Addresses #610 (Zoom resize mode only).

The slow-loading / demuxer cache issue mentioned in #610 is not part of this PR.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] I listed the testing performed below.

## Scope boundaries

This only changes Linux resize handling.

No changes to:
- demuxer/cache settings
- seek behavior
- stream loading
- UI
- translations
- Windows/macOS code

## Testing

Tested on EndeavourOS / Arch Linux, KDE Wayland, NVIDIA GPU.

Tested with ultrawide content and switched between:

Fit → Zoom → Stretch → Fit

Verified in both windowed and fullscreen playback:
- Fit keeps the full frame
- Zoom crops to fill
- Stretch fills without preserving aspect ratio
- switching back to Fit restores the expected behavior

`git diff --check` passes.

## Screenshots / Video

Before:

![BEFORE](https://raw.githubusercontent.com/wiktorekdev/NuvioDesktop/screenshots/fix-linux-zoom-resize-mode/screenshots/fix-linux-zoom/before.png)

After:

![AFTER](https://raw.githubusercontent.com/wiktorekdev/NuvioDesktop/screenshots/fix-linux-zoom-resize-mode/screenshots/fix-linux-zoom/after.png)

(its not the same frame!)

## Breaking changes

None.

## Linked issues

Addresses #610 (Zoom resize mode only).
